### PR TITLE
feat: Add pooling for worker messages

### DIFF
--- a/packages/Datadog.Unity/Runtime/InternalHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/InternalHelpers.cs
@@ -3,6 +3,7 @@
 // Copyright 2023-Present Datadog, Inc.
 
 using System;
+using System.Collections.Generic;
 using Datadog.Unity.Logs;
 
 namespace Datadog.Unity

--- a/packages/Datadog.Unity/Runtime/Logs/DDWorkerProxyLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DDWorkerProxyLogger.cs
@@ -23,38 +23,32 @@ namespace Datadog.Unity.Logs
 
         public override void AddAttribute(string key, object value)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.AddAttributeMessage(_logger, key, value));
+            _worker.AddMessage(DdLogsProcessor.AddAttributeMessage.Create(_logger, key, value));
         }
 
         public override void AddTag(string tag, string value = null)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.AddTagMessage(_logger, tag, value));
+            _worker.AddMessage(DdLogsProcessor.AddTagMessage.Create(_logger, tag, value));
         }
 
         public override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.LogMessage(_logger, level, message, attributes, error));
+            _worker.AddMessage(DdLogsProcessor.LogMessage.Create(_logger, level, message, attributes, error));
         }
 
         public override void RemoveAttribute(string key)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.RemoveAttributeMessage(_logger, key));
+            _worker.AddMessage(DdLogsProcessor.RemoveAttributeMessage.Create(_logger, key));
         }
 
         public override void RemoveTag(string tag)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.RemoveTagMessage(_logger, tag));
