### PR TITLE
feat: Add UnityVersion to telemetry

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -198,6 +198,11 @@ func initializeDatadog() {{
 
                 sb.AppendLine($"    rumConfig.sessionSampleRate = {options.SessionSampleRate}");
                 sb.AppendLine($"    rumConfig.telemetrySampleRate = {options.TelemetrySampleRate}");
+
+                // Uncomment to enable RUM Configuration Telemetry
+    //             sb.AppendLine(@"    rumConfig._internal_mutation {
+    //     $0.configurationTelemetrySampleRate = 100.0
+    // }");
                 sb.AppendLine("    RUM.enable(with: rumConfig)");
             }
 

--- a/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
+++ b/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import DatadogCore
+import DatadogInternal
 
 @_cdecl("Datadog_SetTrackingConsent")
 func Datadog_SetTrackingConsent(trackingConsentInt: Int) {
@@ -83,3 +84,12 @@ func Datadog_ClearAllData() {
     Datadog.clearAllData()
 }
 
+@_cdecl("Datadog_UpdateTelemetryConfiguration")
+func Datadog_UpdateTelemetryConfiguration(unityVersion: CString) {
+    guard let unityVersion = decodeCString(cString: unityVersion) else {
+        return
+    }
+
+    let core = CoreRegistry.default
+    core.telemetry.configuration(unityVersion: unityVersion)
+}

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -118,6 +118,19 @@ namespace Datadog.Unity.Android
                     rumConfigBuilder.Call<AndroidJavaObject>("setVitalsUpdateFrequency", updateFrequency);
                 }
 
+                using var internalBuilder = new AndroidJavaClass("com.datadog.android.rum._RumInternalProxy");
+                using var internalBuilderCompanion = internalBuilder.GetStatic<AndroidJavaObject>("Companion");
+                internalBuilderCompanion.Call<AndroidJavaObject>("setTelemetryConfigurationEventMapper", rumConfigBuilder, new TelemetryCallback());
+
+                // Uncomment to always send Configuraiton telemetry
+                // var rumAdditionalConfig = new Dictionary<string, object>()
+                // {
+                //     { "_dd.telemetry.configuration_sample_rate", 100.0f },
+                // };
+                // internalBuilderCompanion.Call<AndroidJavaObject>("setAdditionalConfiguration",
+                //     rumConfigBuilder,
+                //     DatadogAndroidHelpers.DictionaryToJavaMap(rumAdditionalConfig));
+
                 using var rumConfig = rumConfigBuilder.Call<AndroidJavaObject>("build");
                 using var rumClass = new AndroidJavaClass("com.datadog.android.rum.Rum");
                 rumClass.CallStatic("enable", rumConfig);

--- a/packages/Datadog.Unity/Runtime/Android/TelemetryCallback.cs
+++ b/packages/Datadog.Unity/Runtime/Android/TelemetryCallback.cs
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+using System;
+using UnityEngine;
+using UnityEngine.Scripting;
+
+namespace Datadog.Unity.Android
+{
+    public class TelemetryCallback : AndroidJavaProxy
+    {
+        //private AndroidJavaObject _javaObject;
+
+        public TelemetryCallback() : base("com.datadog.android.event.EventMapper")
+        {
+
+        }
+
+        public AndroidJavaObject map(AndroidJavaObject rumEvent)
+        {
+            var configuration = rumEvent.Call<AndroidJavaObject>("getTelemetry")?.Call<AndroidJavaObject>("getConfiguration");
+            configuration?.Call("setUnityVersion", Application.unityVersion);
+
+            return rumEvent;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Android/TelemetryCallback.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Android/TelemetryCallback.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc95fd02892b4415bd7920c3b5dfa745
+timeCreated: 1710796385

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -25,7 +25,9 @@ namespace Datadog.Unity.iOS
             var options = DatadogConfigurationOptions.Load();
             if (options.Enabled)
             {
-                DatadogSdk.InitWithPlatform(new DatadogiOSPlatform(), options);
+                var platform = new DatadogiOSPlatform();
+                platform.Init(options);
+                DatadogSdk.InitWithPlatform(platform, options);
             }
         }
     }
@@ -34,6 +36,7 @@ namespace Datadog.Unity.iOS
     {
         public void Init(DatadogConfigurationOptions options)
         {
+            Datadog_UpdateTelemetryConfiguration(Application.unityVersion);
         }
 
         public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
@@ -102,5 +105,8 @@ namespace Datadog.Unity.iOS
 
         [DllImport("__Internal")]
         private static extern void Datadog_ClearAllData();
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_UpdateTelemetryConfiguration(string unityVersion);
     }
 }

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -847,7 +847,7 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  additionalIl2CppArgs: '  --emit-source-mapping'
+  additionalIl2CppArgs: '  '
   scriptingRuntimeVersion: 1
   gcIncremental: 1
   gcWBarrierValidation: 0

--- a/tools/scripts/update_versions.py
+++ b/tools/scripts/update_versions.py
@@ -47,14 +47,20 @@ def _update_ios_version(version: str):
     for origin in ios_submodule.module().remotes:
         origin.fetch()
 
-    if version not in ios_submodule.module().tags:
-        print(f"Could not find tag `{version}` in iOS submodule.")
-        return
+    if version != "develop":
+        if version not in ios_submodule.module().tags:
+            print(f"Could not find tag `{version}` in iOS submodule.")
+            return
 
-    version_tag = ios_submodule.module().tags[version]
-    ios_submodule.module().head.reference = version_tag
-    print(f"Resetting dd-sdk-ios to tag {version}")
-    ios_submodule.module().head.reset(index=True, working_tree=True)
+        version_tag = ios_submodule.module().tags[version]
+        ios_submodule.module().head.reference = version_tag
+        print(f"Resetting dd-sdk-ios to tag {version}")
+        ios_submodule.module().head.reset(index=True, working_tree=True)
+    else:
+        develop = ios_submodule.module().branches["develop"]
+        ios_submodule.module().head.reference = develop
+        print(f"Resetting dd-sdk-ios to develop")
+        ios_submodule.module().head.reset(index=True, working_tree=True)
 
     # Build carthage
     print("Running carthage build...")


### PR DESCRIPTION
### What and why?

Add the version of Unity used to create the Application to telemetry.  Also update the iOS SDK to the 2.8.0 release.

refs: RUM-3237

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
