### PR TITLE
feat: Remove prebuilt frameworks in favor of Cocoapods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "modules/dd-sdk-ios"]
-	path = modules/dd-sdk-ios
-	url = git@github.com:DataDog/dd-sdk-ios.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,43 +29,10 @@ Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download)
 
 ## Building for iOS
 
-Some of these steps will be automated in the near future, but are currently manual.
-
 ### Install xcpretty
 
 ```bash
 gem install xcpretty
-```
-
-### Update xcframeworks
-
-You can update and build a specific version of the iOS libraries by using the script in `tools/scripts`:
-
-```bash
-python3 update_versions.py --platform ios --version 2.6.0
-```
-
-This will automatically check out the release tag, build the required `.xcframework` files and copy them to the correct locations.
-
-### Manually building xcframeworks
-
-If you want to update to a specific commit for dd-sdk-ios, you can update the git submodule held in `modules/dd-sdk-ios`.  Then, you can build all of the iOS xcframeworks:
-
-```bash
-# From modules/dd-sdk-ios
-./tools/distribution/build-xcframework.sh
-```
-
-Copy the resulting frameworks to `packages/Datadog.Unity/Plugins/iOS`. Note the trailing tilde (`~`) on each framework is intentional to prevent Unity from attempting to embed the individual framework files manually.
-
-```bash
-#from modules/dd-sdk-ios
-cp -r build/xcframeworks/CrashReporter.xcframework ../../packages/Datadog.Unity/Plugins/iOS/CrashReporter.xcframework~
-cp -r build/xcframeworks/DatadogCore.xcframework ../../packages/Datadog.Unity/Plugins/iOS/DatadogCore.xcframework~
-cp -r build/xcframeworks/DatadogCrashReporting.xcframework ../../packages/Datadog.Unity/Plugins/iOS/DatadogCrashReporting.xcframework~
-cp -r build/xcframeworks/DatadogInternal.xcframework ../../packages/Datadog.Unity/Plugins/iOS/DatadogInternal.xcframework~
-cp -r build/xcframeworks/DatadogLogs.xcframework ../../packages/Datadog.Unity/Plugins/iOS/DatadogLogs.xcframework~
-cp -r build/xcframeworks/DatadogRUM.xcframework ../../packages/Datadog.Unity/Plugins/iOS/DatadogRUM.xcframework~
 ```
 
 ### Tools Prerequisites

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+* Remove precompiled frameworks in favor of Cocoapod resolution with EDM4U
+* Update iOS SDK to 2.9.0
+  * Track App Hangs as RUM errors.
+* Update Android SDK to 2.9.0
+
 ## 1.0.4
 
 * Fix SDK version reporting to Datadog.

--- a/packages/Datadog.Unity/Editor/DatadogDependencies.xml
+++ b/packages/Datadog.Unity/Editor/DatadogDependencies.xml
@@ -11,4 +11,10 @@
     <androidPackage spec="com.datadoghq:dd-sdk-android-ndk:2+">
     </androidPackage>
   </androidPackages>
+  <iosPods>
+    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
+    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
+    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
+    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
+  </iosPods>
 </dependencies>

--- a/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
+++ b/samples/Datadog Sample/ProjectSettings/GvhProjectSettings.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <projectSettings>
+  <projectSetting name="com.google.external-dependency-managerAnalyticsCookie" value="a87ec1e78f6e4cc281eed5dde0894194" />
+  <projectSetting name="com.google.external-dependency-managerAnalyticsEnabled" value="True" />
+  <projectSetting name="Google.IOSResolver.AutoPodToolInstallInEditor" value="True" />
+  <projectSetting name="Google.IOSResolver.CocoapodsIntegrationMethod" value="2" />
+  <projectSetting name="Google.IOSResolver.PodfileAddUseFrameworks" value="True" />
+  <projectSetting name="Google.IOSResolver.PodfileAllowPodsInMultipleTargets" value="True" />
+  <projectSetting name="Google.IOSResolver.PodfileAlwaysAddMainTarget" value="True" />
+  <projectSetting name="Google.IOSResolver.PodfileEnabled" value="True" />
+  <projectSetting name="Google.IOSResolver.PodfileStaticLinkFrameworks" value="True" />
+  <projectSetting name="Google.IOSResolver.PodToolExecutionViaShellEnabled" value="True" />
+  <projectSetting name="Google.IOSResolver.PodToolShellExecutionSetLang" value="True" />
+  <projectSetting name="Google.IOSResolver.SwiftFrameworkSupportWorkaroundEnabled" value="True" />
+  <projectSetting name="Google.IOSResolver.SwiftLanguageVersion" value="5.0" />
   <projectSetting name="Google.IOSResolver.VerboseLoggingEnabled" value="False" />
   <projectSetting name="Google.PackageManagerResolver.VerboseLoggingEnabled" value="False" />
   <projectSetting name="Google.VersionHandler.VerboseLoggingEnabled" value="False" />

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -847,7 +847,7 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  additionalIl2CppArgs: '  '
+  additionalIl2CppArgs: '   --emit-source-mapping'
   scriptingRuntimeVersion: 1
   gcIncremental: 1
   gcWBarrierValidation: 0

