### PR TITLE
feat: Wrap Datadog calls to avoid bubbling errors

### DIFF
--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
@@ -8,20 +8,6 @@ namespace Datadog.Unity.Android
 {
     internal static class DatadogConfigurationHelpers
     {
-        internal static AndroidLogLevel DdLogLevelToAndroidLogLevel(DdLogLevel logLevel)
-        {
-            return logLevel switch
-            {
-                DdLogLevel.Debug => AndroidLogLevel.Debug,
-                DdLogLevel.Info => AndroidLogLevel.Info,
-                DdLogLevel.Notice => AndroidLogLevel.Info,
-                DdLogLevel.Warn => AndroidLogLevel.Warn,
-                DdLogLevel.Error => AndroidLogLevel.Error,
-                DdLogLevel.Critical => AndroidLogLevel.Assert,
-                _ => AndroidLogLevel.Debug,
-            };
-        }
-
         internal static AndroidJavaObject GetSite(DatadogSite site)
         {
             string siteName = site switch

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
@@ -41,7 +41,7 @@ namespace Datadog.Unity.Android
 
         public override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
-            var androidLevel = DatadogConfigurationHelpers.DdLogLevelToAndroidLogLevel(level);
+            var androidLevel = InternalHelpers.DdLogLevelToAndroidLogLevel(level);
 
             using var javaAttributes = DatadogAndroidHelpers.DictionaryToJavaMap(attributes);
             var errorKind = error?.GetType()?.ToString();

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -2,8 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
@@ -17,17 +15,6 @@ using UnityEngine.Scripting;
 
 namespace Datadog.Unity.Android
 {
-    // These are mappings to android.util.Log
-    internal enum AndroidLogLevel
-    {
-        Verbose = 2,
-        Debug = 3,
-        Info = 4,
-        Warn = 5,
-        Error = 6,
-        Assert = 7,
-    }
-
     [Preserve]
     public static class DatadogInitialization
     {
@@ -69,11 +56,14 @@ namespace Datadog.Unity.Android
             configBuilder.Call<AndroidJavaObject>("setBatchSize", DatadogConfigurationHelpers.GetBatchSize(options.BatchSize));
             configBuilder.Call<AndroidJavaObject>("setUploadFrequency", DatadogConfigurationHelpers.GetUploadFrequency(options.UploadFrequency));
 
+            if (options.CustomEndpoint != string.Empty && options.CustomEndpoint.StartsWith("http://"))
+            {
 #if DEBUG
             using var internalProxyClass = new AndroidJavaClass("com.datadog.android._InternalProxy");
             using var proxyInstance = internalProxyClass.GetStatic<AndroidJavaObject>("Companion");
             proxyInstance.Call<AndroidJavaObject>("allowClearTextHttp", configBuilder);
 #endif
+            }
 
             using var configuration = configBuilder.Call<AndroidJavaObject>("build");
             _datadogClass.CallStatic<AndroidJavaObject>(

--- a/packages/Datadog.Unity/Runtime/Android/com.datadoghq.unity.android.asmdef
+++ b/packages/Datadog.Unity/Runtime/Android/com.datadoghq.unity.android.asmdef
@@ -5,8 +5,7 @@
         "com.datadog.unity"
     ],
     "includePlatforms": [
-        "Android",
-        "Editor"
+        "Android"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/packages/Datadog.Unity/Runtime/InternalHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/InternalHelpers.cs
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using System;
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity
+{
+    // These are mappings to android.util.Log
+    internal enum AndroidLogLevel
+    {
+        Verbose = 2,
+        Debug = 3,
+        Info = 4,
+        Warn = 5,
+        Error = 6,
+        Assert = 7,
+    }
+
+    public static class InternalHelpers
+    {
+        public static void Wrap(string functionName, Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                var internalLogger = DatadogSdk.Instance.InternalLogger;
+                internalLogger.Log(DdLogLevel.Warn, $"There was an error calling {functionName}: {e}");
+                internalLogger.Log(DdLogLevel.Warn, "This is likely an error in the DatadogSdk. Please report it to Datadog.");
+                internalLogger.TelemetryError($"Error in {functionName}", e);
+            }
+        }
+
+        internal static AndroidLogLevel DdLogLevelToAndroidLogLevel(DdLogLevel logLevel)
+        {
+            return logLevel switch
+            {
+                DdLogLevel.Debug => AndroidLogLevel.Debug,
+                DdLogLevel.Info => AndroidLogLevel.Info,
+                DdLogLevel.Notice => AndroidLogLevel.Info,
+                DdLogLevel.Warn => AndroidLogLevel.Warn,
+                DdLogLevel.Error => AndroidLogLevel.Error,
+                DdLogLevel.Critical => AndroidLogLevel.Assert,
+                _ => AndroidLogLevel.Debug,
+            };
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/InternalHelpers.cs.meta
+++ b/packages/Datadog.Unity/Runtime/InternalHelpers.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 058b39b7a6004f16bbbb207c0117fd1f
+timeCreated: 1700077639

--- a/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DdLogger.cs
@@ -51,10 +51,13 @@ namespace Datadog.Unity.Logs
 
         public void Log(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
-            if (level >= _logLevel && _sampler.Sample())
+            InternalHelpers.Wrap("Log", () =>
             {
-                PlatformLog(level, message, attributes, error);
-            }
+                if (level >= _logLevel && _sampler.Sample())
+                {
+                    PlatformLog(level, message, attributes, error);
+                }
+            });
         }
 
         public abstract void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null);

--- a/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
@@ -21,79 +21,129 @@ namespace Datadog.Unity.Rum
 
         public void StartView(string key, string name = null, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StartViewMessage(_dateProvider.Now, key, name, attributes));
+            InternalHelpers.Wrap("StartView",
+                () =>
+                {
+                    _worker.AddMessage(new DdRumProcessor.StartViewMessage(_dateProvider.Now, key, name, attributes));
+                });
         }
 
         public void StopView(string key, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StopViewMessage(_dateProvider.Now, key, attributes));
+            InternalHelpers.Wrap("StopView",
+                () => { _worker.AddMessage(new DdRumProcessor.StopViewMessage(_dateProvider.Now, key, attributes)); });
         }
 
         public void AddAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.AddUserActionMessage(_dateProvider.Now, type, name, attributes));
+            InternalHelpers.Wrap("AddAction",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.AddUserActionMessage(_dateProvider.Now, type, name, attributes));
+                });
         }
 
         public void StartAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StartUserActionMessage(_dateProvider.Now, type, name, attributes));
