### PR TITLE
feat: Add `SetUserInfo` methods

### DIFF
--- a/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
+++ b/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
@@ -20,6 +20,28 @@ func Datadog_SetTrackingConsent(trackingConsentInt: Int) {
     }
 }
 
+@_cdecl("Datadog_SetUserInfo")
+func Datadog_SetUserInfo(
+    id: CString?,
+    name: CString?,
+    email: CString?,
+    extraInfo: CString?
+) {
+    let idString = decodeCString(cString: id)
+    let nameString = decodeCString(cString: name)
+    let emailString = decodeCString(cString: email)
+    let decodedExtraInfo = decodeJsonAttributes(fromCString: extraInfo)
+
+    Datadog.setUserInfo(id: idString, name: nameString, email: emailString, extraInfo: decodedExtraInfo)
+}
+
+@_cdecl("Datadog_AddUserExtraInfo")
+func Datadog_AddUserExtraInfo(extraInfo: CString) {
+    let decodedExtraInfo = decodeJsonAttributes(fromCString: extraInfo)
+
+    Datadog.addUserExtraInfo(decodedExtraInfo)
+}
+
 @_cdecl("Datadog_SendDebugTelemetry")
 func Datadog_SendDebugTelemetry(message: UnsafeMutablePointer<CChar>?) {
     guard let message = message else {
@@ -35,7 +57,8 @@ func Datadog_SendDebugTelemetry(message: UnsafeMutablePointer<CChar>?) {
 func Datadog_SendErrorTelemetry(
     message: UnsafeMutablePointer<CChar>?,
     stack: UnsafeMutablePointer<CChar>?,
-    kind: UnsafeMutablePointer<CChar>?) {
+    kind: UnsafeMutablePointer<CChar>?
+) {
     guard let message = message else {
         return
     }

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -139,6 +139,24 @@ namespace Datadog.Unity.Android
             _datadogClass.CallStatic("setTrackingConsent", DatadogConfigurationHelpers.GetTrackingConsent(trackingConsent));
         }
 
+        public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
+        {
+            var javaExtraInfo = DatadogAndroidHelpers.DictionaryToJavaMap(extraInfo);
+            _datadogClass.CallStatic("setUserInfo", id, name, email, javaExtraInfo);
+        }
+
+        public void AddUserExtraInfo(Dictionary<string, object> extraInfo)
+        {
+            if (extraInfo == null)
+            {
+                // Don't bother calling to platform
+                return;
+            }
+
+            var javaExtraInfo = DatadogAndroidHelpers.DictionaryToJavaMap(extraInfo);
+            _datadogClass.CallStatic("addUserExtraInfo", javaExtraInfo);
+        }
+
         public DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker)
         {
             using var loggerBuilder = new AndroidJavaObject("com.datadog.android.log.Logger$Builder");

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
+using System.Collections.Generic;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
@@ -15,6 +16,14 @@ namespace Datadog.Unity
             return new DdNoOpLogger();
         }
 
+        public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
+        {
+        }
+
+        public void AddUserExtraInfo(Dictionary<string, object> extraInfo)
+        {
+        }
+
         public IDdRum InitRum(DatadogConfigurationOptions options)
         {
             return new DdNoOpRum();
@@ -22,7 +31,6 @@ namespace Datadog.Unity
 
         public void SendDebugTelemetry(string message)
         {
-
         }
 
         public void SendErrorTelemetry(string message, string stack, string kind)

--- a/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
+using System.Collections.Generic;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
@@ -18,6 +19,10 @@ namespace Datadog.Unity
         void SetTrackingConsent(TrackingConsent trackingConsent);
 
         DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker);
+
+        void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo);
+
+        void AddUserExtraInfo(Dictionary<string, object> extraInfo);
 
         IDdRum InitRum(DatadogConfigurationOptions options);
 

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -8,6 +8,7 @@ using Datadog.Unity.Core;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -20,6 +21,7 @@ namespace Datadog.Unity
         internal const string SourceConfigKey = "_dd.source";
 
         private IDatadogPlatform _platform = new DatadogNoOpPlatform();
+
         private DdUnityLogHandler _logHandler;
         private DatadogWorker _worker;
         private InternalLogger _internalLogger;
@@ -51,6 +53,43 @@ namespace Datadog.Unity
             InternalHelpers.Wrap("SetTrackingConsent", () =>
             {
                 _platform.SetTrackingConsent(trackingConsent);
+            });
+        }
+
+        /// <summary>
+        /// Sets information about the current user. User information will be added to logs, traces, and RUM events
+        /// automatically.
+        /// </summary>
+        /// <param name="id">The ID for the user.</param>
+        /// <param name="name">The name for the user.</param>
+        /// <param name="email">The user's email.</param>
+        /// <param name="extraInfo">A map of any extra information about the user.</param>
+        public void SetUserInfo(
+            string id = null,
+            string name = null,
+            string email = null,
+            Dictionary<string, object> extraInfo = null)
+        {
+            InternalHelpers.Wrap("SetUserInfo", () =>
+            {
+                _worker.AddMessage(new DdSdkProcessor.SetUserInfoMessage(id, name, email, extraInfo));
+            });
+        }
+
+        /// <summary>
+        /// Add custom attributes to the current user information
+        ///
+        /// This extra info will be added to already existing extra info that is added to logs, traces, and RUM events
+        /// automatically.
+        ///
+        /// Setting an existing attribute to `null` will remove that attribute from the user's extra info.
+        /// </summary>
+        /// <param name="extraInfo">Any additional extra info about a user.</param>
+        public void AddUserExtraInfo(Dictionary<string, object> extraInfo)
+        {
+            InternalHelpers.Wrap("AddUserExtraInfo", () =>
+            {
+                _worker.AddMessage(new DdSdkProcessor.AddUserExtraInfoMessage(extraInfo));
             });
         }
 