+            _worker.AddMessage(DdLogsProcessor.RemoveTagMessage.Create(_logger, tag));
         }
 
         public override void RemoveTagsWithKey(string key)
         {
-            _worker.AddMessage(
-                new DdLogsProcessor.RemoveTagsWithKeyMessage(_logger, key));
+            _worker.AddMessage(DdLogsProcessor.RemoveTagsWithKeyMessage.Create(_logger, key));
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Logs/DdLogProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DdLogProcessor.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
+using UnityEngine.Pool;
 
 namespace Datadog.Unity.Logs
 {
@@ -41,13 +43,11 @@ namespace Datadog.Unity.Logs
 
         internal class LogMessage : IDatadogWorkerMessage
         {
-            public LogMessage(DdLogger logger, DdLogLevel level, string message, Dictionary<string, object> attributes, Exception error)
+            private static ObjectPool<LogMessage> _pool = new (
+                createFunc: () => new LogMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private LogMessage()
             {
-                Logger = logger;
-                Level = level;
-                Message = message;
-                Attributes = attributes;
-                Error = error;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -61,15 +61,39 @@ namespace Datadog.Unity.Logs
             public Dictionary<string, object> Attributes { get; private set; }
 
             public Exception Error { get; private set; }
+
+            public static LogMessage Create(DdLogger logger, DdLogLevel level, string message, Dictionary<string, object> attributes, Exception error)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Level = level;
+                obj.Message = message;
+                obj.Attributes = attributes;
+                obj.Error = error;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Message = null;
+                Attributes = null;
+                Error = null;
+            }
         }
 
         internal class AddTagMessage : IDatadogWorkerMessage
         {
-            public AddTagMessage(DdLogger logger, string tag, string value)
+            private static ObjectPool<AddTagMessage> _pool = new (
+                createFunc: () => new AddTagMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddTagMessage()
             {
-                Logger = logger;
-                Tag = tag;
-                Value = value;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -79,14 +103,36 @@ namespace Datadog.Unity.Logs
             public string Tag { get; private set; }
 
             public string Value { get; private set; }
+
+            public static AddTagMessage Create(DdLogger logger, string tag, string value)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Tag = tag;
+                obj.Value = value;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Tag = null;
+                Value = null;
+            }
         }
 
         internal class RemoveTagMessage : IDatadogWorkerMessage
         {
-            public RemoveTagMessage(DdLogger logger, string tag)
+            private static ObjectPool<RemoveTagMessage> _pool = new (
+                createFunc: () => new RemoveTagMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private RemoveTagMessage()
             {
-                Logger = logger;
-                Tag = tag;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -94,14 +140,34 @@ namespace Datadog.Unity.Logs
             public DdLogger Logger { get; private set; }
 
             public string Tag { get; private set; }
+
+            public static RemoveTagMessage Create(DdLogger logger, string tag)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Tag = tag;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Tag = null;
+            }
         }
 
         internal class RemoveTagsWithKeyMessage : IDatadogWorkerMessage
         {
-            public RemoveTagsWithKeyMessage(DdLogger logger, string tag)
+            private static ObjectPool<RemoveTagsWithKeyMessage> _pool = new (
+                createFunc: () => new RemoveTagsWithKeyMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private RemoveTagsWithKeyMessage()
             {
-                Logger = logger;
-                Tag = tag;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -109,15 +175,34 @@ namespace Datadog.Unity.Logs
             public DdLogger Logger { get; private set; }
 
             public string Tag { get; private set; }
+
+            public static RemoveTagsWithKeyMessage Create(DdLogger logger, string tag)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Tag = tag;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Tag = null;
+            }
         }
 
         internal class AddAttributeMessage : IDatadogWorkerMessage
         {
-            public AddAttributeMessage(DdLogger logger, string key, object value)
+            private static ObjectPool<AddAttributeMessage> _pool = new (
+                createFunc: () => new AddAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddAttributeMessage()
             {
-                Logger = logger;
-                Key = key;
-                Value = value;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -127,14 +212,36 @@ namespace Datadog.Unity.Logs
             public string Key { get; private set; }
 
             public object Value { get; private set; }
+
+            public static AddAttributeMessage Create(DdLogger logger, string key, object value)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Key = key;
+                obj.Value = value;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Key = null;
+                Value = null;
+            }
         }
 
         internal class RemoveAttributeMessage : IDatadogWorkerMessage
         {
-            public RemoveAttributeMessage(DdLogger logger, string key)
+            private static ObjectPool<RemoveAttributeMessage> _pool = new (
+                createFunc: () => new RemoveAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private RemoveAttributeMessage()
             {
-                Logger = logger;
-                Key = key;
             }
 
             public string FeatureTarget => DdLogsProcessor.LogsTargetName;
@@ -142,6 +249,25 @@ namespace Datadog.Unity.Logs
             public DdLogger Logger { get; private set; }
 
             public string Key { get; private set; }
+
+            public static RemoveAttributeMessage Create(DdLogger logger, string key)
+            {
+                var obj = _pool.Get();
+                obj.Logger = logger;
+                obj.Key = key;
+                return obj;
+            }
+
+            public void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Logger = null;
+                Key = null;
+            }
         }
 
         #endregion

--- a/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Unity.Worker;
+using UnityEngine.Pool;
 
 namespace Datadog.Unity.Rum
 {
@@ -91,24 +92,20 @@ namespace Datadog.Unity.Rum
 
         internal abstract class DdRumWorkerMessage : IDatadogWorkerMessage
         {
-            public DateTime? MessageTime { get; private set; }
+            public DateTime? MessageTime { get; protected set; }
 
             public string FeatureTarget => DdRumProcessor.RumTargetName;
 
-            public DdRumWorkerMessage(DateTime? messageTime)
-            {
-                MessageTime = messageTime;
-            }
+            public abstract void Discard();
         }
 
         internal class StartViewMessage : DdRumWorkerMessage
         {
-            public StartViewMessage(DateTime messageTime, string key, string name, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StartViewMessage> _pool = new (
+                createFunc: () => new StartViewMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StartViewMessage()
             {
-                Key = key;
-                Name = name;
-                Attributes = attributes ?? new ();
             }
 
             public string Key { get; private set; }
@@ -116,30 +113,75 @@ namespace Datadog.Unity.Rum
             public string Name { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StartViewMessage Create(DateTime messageTime, string key, string name, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Key = key;
+                obj.Name = name;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Key = null;
+                Name = null;
+                Attributes = null;
+            }
         }
 
         internal class StopViewMessage : DdRumWorkerMessage
         {
-            public StopViewMessage(DateTime messageTime, string key, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StopViewMessage> _pool = new (
+                createFunc: () => new StopViewMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StopViewMessage()
             {
-                Key = key;
-                Attributes = attributes ?? new ();
             }
 
             public string Key { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StopViewMessage Create(DateTime messageTime, string key, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Key = key;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Key = null;
+                Attributes = null;
+            }
         }
 
         internal class AddUserActionMessage : DdRumWorkerMessage
         {
-            public AddUserActionMessage(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<AddUserActionMessage> _pool = new (
+                createFunc: () => new AddUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddUserActionMessage()
             {
-                Type = type;
-                Name = name;
-                Attributes = attributes ?? new ();
             }
 
             public RumUserActionType Type { get; private set; }
@@ -147,16 +189,38 @@ namespace Datadog.Unity.Rum
             public string Name { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static AddUserActionMessage Create(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Type = type;
+                obj.Name = name;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Name = null;
+                Attributes = null;
+            }
         }
 
         internal class StartUserActionMessage : DdRumWorkerMessage
         {
-            public StartUserActionMessage(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StartUserActionMessage> _pool = new (
+                createFunc: () => new StartUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StartUserActionMessage()
             {
-                Type = type;
-                Name = name;
-                Attributes = attributes ?? new ();
             }
 
             public RumUserActionType Type { get; private set; }
@@ -164,16 +228,38 @@ namespace Datadog.Unity.Rum
             public string Name { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StartUserActionMessage Create(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Type = type;
+                obj.Name = name;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Name = null;
+                Attributes = null;
+            }
         }
 
         internal class StopUserActionMessage : DdRumWorkerMessage
         {
-            public StopUserActionMessage(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StopUserActionMessage> _pool = new (
+                createFunc: () => new StopUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StopUserActionMessage()
             {
-                Type = type;
-                Name = name;
-                Attributes = attributes ?? new ();
             }
 
             public RumUserActionType Type { get; private set; }
@@ -181,16 +267,38 @@ namespace Datadog.Unity.Rum
             public string Name { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StopUserActionMessage Create(DateTime messageTime, RumUserActionType type, string name, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Type = type;
+                obj.Name = name;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Name = null;
+                Attributes = null;
+            }
         }
 
         internal class AddErrorMessage : DdRumWorkerMessage
         {
-            public AddErrorMessage(DateTime messageTime, Exception error, RumErrorSource source, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<AddErrorMessage> _pool = new (
+                createFunc: () => new AddErrorMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddErrorMessage()
             {
-                Error = error;
-                Source = source;
-                Attributes = attributes ?? new ();
             }
 
             public Exception Error { get; private set; }
@@ -198,42 +306,97 @@ namespace Datadog.Unity.Rum
             public RumErrorSource Source { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static AddErrorMessage Create(DateTime messageTime, Exception error, RumErrorSource source, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Error = error;
+                obj.Source = source;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Error = null;
+                Source = default;
+                Attributes = null;
+            }
         }
 
         internal class AddAttributeMessage : DdRumWorkerMessage
         {
-            public AddAttributeMessage(string key, object value)
-                : base(null)
+            private static ObjectPool<AddAttributeMessage> _pool = new (
+                createFunc: () => new AddAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddAttributeMessage()
             {
-                Key = key;
-                Value = value;
             }
 
             public string Key { get; private set; }
 
             public object Value { get; private set; }
+
+            public static AddAttributeMessage Create(string key, object value)
+            {
+                var obj = _pool.Get();
+                obj.Key = key;
+                obj.Value = value;
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Key = null;
+                Value = null;
+            }
         }
 
         internal class RemoveAttributeMessage : DdRumWorkerMessage
         {
-            public RemoveAttributeMessage(string key)
-                : base(null)
+            private static ObjectPool<RemoveAttributeMessage> _pool = new (createFunc: () => new RemoveAttributeMessage());
+
+            private RemoveAttributeMessage()
             {
-                Key = key;
             }
 
             public string Key { get; private set; }
+
+            public static RemoveAttributeMessage Create(string key)
+            {
+                var obj = _pool.Get();
+                obj.Key = key;
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
         }
 
         internal class StartResourceLoadingMessage : DdRumWorkerMessage
         {
-            public StartResourceLoadingMessage(DateTime messageTime, string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StartResourceLoadingMessage> _pool = new (
+                createFunc: () => new StartResourceLoadingMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StartResourceLoadingMessage()
             {
-                Key = key;
-                HttpMethod = httpMethod;
-                Url = url;
-                Attributes = attributes ?? new();
             }
 
             public string Key { get; private set; }
@@ -243,18 +406,40 @@ namespace Datadog.Unity.Rum
             public string Url { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StartResourceLoadingMessage Create(DateTime messageTime, string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Key = key;
+                obj.HttpMethod = httpMethod;
+                obj.Url = url;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Key = null;
+                Url = null;
+                Attributes = null;
+            }
         }
 
         internal class StopResourceLoadingMessage : DdRumWorkerMessage
         {
-            public StopResourceLoadingMessage(DateTime messageTime, string key, RumResourceType resourceType, int? statusCode, long? size, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StopResourceLoadingMessage> _pool = new (
+                createFunc: () => new StopResourceLoadingMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StopResourceLoadingMessage()
             {
-                Key = key;
-                ResourceType = resourceType;
-                StatusCode = statusCode;
-                Size = size;
-                Attributes = attributes ?? new();
             }
 
             public string Key { get; private set; }
@@ -266,18 +451,42 @@ namespace Datadog.Unity.Rum
             public int? StatusCode { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StopResourceLoadingMessage Create(DateTime messageTime, string key, RumResourceType resourceType, int? statusCode, long? size, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Key = key;
+                obj.ResourceType = resourceType;
+                obj.StatusCode = statusCode;
+                obj.Size = size;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Key = null;
+                Size = null;
+                StatusCode = null;
+                Attributes = null;
+            }
         }
 
         internal class StopResourceLoadingWithErrorMessage : DdRumWorkerMessage
         {
-            public StopResourceLoadingWithErrorMessage(DateTime messageTime, string key,
-                string errorType, string errorMessage, Dictionary<string, object> attributes)
-                : base(messageTime)
+            private static ObjectPool<StopResourceLoadingWithErrorMessage> _pool = new (
+                createFunc: () => new StopResourceLoadingWithErrorMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private StopResourceLoadingWithErrorMessage()
             {
-                Key = key;
-                ErrorType = errorType;
-                ErrorMessage = errorMessage;
-                Attributes = attributes ?? new();
             }
 
             public string Key { get; private set; }
@@ -289,27 +498,78 @@ namespace Datadog.Unity.Rum
             public string ErrorMessage { get; private set; }
 
             public Dictionary<string, object> Attributes { get; private set; }
+
+            public static StopResourceLoadingWithErrorMessage Create(DateTime messageTime, string key,
+                string errorType, string errorMessage, Dictionary<string, object> attributes)
+            {
+                var obj = _pool.Get();
+                obj.MessageTime = messageTime;
+                obj.Key = key;
+                obj.ErrorType = errorType;
+                obj.ErrorMessage = errorMessage;
+                obj.Attributes = attributes ?? new();
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                MessageTime = null;
+                Key = null;
+                ErrorType = null;
+                ErrorMessage = null;
+                Attributes = null;
+            }
         }
 
         internal class AddFeatureFlagEvaluationMessage : DdRumWorkerMessage
         {
-            public AddFeatureFlagEvaluationMessage(string key, object value)
-                : base(null)
+            private static ObjectPool<AddFeatureFlagEvaluationMessage> _pool = new (
+                createFunc: () => new AddFeatureFlagEvaluationMessage(), actionOnRelease: (obj) => obj.Reset());
+
+            private AddFeatureFlagEvaluationMessage()
             {
-                Key = key;
-                Value = value;
             }
 
             public string Key { get; private set; }
 
             public object Value { get; private set; }
+
+            public static AddFeatureFlagEvaluationMessage Create(string key, object value)
+            {
+                var obj = _pool.Get();
+                obj.Key = key;
+                obj.Value = value;
+
+                return obj;
+            }
+
+            public override void Discard()
+            {
+                _pool.Release(this);
+            }
+
+            private void Reset()
+            {
+                Key = null;
+                Value = null;
+            }
         }
 
         internal class StopSessionMessage : DdRumWorkerMessage
         {
             public StopSessionMessage()
-                : base(null)
             {
+            }
+
+            public override void Discard()
+            {
+                // This should be a fairly rare message, so we don't need to pool it.
             }
         }
 

--- a/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
@@ -24,14 +24,14 @@ namespace Datadog.Unity.Rum
             InternalHelpers.Wrap("StartView",
                 () =>
                 {
-                    _worker.AddMessage(new DdRumProcessor.StartViewMessage(_dateProvider.Now, key, name, attributes));
+                    _worker.AddMessage(DdRumProcessor.StartViewMessage.Create(_dateProvider.Now, key, name, attributes));
                 });
         }
 
         public void StopView(string key, Dictionary<string, object> attributes = null)
         {
             InternalHelpers.Wrap("StopView",
-                () => { _worker.AddMessage(new DdRumProcessor.StopViewMessage(_dateProvider.Now, key, attributes)); });
+                () => { _worker.AddMessage(DdRumProcessor.StopViewMessage.Create(_dateProvider.Now, key, attributes)); });
         }
 
         public void AddAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
@@ -40,7 +40,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.AddUserActionMessage(_dateProvider.Now, type, name, attributes));
+                        DdRumProcessor.AddUserActionMessage.Create(_dateProvider.Now, type, name, attributes));
                 });
         }
 
@@ -50,7 +50,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.StartUserActionMessage(_dateProvider.Now, type, name, attributes));
+                        DdRumProcessor.StartUserActionMessage.Create(_dateProvider.Now, type, name, attributes));
                 });
         }
 
@@ -60,7 +60,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.StopUserActionMessage(_dateProvider.Now, type, name, attributes));
+                        DdRumProcessor.StopUserActionMessage.Create(_dateProvider.Now, type, name, attributes));
                 });
         }
 
@@ -70,7 +70,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.AddErrorMessage(_dateProvider.Now, error, source, attributes));
+                        DdRumProcessor.AddErrorMessage.Create(_dateProvider.Now, error, source, attributes));
                 });
         }
 
@@ -81,7 +81,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.StartResourceLoadingMessage(_dateProvider.Now, key, httpMethod, url,
+                        DdRumProcessor.StartResourceLoadingMessage.Create(_dateProvider.Now, key, httpMethod, url,
                             attributes));
                 });
         }
@@ -93,7 +93,7 @@ namespace Datadog.Unity.Rum
                 () =>
                 {
                     _worker.AddMessage(
-                        new DdRumProcessor.StopResourceLoadingMessage(_dateProvider.Now, key, kind, statusCode, size,
+                        DdRumProcessor.StopResourceLoadingMessage.Create(_dateProvider.Now, key, kind, statusCode, size,
                             attributes));
                 });
         }
@@ -104,7 +104,7 @@ namespace Datadog.Unity.Rum
             InternalHelpers.Wrap("StopResourceWithError",
                 () =>
                 {
-                    _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
+                    _worker.AddMessage(DdRumProcessor.StopResourceLoadingWithErrorMessage.Create(
                         _dateProvider.Now, key, errorType, errorMessage, attributes));
                 });
         }
@@ -117,7 +117,7 @@ namespace Datadog.Unity.Rum
                     var errorType = error?.GetType()?.ToString();
                     var errorMessage = error?.Message;
 
-                    _worker.AddMessage(new DdRumProcessor.StopResourceLoadingWithErrorMessage(
+                    _worker.AddMessage(DdRumProcessor.StopResourceLoadingWithErrorMessage.Create(
                         _dateProvider.Now, key, errorType, errorMessage, attributes));
                 });
         }
@@ -125,19 +125,19 @@ namespace Datadog.Unity.Rum
         public void AddAttribute(string key, object value)
         {
             InternalHelpers.Wrap("AddAttribute",
-                () => { _worker.AddMessage(new DdRumProcessor.AddAttributeMessage(key, value)); });
+                () => { _worker.AddMessage(DdRumProcessor.AddAttributeMessage.Create(key, value)); });
         }
 
         public void RemoveAttribute(string key)
         {
             InternalHelpers.Wrap("RemoveAttribute",
-                () => { _worker.AddMessage(new DdRumProcessor.RemoveAttributeMessage(key)); });
+                () => { _worker.AddMessage(DdRumProcessor.RemoveAttributeMessage.Create(key)); });
         }
 
         public void AddFeatureFlagEvaluation(string key, object value)
         {
             InternalHelpers.Wrap("AddFeatureFlagEvaluation",
-                () => { _worker.AddMessage(new DdRumProcessor.AddFeatureFlagEvaluationMessage(key, value)); });
+                () => { _worker.AddMessage(DdRumProcessor.AddFeatureFlagEvaluationMessage.Create(key, value)); });
         }
 
         public void StopSession()

--- a/packages/Datadog.Unity/Runtime/Worker/DatadogWorker.cs
+++ b/packages/Datadog.Unity/Runtime/Worker/DatadogWorker.cs
@@ -19,6 +19,8 @@ namespace Datadog.Unity.Worker
     internal interface IDatadogWorkerMessage
     {
         public string FeatureTarget { get; }
+
+        public void Discard();
     }
 
     // In order to ensure that we don't interrupt the main game loop when communicating to
@@ -113,6 +115,8 @@ namespace Datadog.Unity.Worker
                             DatadogSdk.Instance.InternalLogger.TelemetryError(
                                 $"Attempting to send message to unknown feature: {message.FeatureTarget}", null);
                         }
+
+                        message.Discard();
                     }
                 }
                 catch (InvalidOperationException)

--- a/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
+++ b/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <projectSettings>
   <projectSetting name="Google.IOSResolver.VerboseLoggingEnabled" value="False" />
+  <projectSetting name="Google.PackageManagerResolver.VerboseLoggingEnabled" value="False" />
+  <projectSetting name="Google.VersionHandler.VerboseLoggingEnabled" value="False" />
+  <projectSetting name="GooglePlayServices.PromptBeforeAutoResolution" value="False" />
 </projectSettings>


### PR DESCRIPTION
### What and why?

Pooling messages for the worker thread into object pools should prevent extraneous memory usage and GC stalls due to using Datadog.

refs: RUM-2164

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
