### PR TITLE
chore: Remove Moq in favor of NSubstitute

### DIFF
--- a/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
+++ b/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
@@ -13,8 +13,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "Moq.dll",
-        "Newtonsoft.Json.dll"
+        "Newtonsoft.Json.dll",
+        "NSubstitute.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/samples/Datadog Sample/Assets/packages.config
+++ b/samples/Datadog Sample/Assets/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="5.1.1" />
+  <package id="Castle.Core" version="5.0.0" />
   <package id="Microsoft.Unity.Analyzers" version="1.16.1" />
-  <package id="Moq" version="4.18.4" />
+  <package id="NSubstitute" version="5.0.0" />
+  <package id="NSubstitute.Analyzers.CSharp" version="1.0.16" />
   <package id="StyleCop.Analyzers" version="1.1.118" />
   <package id="System.Diagnostics.EventLog" version="4.7.0" />
   <package id="System.Security.Principal.Windows" version="4.7.0" />

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
### What and why?

Removes Moq in favor of a different mocking framework for reasons.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