--- a/tools/scripts/update_versions.py
+++ b/tools/scripts/update_versions.py
@@ -10,13 +10,8 @@
 # native libraries
 
 import argparse
-import os
-import shutil
-import subprocess
-import git
 import xml.etree.ElementTree as et
 
-IOS_MODULE_PATH = "../../modules/dd-sdk-ios"
 UNITY_PLUGIN_PATH = "../../packages/Datadog.Unity/Plugins"
 UNITY_DEPENDENCIES_FILE = "../../packages/Datadog.Unity/Editor/DatadogDependencies.xml"
 
@@ -36,48 +31,14 @@ def _update_android_version(version: str):
 
 
 def _update_ios_version(version: str):
-    repo = git.Repo("../../")
+    tree = et.parse(UNITY_DEPENDENCIES_FILE)
+    root = tree.getroot()
 
-    # Update git subodule
-    ios_submodule = next((x for x in repo.submodules if x.name == "modules/dd-sdk-ios"), None)
-    if ios_submodule is None:
-        print("Could not find the iOS sdk submodule to update")
-        return
+    for item in root.findall("./iosPods/iosPod"):
+        if "name" in item.attrib and item.attrib['name'].startswith("Datadog"):
+            item.attrib["version"] = version
 
-    for origin in ios_submodule.module().remotes:
-        origin.fetch()
-
-    if version != "develop":
-        if version not in ios_submodule.module().tags:
-            print(f"Could not find tag `{version}` in iOS submodule.")
-            return
-
-        version_tag = ios_submodule.module().tags[version]
-        ios_submodule.module().head.reference = version_tag
-        print(f"Resetting dd-sdk-ios to tag {version}")
-        ios_submodule.module().head.reset(index=True, working_tree=True)
-    else:
-        develop = ios_submodule.module().branches["develop"]
-        ios_submodule.module().head.reference = develop
-        print(f"Resetting dd-sdk-ios to develop")
-        ios_submodule.module().head.reset(index=True, working_tree=True)
-
-    # Build carthage
-    print("Running carthage build...")
-    process = subprocess.Popen(["./tools/distribution/build-xcframework.sh"],
-                               stdout=subprocess.PIPE, universal_newlines=True, cwd=IOS_MODULE_PATH)
-    for line in process.stdout:
-        print(f"{line}")
-
-    # Copy frameworks
-    frameworks = [ "CrashReporter", "DatadogCore", "DatadogCrashReporting", "DatadogInternal", "DatadogLogs", "DatadogRUM" ]
-    for framework in frameworks:
-        src = os.path.join(IOS_MODULE_PATH, "build", "xcframeworks", f'{framework}.xcframework')
-        dest = os.path.join(UNITY_PLUGIN_PATH, "iOS", f"{framework}.xcframework~")
-        if os.path.exists(dest):
-            shutil.rmtree(dest)
-        print(f"Copying ${src} => {dest}")
-        shutil.copytree(src, dest)
+    tree.write(UNITY_DEPENDENCIES_FILE)
 
 def main():
     arg_parser = argparse.ArgumentParser()


### PR DESCRIPTION
### What and why?

Something about PLCrashReporter breaks App Store Connect validation when using prebuilt frameworks with XCode 15+. To get around this, we're switching to Cocoapods through EDM4U for dependency resolution.

Also fix swift libraries being embedded improperly in UnityFramework.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
