### PR TITLE
fix: Fix compilation after access modifier change on DdLogger

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md.meta
+++ b/packages/Datadog.Unity/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1a900a5c72e6042518ff1004389cdf33
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/README.md
+++ b/packages/Datadog.Unity/README.md
@@ -10,7 +10,7 @@ The Datadog Unity SDK supports logging and crash reporting for Android and iOS a
 
 1. Install [External Dependency Manager for Unity (EDM4U)](https://github.com/googlesamples/unity-jar-resolver). This can be done using [Open UPM](https://openupm.com/packages/com.google.external-dependency-manager/).
 
-2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package](https://github.com/DataDog/unity-package).
+2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package](https://github.com/DataDog/unity-package).  The package url is `https://github.com/DataDog/unity-package.git`.
 
 > [!NOTE]
 > Datadog plans on adding support for Open UPM after Closed Beta.

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidLogger.cs
@@ -39,7 +39,7 @@ namespace Datadog.Unity.Android
             }
         }
 
-        public override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
+        internal override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
             var androidLevel = InternalHelpers.DdLogLevelToAndroidLogLevel(level);
 

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -62,7 +62,7 @@ namespace Datadog.Unity.Android
             configBuilder.Call<AndroidJavaObject>("useSite", DatadogConfigurationHelpers.GetSite(options.Site));
             configBuilder.Call<AndroidJavaObject>("setBatchSize", DatadogConfigurationHelpers.GetBatchSize(options.BatchSize));
             configBuilder.Call<AndroidJavaObject>("setUploadFrequency", DatadogConfigurationHelpers.GetUploadFrequency(options.UploadFrequency));
-            configBuilder.Call<AndroidJavaObject>("setBatchProcessing", DatadogConfigurationHelpers.GetBatchProcessingLevel(options.BatchProcessingLevel));
+            configBuilder.Call<AndroidJavaObject>("setBatchProcessingLevel", DatadogConfigurationHelpers.GetBatchProcessingLevel(options.BatchProcessingLevel));
 
             var additionalConfig = new Dictionary<string, object>()
             {

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSLogger.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSLogger.cs
@@ -33,7 +33,7 @@ namespace Datadog.Unity.iOS
             return null;
         }
 
-        public override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
+        internal override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
             // To serialize a non-object, we need to use JsonConvert, which isn't as optimized but supports
             // Dictionaries, where JsonUtility does not.


### PR DESCRIPTION
### What and why?

During documentation of public members I changed DdLogger's PlatformLog method to internal, but the platform implementations were left as public.  This broke compilation on those platforms.

Also add CHANGELOG meta to prevent warnings in Unity and add correct package URL to the README.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
