### PR TITLE
feat: Add `BatchProcessingLevel` to configuration

### DIFF
--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -53,6 +53,7 @@ namespace Datadog.Unity.Editor
             _options.CustomEndpoint = EditorGUILayout.TextField("Custom Endpoint", _options.CustomEndpoint);
             _options.BatchSize = (BatchSize)EditorGUILayout.EnumPopup("Batch Size", _options.BatchSize);
             _options.UploadFrequency = (UploadFrequency)EditorGUILayout.EnumPopup("Upload Frequency", _options.UploadFrequency);
+            _options.BatchProcessingLevel = (BatchProcessingLevel)EditorGUILayout.EnumPopup("Batch Processing Level", _options.BatchProcessingLevel);
             _options.CrashReportingEnabled = EditorGUILayout.ToggleLeft(
                 new GUIContent("Enable Crash Reporting", "Whether to report native crashes to Datadog."),
                 _options.CrashReportingEnabled);

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -138,7 +138,8 @@ func initializeDatadog() {{
         clientToken: ""{options.ClientToken}"",
         env: ""{env}"",
         batchSize: {GetSwiftBatchSize(options.BatchSize)},
-        uploadFrequency: {GetSwiftUploadFrequency(options.UploadFrequency)}
+        uploadFrequency: {GetSwiftUploadFrequency(options.UploadFrequency)},
+        batchProcessingLevel: {GetSwiftBatchProcessingLevel(options.BatchProcessingLevel)}
     )
 ");
             var additionalConfigurationItems = new List<string>()
@@ -322,6 +323,16 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
                 UploadFrequency.Rare => ".rare",
                 UploadFrequency.Frequent => ".frequent",
                 _ => ".average",
+            };
+        }
+
+        private static string GetSwiftBatchProcessingLevel(BatchProcessingLevel batchProcessingLevel)
+        {
+            return batchProcessingLevel switch
+            {
+                BatchProcessingLevel.Low => ".low",
+                BatchProcessingLevel.High => ".high",
+                _ => ".medium",
             };
         }
 

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
@@ -52,6 +52,19 @@ namespace Datadog.Unity.Android
             return uploadFrequencyClass.GetStatic<AndroidJavaObject>(sizeName);
         }
 
+        internal static AndroidJavaObject GetBatchProcessingLevel(BatchProcessingLevel processingLevel)
+        {
+            string processingLevelName = processingLevel switch
+            {
+                BatchProcessingLevel.Low => "LOW",
+                BatchProcessingLevel.Medium => "MEDIUM",
+                BatchProcessingLevel.High => "HIGH",
+                _ => "MEDIUM"
+            };
+            using var processingLevelClass = new AndroidJavaClass("com.datadog.android.core.configuration.BatchProcessingLevel");
+            return processingLevelClass.GetStatic<AndroidJavaObject>(processingLevelName);
+        }
+
         internal static AndroidJavaObject GetVitalsUpdateFrequency(VitalsUpdateFrequency updateFrequency)
         {
             string frequencyName = updateFrequency switch

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -62,6 +62,7 @@ namespace Datadog.Unity.Android
             configBuilder.Call<AndroidJavaObject>("useSite", DatadogConfigurationHelpers.GetSite(options.Site));
             configBuilder.Call<AndroidJavaObject>("setBatchSize", DatadogConfigurationHelpers.GetBatchSize(options.BatchSize));
             configBuilder.Call<AndroidJavaObject>("setUploadFrequency", DatadogConfigurationHelpers.GetUploadFrequency(options.UploadFrequency));
+            configBuilder.Call<AndroidJavaObject>("setBatchProcessing", DatadogConfigurationHelpers.GetBatchProcessingLevel(options.BatchProcessingLevel));
 
             var additionalConfig = new Dictionary<string, object>()
             {

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -79,6 +79,20 @@ namespace Datadog.Unity
     }
 
     /// <summary>
+    /// Defines the maximum amount of batches processed sequentially without a delay within one reading/uploading cycle.
+    /// High level will mean that more data will be sent in a single upload cycle but more CPU and memory
+    /// will be used to process the data.
+    /// Low level will mean that less data will be sent in a single upload cycle but less CPU and memory
+    /// will be used to process the data.
+    /// </summary>
+    public enum BatchProcessingLevel
+    {
+        Low,
+        Medium,
+        High,
+    }
+
+    /// <summary>
     /// The Consent enum class providing the possible values for the Data Tracking Consent flag.
     /// </summary>
     public enum TrackingConsent
@@ -166,6 +180,7 @@ namespace Datadog.Unity
         public string CustomEndpoint;
         public BatchSize BatchSize;
         public UploadFrequency UploadFrequency;
+        public BatchProcessingLevel BatchProcessingLevel = BatchProcessingLevel.Medium;
         public bool CrashReportingEnabled = true;
 
         // Logging

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -52,6 +52,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.IsEmpty(options.CustomEndpoint);
             Assert.AreEqual(BatchSize.Medium, options.BatchSize);
             Assert.AreEqual(UploadFrequency.Average, options.UploadFrequency);
+            Assert.AreEqual(BatchProcessingLevel.Medium, options.BatchProcessingLevel);
             Assert.IsTrue(options.CrashReportingEnabled);
 
             // Logging

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -108,7 +108,26 @@ namespace Datadog.Unity.Editor.iOS
             var lines = File.ReadAllLines(_initializationFilePath);
             var uploadFrequencyLines = lines.Where(l => l.Contains("uploadFrequency:")).ToArray();
             Assert.AreEqual(1, uploadFrequencyLines.Length);
-            Assert.AreEqual($"uploadFrequency: {expectedUploadFrequency}", uploadFrequencyLines.First().Trim());
+            Assert.IsTrue(uploadFrequencyLines.First().Trim().StartsWith($"uploadFrequency: {expectedUploadFrequency}"));
+        }
+
+        [TestCase(BatchProcessingLevel.Low, ".low")]
+        [TestCase(BatchProcessingLevel.Medium, ".medium")]
+        [TestCase(BatchProcessingLevel.High, ".high")]
+        public void GenerationOptionsFileWritesBatchProcessingLevel(
+            BatchProcessingLevel processingLevel, string expectedProcessingLevel)
+        {
+            var options = new DatadogConfigurationOptions()
+            {
+                Enabled = true,
+                BatchProcessingLevel = processingLevel,
+            };
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var processingLevelLines = lines.Where(l => l.Contains("batchProcessingLevel:")).ToArray();
+            Assert.AreEqual(1, processingLevelLines.Length);
+            Assert.IsTrue(processingLevelLines.First().Trim().StartsWith($"batchProcessingLevel: {expectedProcessingLevel}"));
         }
 
         [Test]


### PR DESCRIPTION
### What and why?

Adds the new `BatchProcessingLevel` configuration option to Unity.

refs: RUM-3035

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
