### PR TITLE
feat: Add errors on logs

### DIFF
--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
@@ -42,7 +42,11 @@ namespace Datadog.Unity.Android
             var androidLevel = DatadogConfigurationHelpers.DdLogLevelToAndroidLogLevel(level);
 
             using var javaAttributes = DictionaryToJavaMap(attributes);
-            _androidLogger.Call("log", (int)androidLevel, message, null, null, null, javaAttributes);
+            var errorKind = error?.GetType()?.ToString();
+            var errorMessage = error?.Message;
+            var errorStack = error?.StackTrace?.ToString();
+
+            _androidLogger.Call("log", (int)androidLevel, message, errorKind, errorMessage, errorStack, javaAttributes);
         }
 
         public override void RemoveAttribute(string key)

--- a/packages/Datadog.Unity/Tests/Integration/LogDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/LogDecoder.cs
@@ -54,6 +54,21 @@ namespace Datadog.Unity.Tests.Integration
             get { return GetNestedProperty<string>("logger.name"); }
         }
 
+        public string ErrorKind
+        {
+            get { return GetNestedProperty<string>("error.kind"); }
+        }
+
+        public string ErrorMessage
+        {
+            get { return GetNestedProperty<string>("error.message"); }
+        }
+
+        public string ErrorStack
+        {
+            get { return GetNestedProperty<string>("error.stack"); }
+        }
+
         private T GetNestedProperty<T>(string key)
         {
 #if UNITY_ANDROID


### PR DESCRIPTION
### What and why?

Added the ability to attach Exceptions to errors, which populates `error.kind`, `error.message`, and `error.stack` if they are available.

refs: RUMM-3272

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