+            InternalHelpers.Wrap("StartAction",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.StartUserActionMessage(_dateProvider.Now, type, name, attributes));
+                });
         }
 
         public void StopAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StopUserActionMessage(_dateProvider.Now, type, name, attributes));
+            InternalHelpers.Wrap("StopAction",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.StopUserActionMessage(_dateProvider.Now, type, name, attributes));
+                });
         }
 
         public void AddError(Exception error, RumErrorSource source, Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.AddErrorMessage(_dateProvider.Now, error, source, attributes));
+            InternalHelpers.Wrap("StopView",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.AddErrorMessage(_dateProvider.Now, error, source, attributes));
+                });
         }
 
-        public void StartResource(string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes = null)
+        public void StartResource(string key, RumHttpMethod httpMethod, string url,
+            Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StartResourceLoadingMessage(_dateProvider.Now, key, httpMethod, url, attributes));
+            InternalHelpers.Wrap("StartResource",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.StartResourceLoadingMessage(_dateProvider.Now, key, httpMethod, url,
+                            attributes));
+                });
         }
 
         public void StopResource(string key, RumResourceType kind, int? statusCode = null, long? size = null,
             Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(
-                new DdRumProcessor.StopResourceLoadingMessage(_dateProvider.Now, key, kind, statusCode, size, attributes));
+            InternalHelpers.Wrap("StopResource",
+                () =>
+                {
+                    _worker.AddMessage(
+                        new DdRumProcessor.StopResourceLoadingMessage(_dateProvider.Now, key, kind, statusCode, size,
+                            attributes));
+                });
         }
 
