### PR TITLE
fix: TraceIds should use lower hex

### DIFF
--- a/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
@@ -50,11 +50,11 @@ namespace Datadog.Unity.Rum
                     string hexString;
                     if (_high > 0 && representation != TraceIdRepresentation.hex16Chars)
                     {
-                        hexString = $"{_high:X}{_low:X16}";
+                        hexString = $"{_high:x}{_low:x16}";
                     }
                     else
                     {
-                        hexString = $"{_low:X}";
+                        hexString = $"{_low:x}";
                     }
 
                     if (representation == TraceIdRepresentation.hex16Chars)

--- a/packages/Datadog.Unity/Tests/Rum/TracingUUIDTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/TracingUUIDTest.cs
@@ -39,8 +39,8 @@ namespace Datadog.Unity.Rum.Tests
         }
 
         [Test]
-        [TestCase(0ul, 0x2fee4ul, "2FEE4")]
-        [TestCase(0xf1aul, 0x14e255ul, "F1A000000000014E255")]
+        [TestCase(0ul, 0x2fee4ul, "2fee4")]
+        [TestCase(0xf1aul, 0x14e255ul, "f1a000000000014e255")]
         public void TracingUuidHexRepresentationsAreCorrect(ulong high, ulong low, string expected)
         {
             // Given
@@ -54,8 +54,8 @@ namespace Datadog.Unity.Rum.Tests
         }
 
         [Test]
-        [TestCase(0ul, 0x2fee4ul, "000000000002FEE4")]
-        [TestCase(0xf1aul, 0x14e255ul, "000000000014E255")]
+        [TestCase(0ul, 0x2fee4ul, "000000000002fee4")]
+        [TestCase(0xf1aul, 0x14e255ul, "000000000014e255")]
         public void TracingUuidHex16RepresentationsAreCorrect(ulong high, ulong low, string expected)
         {
             // Given
@@ -69,8 +69,8 @@ namespace Datadog.Unity.Rum.Tests
         }
 
         [Test]
-        [TestCase(0ul, 0x2fee4ul, "0000000000000000000000000002FEE4")]
-        [TestCase(0xf1aul, 0x14e255ul, "0000000000000F1A000000000014E255")]
+        [TestCase(0ul, 0x2fee4ul, "0000000000000000000000000002fee4")]
+        [TestCase(0xf1aul, 0x14e255ul, "0000000000000f1a000000000014e255")]
         public void TracingUuidHex32RepresentationsAreCorrect(ulong high, ulong low, string expected)
         {
             // Given


### PR DESCRIPTION
### What and why?

Logic for TraceIds specifically created upperhex ids. This is wrong according to Otel requirements.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
