### PR TITLE
feat: Ensure telemetry gets called from DDUnityLogHandler

### DIFF
--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -22,7 +22,7 @@ namespace Datadog.Unity
 
         private DdUnityLogHandler _logHandler;
         private DatadogWorker _worker;
-        private InternalLogger _internalLogger;
+        private IInternalLogger _internalLogger;
         private ResourceTrackingHelper _resourceTrackingHelper;
 
         /// <summary>
@@ -57,7 +57,11 @@ namespace Datadog.Unity
         /// </summary>
         public IDdRum Rum { get; private set; } = new DdNoOpRum();
 
-        internal InternalLogger InternalLogger => _internalLogger;
+        internal IInternalLogger InternalLogger
+        {
+            get { return _internalLogger;  }
+            set { _internalLogger = value; }
+        }
 
         internal ResourceTrackingHelper ResourceTrackingHelper => _resourceTrackingHelper;
 

--- a/packages/Datadog.Unity/Runtime/DdUnityLogHandler.cs
+++ b/packages/Datadog.Unity/Runtime/DdUnityLogHandler.cs
@@ -46,10 +46,6 @@ namespace Datadog.Unity
             {
                 _ddLogger.Critical(exception.Message, error: exception);
             }
-            catch (Exception e)
-            {
-                // TODO: RUM-734 telemetry
-            }
             finally
             {
                 // Pass exception onto Unity
@@ -61,7 +57,7 @@ namespace Datadog.Unity
         {
             try
             {
-                if (args.Length >= 1 && InternalLogger.DatadogTag.Equals(args[0]))
+                if (args.Length >= 1 && IInternalLogger.DatadogTag.Equals(args[0]))
                 {
                     // Don't forward internal logs
                     return;
@@ -70,10 +66,6 @@ namespace Datadog.Unity
                 var logLevel = DdLogHelpers.LogTypeToDdLogLevel(logType);
                 var message = args.Length == 0 ? format : string.Format(format, args);
                 _ddLogger.Log(logLevel, message);
-            }
-            catch (Exception e)
-            {
-                // TODO: RUM-734 telemetry
             }
             finally
             {

--- a/packages/Datadog.Unity/Runtime/InternalLogger.cs
+++ b/packages/Datadog.Unity/Runtime/InternalLogger.cs
@@ -11,15 +11,22 @@ using UnityEngine.Pool;
 
 namespace Datadog.Unity.Core
 {
+    public interface IInternalLogger
+    {
+        public const string DatadogTag = "Datadog";
+
+        public void Log(DdLogLevel level, string message);
+        public void TelemetryError(string message, Exception exception);
+        public void TelemetryDebug(string message);
+    }
+
     /// <summary>
     /// InternalLogger is used to log messages to users of the DatadogSdk, bypassing sending logs
     /// to Datadog. It is also used for sending telemetry to Datadog about the performance of
     /// the SDK.
     /// </summary>
-    internal class InternalLogger
+    internal class InternalLogger : IInternalLogger
     {
-        public const string DatadogTag = "Datadog";
-
         private DatadogWorker _worker;
 
         public InternalLogger(DatadogWorker worker, IDatadogPlatform platform)
@@ -33,7 +40,7 @@ namespace Datadog.Unity.Core
         public void Log(DdLogLevel level, string message)
         {
             var unityLogLevel = DdLogHelpers.DdLogLevelToLogType(level);
-            Debug.unityLogger.Log(unityLogLevel, DatadogTag, message);
+            Debug.unityLogger.Log(unityLogLevel, IInternalLogger.DatadogTag, message);
         }
 
         public void TelemetryError(string message, Exception exception)

--- a/packages/Datadog.Unity/Tests/InternalLoggerTest.cs
+++ b/packages/Datadog.Unity/Tests/InternalLoggerTest.cs
@@ -55,7 +55,7 @@ namespace Datadog.Unity.Tests
                 logType,
                 null,
                 "{0}: {1}",
-                InternalLogger.DatadogTag,
+                IInternalLogger.DatadogTag,
                 "Fake Message");
         }
 


### PR DESCRIPTION
### What and why?

There was an open TODO to add telemetry, but in reality the telemetry was already there via a wrap call. Remove the TODO but add unit tests to ensure telemetry is called on errors.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