-        public void StopResourceWithError(string key, string errorType, string errorMessage, Dictionary<string, object> attributes = null)
+        public void StopResourceWithError(string key, string errorType, string errorMessage,
+            Dictionary<string, object> attributes = null)
         {
-            _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
-                _dateProvider.Now, key, errorType, errorMessage, attributes));
+            InternalHelpers.Wrap("StopResourceWithError",
+                () =>
+                {
+                    _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
+                        _dateProvider.Now, key, errorType, errorMessage, attributes));
+                });
         }
 
         public void StopResource(string key, Exception error, Dictionary<string, object> attributes = null)
         {
-            var errorType = error?.GetType()?.ToString();
-            var errorMessage = error?.Message;
+            InternalHelpers.Wrap("StopResource",
+                () =>
+                {
+                    var errorType = error?.GetType()?.ToString();
+                    var errorMessage = error?.Message;
 
-            _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
-                _dateProvider.Now, key, errorType, errorMessage, attributes));
+                    _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
+                        _dateProvider.Now, key, errorType, errorMessage, attributes));
+                });
         }
 
         public void AddAttribute(string key, object value)
         {
-            _worker.AddMessage(new DdRumProcessor.AddAttributeMessage(key, value));
+            InternalHelpers.Wrap("AddAttribute",
+                () => { _worker.AddMessage(new DdRumProcessor.AddAttributeMessage(key, value)); });
         }
 
         public void RemoveAttribute(string key)
         {
-            _worker.AddMessage(new DdRumProcessor.RemoveAttributeMessage(key));
+            InternalHelpers.Wrap("RemoveAttribute",
+                () => { _worker.AddMessage(new DdRumProcessor.RemoveAttributeMessage(key)); });
         }
 
         public void AddFeatureFlagEvaluation(string key, object value)
         {
-            _worker.AddMessage(new DdRumProcessor.AddFeatureFlagEvaluationMessage(key, value));
+            InternalHelpers.Wrap("AddFeatureFlagEvaluation",
+                () => { _worker.AddMessage(new DdRumProcessor.AddFeatureFlagEvaluationMessage(key, value)); });
         }
 
         public void StopSession()
         {
-            _worker.AddMessage(new DdRumProcessor.StopSessionMessage());
+            InternalHelpers.Wrap("StopSession",
+                () => { _worker.AddMessage(new DdRumProcessor.StopSessionMessage()); });
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/iOS/com.datadoghq.unity.ios.asmdef
+++ b/packages/Datadog.Unity/Runtime/iOS/com.datadoghq.unity.ios.asmdef
@@ -5,9 +5,7 @@
         "com.datadog.unity"
     ],
     "includePlatforms": [
-        "Editor",
         "iOS",
-        "macOSStandalone",
         "tvOS"
     ],
     "excludePlatforms": [],

--- a/packages/Datadog.Unity/Tests/LoggingTests.cs
+++ b/packages/Datadog.Unity/Tests/LoggingTests.cs
@@ -5,9 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-#if UNITY_ANDROID
-using Datadog.Unity.Android;
-#endif
 using Datadog.Unity.Logs;
 using Datadog.Unity.Worker;
 using NSubstitute;
@@ -34,7 +31,7 @@ namespace Datadog.Unity.Tests
         [TestCase(DdLogLevel.Critical, AndroidLogLevel.Assert)]
         public void DdLogLevelTranslatedToAndroidLogLevel(DdLogLevel ddLogLevel, int androidLogLevel)
         {
-            var translated = DatadogConfigurationHelpers.DdLogLevelToAndroidLogLevel(ddLogLevel);
+            var translated = InternalHelpers.DdLogLevelToAndroidLogLevel(ddLogLevel);
             Assert.AreEqual(androidLogLevel, (int)translated);
         }
 #endif

--- a/packages/Datadog.Unity/Tests/Rum/DdWorkerProxyRumTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/DdWorkerProxyRumTest.cs
@@ -278,7 +278,7 @@ namespace Datadog.Unity.Rum.Tests
             var rum = new DdWorkerProxyRum(_worker, _mockDateProvider);
             var date = new DateTime(2063, 4, 5, 12, 22, 10, DateTimeKind.Utc);
             Dictionary<string, object> capturedAttributes = null;
-            _mockRum.StopResource(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Do<Dictionary<string, object>>(x => capturedAttributes = x));
+            _mockRum.StopResourceWithError(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),Arg.Do<Dictionary<string, object>>(x => capturedAttributes = x));
             _mockDateProvider.Now.Returns(date);
 
             var exception = new Exception();
@@ -293,7 +293,8 @@ namespace Datadog.Unity.Rum.Tests
 
             // Then
             var dateOffset = new DateTimeOffset(date);
-            _mockRum.Received(1).StopResource("fake_resource", exception, Arg.Any<Dictionary<string, object>>());
+            _mockRum.Received(1).StopResourceWithError("fake_resource", exception.GetType().ToString(), exception.Message,
+                Arg.Any<Dictionary<string, object>>());
             Assert.IsNotNull(capturedAttributes);
             Assert.AreEqual("my property", capturedAttributes["attribute_1"]);
             Assert.AreEqual(222, capturedAttributes["int_attribute_3"]);

--- a/samples/Datadog Sample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/samples/Datadog Sample/Assets/Plugins/Android/mainTemplate.gradle
@@ -8,6 +8,9 @@
         maven {
             url "https://repo.maven.apache.org/maven2" // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:6
         }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots" // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:6
+        }
         mavenLocal()
         mavenCentral()
     }

