### PR TITLE
fix: Fix SDK Version reporting

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix SDK version reporting to Datadog.
+
+
 
 ## 1.0.2
 

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -121,7 +121,7 @@ namespace Datadog.Unity.Editor.iOS
                 env = "prod";
             }
 
-            var sdkVersion = typeof(DatadogSdk).Assembly.GetName().Version?.ToString();
+            var sdkVersion = DatadogSdk.SdkVersion;
 
             var sb = new StringBuilder($@"// Datadog Options File -
 // THIS FILE IS AUTO GENERATED --- changes to this file will be lost!

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -66,14 +66,9 @@ namespace Datadog.Unity.Android
 
             var additionalConfig = new Dictionary<string, object>()
             {
-                { DatadogSdk.SourceConfigKey, "unity" },
+                { DatadogSdk.ConfigKeys.Source, "unity" },
+                { DatadogSdk.ConfigKeys.SdkVersion, DatadogSdk.SdkVersion }
             };
-
-            var sdkVersion = typeof(DatadogSdk).Assembly.GetName().Version?.ToString();
-            if (sdkVersion != null)
-            {
-                additionalConfig.Add(DatadogSdk.ConfigKeys.SdkVersion, sdkVersion);
-            }
 
             configBuilder.Call<AndroidJavaObject>("setAdditionalConfiguration", DatadogAndroidHelpers.DictionaryToJavaMap(additionalConfig));
 

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -18,14 +18,25 @@ namespace Datadog.Unity
     {
         public static readonly DatadogSdk Instance = new();
 
-        internal const string SourceConfigKey = "_dd.source";
-
         private IDatadogPlatform _platform = new DatadogNoOpPlatform();
 
         private DdUnityLogHandler _logHandler;
         private DatadogWorker _worker;
         private InternalLogger _internalLogger;
         private ResourceTrackingHelper _resourceTrackingHelper;
+
+        /// <summary>
+        /// Gets the version of the SDK reported to Datadog. This strips the final (revision) part of the version.
+        /// to be more compliant with "SemVer" standards.
+        /// </summary>
+        public static string SdkVersion
+        {
+            get
+            {
+                var version = typeof(DatadogSdk).Assembly.GetName().Version;
+                return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.0.0";
+            }
+        }
 
         private DatadogSdk()
         {
@@ -109,7 +120,7 @@ namespace Datadog.Unity
                 _worker.AddMessage(new DdSdkProcessor.AddUserExtraInfoMessage(extraInfo));
             });
         }
-      
+
         /// <summary>
         /// Create a logger with the given logging options.
         ///

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -271,8 +271,9 @@ namespace Datadog.Unity.Editor.iOS
         [Test]
         public void ConfigWritesSdkVersion()
         {
-            var sdkVersion = typeof(DatadogSdk).Assembly.GetName().Version?.ToString();
+            var sdkVersion = typeof(DatadogSdk).Assembly.GetName().Version;
             Assert.IsNotNull(sdkVersion);
+            var expectedVersion = $"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Build}";
 
             var options = new DatadogConfigurationOptions()
             {
@@ -284,7 +285,7 @@ namespace Datadog.Unity.Editor.iOS
             var lines = File.ReadAllLines(_initializationFilePath);
             var sdkVersionLines = lines.Where(l => l.Contains("\"_dd.sdk_version\":")).ToArray();
             Assert.AreEqual(1, sdkVersionLines.Length);
-            Assert.IsTrue(sdkVersionLines.First().Trim().StartsWith($"\"_dd.sdk_version\": \"{sdkVersion}\""));
+            Assert.IsTrue(sdkVersionLines.First().Trim().StartsWith($"\"_dd.sdk_version\": \"{expectedVersion}\""));
         }
 
 		[Test]

--- a/tools/scripts/release_package.py
+++ b/tools/scripts/release_package.py
@@ -66,6 +66,16 @@ def _modify_package_version(dest: str, version: str):
     with open(package_path, "w") as json_file:
         json.dump(package_json, json_file, indent=2)
 
+def _modify_assembly_info_version(dest: str, version: str):
+    assembly_info_path = os.path.join(dest, "Runtime/AssemblyInfo.cs")
+
+    with fileinput.input(assembly_info_path, inplace=True) as f:
+        for line in f:
+            if line.startswith("[assembly: AssemblyVersion"):
+                print(f"[assembly: AssemblyVersion(\"{version}\")]")
+            else:
+                print(line, end='')
+
 def _update_android_versions(version: str, github_token: str):
     if version is None:
         # Need to get the latest version from Github
@@ -176,6 +186,7 @@ def main():
     print(f"Creating release branch '{branch_name}'")
     _branch(REPO_ROOT, branch_name)
     _modify_package_version(PACKAGE_LOCATION, version)
+    _modify_assembly_info_version(PACKAGE_LOCATION, version)
     if args.ios_version:
         print(f'Updating iOS to version {args.ios_version} and rebuilding.')
         uv._update_ios_version(args.ios_version)


### PR DESCRIPTION
### What and why?

SDK Versions weren't updated during package release, but also weren't SemVer compatible, which was breaking SDK version reporting. This fixes it so that DatadogSdk always reports an SDK Version that is SemVer compliant and updates the version as part of release.

refs: RUM-3308

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
