### PR TITLE
feat: Add tag support

### DIFF
--- a/packages/Datadog.Unity/Plugins/iOS/DatadogLogging_Bridge.swift
+++ b/packages/Datadog.Unity/Plugins/iOS/DatadogLogging_Bridge.swift
@@ -93,3 +93,20 @@ func DatadogLogging_Log(logId: UnsafeMutablePointer<CChar>?, logLevel: Int, mess
         logger.log(level: logLevel, message: swiftMessage, error: nil, attributes: nil)
     }
 }
+
+@_cdecl("DatadogLogging_AddTag")
+func DatadogLogging_AddTag(logId: UnsafeMutablePointer<CChar>?, tag: UnsafeMutablePointer<CChar>?, value: UnsafeMutablePointer<CChar>?) {
+    guard let logId = logId, let tag = tag else {
+        return
+    }
+
+    if let idString = String(cString: logId, encoding: .utf8),
+       let logger = LogRegistry.shared.logs[idString],
+       let swiftTag = String(cString: tag, encoding: .utf8) {
+        if let value = value, let swiftValue = String(cString: value, encoding: .utf8) {
+            logger.addTag(withKey: swiftTag, value: swiftValue)
+        } else {
+            logger.add(tag: swiftTag)
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
@@ -18,6 +18,15 @@ namespace Datadog.Unity.Android
             _androidLogger = androidLogger;
         }
 
+        public override void AddTag(string tag, string value = null)
+        {
+            if (value != null) {
+                _androidLogger.Call("addTag", tag, value);
+            } else {
+                _androidLogger.Call("addTag", tag);
+            }
+        }
+
         public override void Log(DdLogLevel level, string message, Dictionary<string, object> attributes, Exception error = null)
         {
             // TODO: RUMM-3271, RUMM-3272 - Support attributes and errors

--- a/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
@@ -40,5 +40,7 @@ namespace Datadog.Unity.Logs
         }
 
         public abstract void Log(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null);
+
+        public abstract void AddTag(string tag, string value = null);
     }
 }

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSBridge.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSBridge.cs
@@ -36,6 +36,11 @@ namespace Datadog.Unity.iOS
             // TODO: RUMM-3271, RUMM-3272 - Support attributes and errors
             DatadogLoggingBridge.DatadogLogging_Log(_loggerId, (int)level, message);
         }
+
+        public override void AddTag(string tag, string value = null)
+        {
+            DatadogLoggingBridge.DatadogLogging_AddTag(_loggerId, tag, value);
+        }
     }
 
     internal static class DatadogLoggingBridge
@@ -45,5 +50,8 @@ namespace Datadog.Unity.iOS
 
         [DllImport("__Internal")]
         public static extern void DatadogLogging_Log(string loggerId, int logLevel, string message);
+
+        [DllImport("__Internal")]
+        public static extern void DatadogLogging_AddTag(string loggerId, string tag, string value);
     }
 }

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -178,7 +178,7 @@ PlayerSettings:
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask: 4054
-  iPhoneSdkVersion: 989
+  iPhoneSdkVersion: 988
   iOSTargetOSVersionString: 12.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0

--- a/tools/scripts/run_integration_test.py
+++ b/tools/scripts/run_integration_test.py
@@ -68,7 +68,7 @@ def main():
     run_unity_command(
         "-runTests", "-batchMode", "-projectPath", integration_project_path,
         "-testCategory", "integration", "-testPlatform", "android",
-        "-testResults", "tmp/results.xml", "-logFile", "-"
+        "-testResults", "tmp/results.xml", "-logFile", "-",
     )
 
     mock_server.terminate()


### PR DESCRIPTION
### What and why?

Added tag support to loggers. This is the simplest next step, but allowed me to hone the integration test libraries, which meant improving parsing logs from the mock server to give us a full view of the requests sent.

refs: RUMM-3326

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
