### PR TITLE
feat: Support disabling Datadog

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -44,11 +44,12 @@ namespace Datadog.Unity.Editor.iOS
 
                 var optionsFile = Path.Combine("MainApp", "DatadogOptions.m");
                 var optionsPath = Path.Combine(pathToProject, optionsFile);
-                GenerateOptionsFile(optionsPath, DatadogConfigurationOptionsExtensions.GetOrCreate());
+                var datadogOptions = DatadogConfigurationOptionsExtensions.GetOrCreate();
+                GenerateOptionsFile(optionsPath, datadogOptions);
                 var optionsFileGuid = pbxProject.AddFile(optionsFile, optionsFile, PBXSourceTree.Source);
                 pbxProject.AddFileToBuild(mainTarget, optionsFileGuid);
 
-                AddInitializationToMain(Path.Combine(pathToProject, "MainApp", "main.mm"));
+                AddInitializationToMain(Path.Combine(pathToProject, "MainApp", "main.mm"), datadogOptions);
 
                 var projectInString = pbxProject.WriteToString();
 
@@ -126,7 +127,7 @@ DDConfiguration* buildDatadogConfiguration() {{
             File.WriteAllText(path, optionsFileString);
         }
 
-        internal static void AddInitializationToMain(string pathToMain)
+        internal static void AddInitializationToMain(string pathToMain, DatadogConfigurationOptions options)
         {
             if (!File.Exists(pathToMain))
             {
@@ -135,7 +136,10 @@ DDConfiguration* buildDatadogConfiguration() {{
 
             var mainText = new List<string>(File.ReadAllLines(pathToMain));
             mainText = RemoveDatadogBlocks(mainText);
-            AddDatadogBlocks(mainText);
+            if (options.Enabled)
+            {
+                AddDatadogBlocks(mainText);
+            }
 
             File.WriteAllLines(pathToMain, mainText);
         }

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -31,9 +31,12 @@ namespace Datadog.Unity.Android
         public static void InitializeDatadog()
         {
             var options = DatadogConfigurationOptions.Load();
-            var datadogPlatform = new DatadogAndroidPlatform();
-            datadogPlatform.Init(options);
-            DatadogSdk.InitWithPlatform(datadogPlatform, options);
+            if (options.Enabled)
+            {
+                var datadogPlatform = new DatadogAndroidPlatform();
+                datadogPlatform.Init(options);
+                DatadogSdk.InitWithPlatform(datadogPlatform, options);
+            }
         }
     }
 

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity
+{
+    internal class DatadogNoopPlatform : IDatadogPlatform
+    {
+        public IDdLogger CreateLogger(DatadogLoggingOptions options)
+        {
+            return new DdNoopLogger();
+        }
+
+        public void Init(DatadogConfigurationOptions options)
+        {
+        }
+
+        public void SetTrackingConsent(TrackingConsent trackingConsent)
+        {
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs.meta
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7fea747f519240f9820337fee81efd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -11,7 +11,7 @@ namespace Datadog.Unity
     {
         public static readonly DatadogSdk Instance = new();
 
-        private IDatadogPlatform _platform;
+        private IDatadogPlatform _platform = new DatadogNoopPlatform();
         private DdUnityLogHandler _logHandler;
 
         private DatadogSdk()

--- a/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
@@ -51,4 +51,31 @@ namespace Datadog.Unity.Logs
 
         public abstract void RemoveAttribute(string key);
     }
+
+    internal class DdNoopLogger : IDdLogger
+    {
+        public override void AddAttribute(string key, object value)
+        {
+        }
+
+        public override void AddTag(string tag, string value = null)
+        {
+        }
+
+        public override void Log(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
+        {
+        }
+
+        public override void RemoveAttribute(string key)
+        {
+        }
+
+        public override void RemoveTag(string tag)
+        {
+        }
+
+        public override void RemoveTagsWithKey(string key)
+        {
+        }
+    }
 }

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -19,7 +19,10 @@ namespace Datadog.Unity.iOS
         public static void InitializeDatadog()
         {
             var options = DatadogConfigurationOptions.Load();
-            DatadogSdk.InitWithPlatform(new DatadogiOSPlatform(), options);
+            if (options.Enabled)
+            {
+                DatadogSdk.InitWithPlatform(new DatadogiOSPlatform(), options);
+            }
         }
     }
 

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -92,7 +92,8 @@ namespace Datadog.Unity.Editor.iOS
         [Test]
         public void AddInitializationToMainAddsDatadogBlocks()
         {
-            PostBuildProcess.AddInitializationToMain(_mainFilePath);
+            var options = new DatadogConfigurationOptions();
+            PostBuildProcess.AddInitializationToMain(_mainFilePath, options);
 
             string fileContents = File.ReadAllText(_mainFilePath);
 
@@ -115,7 +116,8 @@ namespace Datadog.Unity.Editor.iOS
         [Test]
         public void RemoveDatadogBlocksRemovesDatadogBlocks()
         {
-            PostBuildProcess.AddInitializationToMain(_mainFilePath);
+            var options = new DatadogConfigurationOptions();
+            PostBuildProcess.AddInitializationToMain(_mainFilePath, options);
 
             var fileContents = File.ReadAllLines(_mainFilePath);
             var cleanContents = PostBuildProcess.RemoveDatadogBlocks(new List<string>(fileContents));

--- a/samples/Datadog Sample/Assets/Scripts/UIBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/UIBehavior.cs
@@ -38,8 +38,8 @@ public class UIBehavior : MonoBehaviour
 
 #region iOS implementations
     #if PLATFORM_IOS
-    // CrashHelper.swift
-    [DllImport("__Internal")]
+    // SwiftCrashHelper.swift
+    [DllImport("__Internal", EntryPoint="PerformNativeSwiftCrash")]
     private static extern void PerformNativeCrash();
 
     [DllImport("__Internal", EntryPoint="throwObjectiveC")]


### PR DESCRIPTION
### What and why?

There's an option in the Datadog configuration that allowed you to disable Datadog, but it didn't actually do anything. The checkbox now avoids performing native initialization and supplies a `NoOp` platform so Datadog methods can be called without actually sending any information to Datadog.
### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