@@ -93,6 +132,8 @@ namespace Datadog.Unity
 
                 // Create our worker thread
                 _worker = new ();
+                _worker.AddProcessor(DdSdkProcessor.SdkTargetName, new DdSdkProcessor(_platform));
+
                 _worker.AddProcessor(DdLogsProcessor.LogsTargetName, new DdLogsProcessor());
                 _internalLogger = new InternalLogger(_worker, _platform);
                 _resourceTrackingHelper = new ResourceTrackingHelper(options);

--- a/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Worker
+{
+    internal class DdSdkProcessor : IDatadogWorkerProcessor
+    {
+        public const string SdkTargetName = "core_sdk";
+
+        private readonly IDatadogPlatform _platform;
+
+        internal DdSdkProcessor(IDatadogPlatform platform)
+        {
+            _platform = platform;
+        }
+
+        public void Process(IDatadogWorkerMessage message)
+        {
+            switch (message)
+            {
+                case SetUserInfoMessage msg:
+                    _platform.SetUserInfo(msg.Id, msg.Name, msg.Email, msg.ExtraInfo);
+                    break;
+                case AddUserExtraInfoMessage msg:
+                    _platform.AddUserExtraInfo(msg.ExtraInfo);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        internal class SetUserInfoMessage : IDatadogWorkerMessage
+        {
+            public string FeatureTarget => SdkTargetName;
+
+            public string Id { get; }
+
+            public string Name { get; }
+
+            public string Email { get; }
+
+            public Dictionary<string, object> ExtraInfo { get; }
+
+            public SetUserInfoMessage(string id, string name, string email, Dictionary<string, object> extraInfo)
+            {
+                Id = id;
+                Name = name;
+                Email = email;
+                ExtraInfo = extraInfo;
+            }
+
+            public void Discard()
+            {
+                // Nothing to do here
+            }
+        }
+
+        internal class AddUserExtraInfoMessage : IDatadogWorkerMessage
+        {
+            public string FeatureTarget => SdkTargetName;
+
+            public Dictionary<string, object> ExtraInfo { get; }
+
+            public AddUserExtraInfoMessage(Dictionary<string, object> extraInfo)
+            {
+                ExtraInfo = extraInfo;
+            }
+
+            public void Discard()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs.meta
+++ b/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dc7429d622e6465f87e4b24c7ee28b4a
+timeCreated: 1706736170

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -1,11 +1,13 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Datadog.Unity;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
+using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Scripting;
 
@@ -32,6 +34,24 @@ namespace Datadog.Unity.iOS
     {
         public void Init(DatadogConfigurationOptions options)
         {
+        }
+
+        public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
+        {
+            var jsonAttributes = extraInfo != null ? JsonConvert.SerializeObject(extraInfo) : null;
+            Datadog_SetUserInfo(id, name, email, jsonAttributes);
+        }
+
+        public void AddUserExtraInfo(Dictionary<string, object> extraInfo)
+        {
+            if (extraInfo == null)
+            {
+                // Don't bother calling to platform
+                return;
+            }
+
+            var jsonAttributes = JsonConvert.SerializeObject(extraInfo);
+            Datadog_AddUserExtraInfo(jsonAttributes);
         }
 
         public void SetTrackingConsent(TrackingConsent trackingConsent)
@@ -67,6 +87,12 @@ namespace Datadog.Unity.iOS
 
         [DllImport("__Internal")]
         private static extern void Datadog_SetTrackingConsent(int trackingConsent);
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_SetUserInfo(string id, string name, string email, string extraInfo);
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_AddUserExtraInfo(string extraInfo);
 
         [DllImport("__Internal")]
         private static extern void Datadog_SendDebugTelemetry(string message);

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -91,6 +91,11 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.IsFalse(errorLog.RawJson.ContainsKey("logger-attribute1"));
             Assert.AreEqual(1000, (long)errorLog.RawJson["logger-attribute2"]);
             Assert.AreEqual("value", (string)errorLog.RawJson["attribute"]);
+            Assert.AreEqual("user-id", errorLog.UserId);
+            Assert.AreEqual("user-name", errorLog.UserName);
+            Assert.IsNull(errorLog.UserEmail);
+            Assert.AreEqual("property", errorLog.UserExtraInfo["extra"].ToString());
+
 
             var exceptionLog = logs[4];
             Assert.AreEqual("warn", exceptionLog.Status);
@@ -154,6 +159,11 @@ namespace Datadog.Unity.Tests.Integration.Logging
 
                 logger.RemoveAttribute("logger-attribute1");
                 logger.RemoveTagsWithKey("tag1");
+
+                DatadogSdk.Instance.SetUserInfo("user-id", "user-name", extraInfo: new()
+                {
+                    { "extra", "property" },
+                });
 
                 logger.Error("error message", new() { { "attribute", "value" } });
 

--- a/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumEventDecoder.cs
@@ -33,6 +33,14 @@ namespace Datadog.Unity.Tests.Integration.Rum.Decoders
 
         public JObject FeatureFlags => rumEvent["feature_flags"] as JObject;
 
+        public string UserName => jsonGetProp<string>(rumEvent, "usr.name");
+
+        public string UserId => jsonGetProp<string>(rumEvent, "usr.id");
+
+        public string UserEmail => jsonGetProp<string>(rumEvent, "usr.email");
+
+        public JObject UserAttributes => rumEvent["usr"] as JObject;
+
         protected RumEventDecoder(JObject rawJson)
         {
             rumEvent = rawJson;

--- a/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Net.NetworkInformation;
-using System.Security.Cryptography;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Tests.Integration.Rum.Decoders;
 using Newtonsoft.Json.Linq;
@@ -104,6 +103,10 @@ namespace Datadog.Unity.Tests.Integration.Rum
             var finalSecondVisitView = secondVisit.ViewEvents.Last();
             Assert.AreEqual("True", finalSecondVisitView.FeatureFlags["mock_flag_a"].Value<string>());
             Assert.AreEqual("mock_value", finalSecondVisitView.FeatureFlags["mock_flag_b"].Value<string>());
+            Assert.AreEqual("user-id", finalSecondVisitView.UserId);
+            Assert.AreEqual("user-name", finalSecondVisitView.UserName);
+            Assert.IsNull(finalSecondVisitView.UserEmail);
+            Assert.AreEqual("property", finalSecondVisitView.UserAttributes["extra"].ToString());
 
             var automaticVisit = visits[2];
             var visitView = automaticVisit.ViewEvents.Last();
@@ -152,6 +155,11 @@ namespace Datadog.Unity.Tests.Integration.Rum
 
             yield return new WaitForSeconds(0.03f);
             rum?.StopResource(resourceKey2, new NetworkInformationException());
+
+            DatadogSdk.Instance.SetUserInfo("user-id", "user-name", extraInfo: new()
+            {
+                { "extra", "property" },
+            });
 
             rum?.StartView("ErrorScreen", name: "Error Screen");
             rum?.AddFeatureFlagEvaluation("mock_flag_a", true);


### PR DESCRIPTION
### What and why?

Add `SetUserInfo` and `AddUserExtraInfo` methods to `DatadogSdk`, as well as integration tests.

These are the first two methods on DatadogSdk that need to be processed on the worker thread, so a new processor was made for them. However I don't expect them to be super frequent, so I'm not pooling these messages.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
