### PR TITLE
chore: Fix signed commits in releaser script

### DIFF
--- a/tools/scripts/release_package.py
+++ b/tools/scripts/release_package.py
@@ -89,7 +89,9 @@ def _branch(dest: str, branch_name: str):
 
 def _commit(repo: git.Repo, message: str):
     repo.git.add('--all')
-    repo.index.commit(message)
+    repo.index.write()
+    repo.git.commit('-m', message)
+
 
 def _commit_and_tag(repo: git.Repo, version: str):
     _commit(repo, f'Publish version {version}')


### PR DESCRIPTION
### What and why?

Apparently `repo.commit` doesn't properly sign commits using your configured signing key, and you have to run the git command directly using `repo.git.commit`.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