--- a/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
@@ -17,7 +17,7 @@
     <setting name="packageDir" value="Assets/Plugins/Android" />
     <setting name="patchAndroidManifest" value="True" />
     <setting name="patchMainTemplateGradle" value="True" />
-    <setting name="projectExportEnabled" value="False" />
+    <setting name="projectExportEnabled" value="True" />
     <setting name="useJetifier" value="False" />
   </settings>
 </dependencies>

--- a/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
+++ b/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <projectSettings>
   <projectSetting name="Google.IOSResolver.VerboseLoggingEnabled" value="False" />
-  <projectSetting name="Google.PackageManagerResolver.VerboseLoggingEnabled" value="False" />
-  <projectSetting name="Google.VersionHandler.VerboseLoggingEnabled" value="False" />
-  <projectSetting name="GooglePlayServices.PromptBeforeAutoResolution" value="False" />
 </projectSettings>

--- a/samples/Datadog Sample/ProjectSettings/QualitySettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/QualitySettings.asset
@@ -6,7 +6,7 @@ QualitySettings:
   serializedVersion: 5
   m_CurrentQuality: 5
   m_QualitySettings:
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: Very Low
     pixelLightCount: 0
     shadows: 0
@@ -19,16 +19,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
     skinWeights: 1
-    textureQuality: 1
+    globalTextureMipmapLimit: 1
+    textureMipmapLimitSettings: []
     anisotropicTextures: 0
     antiAliasing: 0
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
+    useLegacyDetailDistribution: 1
     vSyncCount: 0
+    realtimeGICPUUsage: 25
     lodBias: 0.3
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -41,8 +45,17 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: Low
     pixelLightCount: 0
     shadows: 0
@@ -55,16 +68,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
     skinWeights: 2
-    textureQuality: 0
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
     anisotropicTextures: 0
     antiAliasing: 0
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
+    useLegacyDetailDistribution: 1
     vSyncCount: 0
+    realtimeGICPUUsage: 25
     lodBias: 0.4
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -77,8 +94,17 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: Medium
     pixelLightCount: 1
     shadows: 1
@@ -91,16 +117,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
     skinWeights: 2
-    textureQuality: 0
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
     anisotropicTextures: 1
     antiAliasing: 0
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
+    useLegacyDetailDistribution: 1
     vSyncCount: 1
+    realtimeGICPUUsage: 25
     lodBias: 0.7
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -113,8 +143,17 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: High
     pixelLightCount: 2
     shadows: 2
@@ -127,16 +166,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 1
     skinWeights: 2
-    textureQuality: 0
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
     anisotropicTextures: 1
     antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
+    useLegacyDetailDistribution: 1
     vSyncCount: 1
+    realtimeGICPUUsage: 50
     lodBias: 1
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -149,8 +192,17 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: Very High
     pixelLightCount: 3
     shadows: 2
@@ -163,16 +215,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 1
     skinWeights: 4
-    textureQuality: 0
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
     anisotropicTextures: 2
     antiAliasing: 2
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
+    useLegacyDetailDistribution: 1
     vSyncCount: 1
+    realtimeGICPUUsage: 50
     lodBias: 1.5
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -185,8 +241,17 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
-  - serializedVersion: 2
+  - serializedVersion: 3
     name: Ultra
     pixelLightCount: 4
     shadows: 2
@@ -199,16 +264,20 @@ QualitySettings:
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 1
     skinWeights: 255
-    textureQuality: 0
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
     anisotropicTextures: 2
     antiAliasing: 2
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
+    useLegacyDetailDistribution: 1
     vSyncCount: 1
+    realtimeGICPUUsage: 100
     lodBias: 2
     maximumLODLevel: 0
+    enableLODCrossFade: 1
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
     streamingMipmapsMemoryBudget: 512
@@ -221,5 +290,15 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
     excludedTargetPlatforms: []
+  m_TextureMipmapLimitGroupNames: []
   m_PerPlatformDefaultQuality: {}


### PR DESCRIPTION
### What and why?

Most calls into the DatadogSDK are now wrapped in try / catch blocks to they will not bubble exceptions up to the calling application / game. Errors are sent to the user's log as well as to Datadog's telemetry.

This is done with a `InternalHelpers.Wrap` to so that the error messaging and telemetry errors can be consistent.

I've also removed the Platform specific SDK dlls from being included in editor builds, as this was causing error messages when playing the sample app in the editor. One drawback of this was that some items that are platform specific but need unit tests needed to be pulled into the `InternalHelpers` class.

refs: RUM-352


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
