### PR TITLE
dev: Small fixes to make integration testing easier

### DIFF
--- a/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
+++ b/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
@@ -27,6 +27,11 @@ namespace Datadog.Unity.Tests.Integration
             _endpoint = configuration.CustomEndpoint;
         }
 
+        public async Task Clear()
+        {
+            await _client.GetAsync($"{_endpoint}/reset");
+        }
+
         public async Task<List<MockServerLog>> PollRequests(TimeSpan duration, Func<List<MockServerLog>, bool> parseRequests)
         {
             List<Dictionary<string, object>> requests = new();

--- a/packages/Datadog.Unity/Tests/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/LoggingIntegrationTests.cs
@@ -22,6 +22,8 @@ namespace Datadog.Unity.Tests
         public IEnumerator LoggingIntegrationScenario()
         {
             var mockServerHelper = new MockServerHelper();
+            var resetTask = mockServerHelper.Clear();
+            yield return new WaitUntil(() => resetTask.IsCompleted);
 
             yield return new MonoBehaviourTest<TestLoggingMonoBehavior>();
 

--- a/samples/Datadog Sample/.gitignore
+++ b/samples/Datadog Sample/.gitignore
@@ -74,3 +74,5 @@ crashlytics-build.properties
 /[Pp]ackages
 
 /[Aa]ssets/initTestScene*
+
+/tmp/*

--- a/tools/mock_server/app.py
+++ b/tools/mock_server/app.py
@@ -184,6 +184,19 @@ def inspect():
     global endpoints
     return render_template('endpoints.html', title='Endpoints', endpoints=endpoints)
 
+@app.route('/reset')
+def reset():
+    """
+    GET /reset
+
+    Clear currently logged requests on all endpoints
+    """
+    global endpoints
+    for e in endpoints:
+        e.requests.clear()
+    return 'OK', 200
+
+
 
 @app.route('/inspect/<schema_name>/<endpoint_hash>')
 def inspect_endpoint(schema_name, endpoint_hash):

--- a/tools/scripts/run_integration_test.py
+++ b/tools/scripts/run_integration_test.py
@@ -6,9 +6,8 @@
 # Copyright 2023-Present Datadog, Inc.
 # -----------------------------------------------------------
 
+import argparse
 import subprocess
-import sys
-import json
 import os
 import threading
 
@@ -45,6 +44,14 @@ def modify_datadog_settings(local_server_address):
 
 
 def main():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("--platform")
+    args = arg_parser.parse_args()
+
+    if args.platform is None:
+        print('--platform is required')
+        return
+
     mock_server = run_mock_server()
 
     # Find the IP address we started on
@@ -67,7 +74,8 @@ def main():
 
     run_unity_command(
         "-runTests", "-batchMode", "-projectPath", integration_project_path,
-        "-testCategory", "integration", "-testPlatform", "android",
+        "-buildTarget", args.platform,
+        "-testCategory", "integration", "-testPlatform", args.platform,
         "-testResults", "tmp/results.xml", "-logFile", "-",
     )
 


### PR DESCRIPTION
### What and why?

Added a `/reset` command on the mock server so that devs don't have to reset it to start a new session. Added `--platform` to the integration test runner.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
