### PR TITLE
feat: Allow configuration of Datadog SDK verbosity

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Allow configuration of Datadog SDK verbosity.
+
 ## 1.1.0
 
 * Remove precompiled frameworks in favor of Cocoapod resolution with EDM4U

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationOptionsExtensions.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationOptionsExtensions.cs
@@ -21,6 +21,7 @@ namespace Datadog.Unity.Editor
                 options = ScriptableObject.CreateInstance<DatadogConfigurationOptions>();
 
                 // Base Config
+                options.SdkVerbosity = CoreLoggerLevel.Warn;
                 options.ClientToken = string.Empty;
                 options.Enabled = true;
                 options.Env = string.Empty;

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -116,6 +116,7 @@ namespace Datadog.Unity.Editor
             _showAdvancedOptions = EditorGUILayout.BeginFoldoutHeaderGroup(_showAdvancedOptions, "Advanced RUM Options");
             if (_showAdvancedOptions)
             {
+                _options.SdkVerbosity = (CoreLoggerLevel)EditorGUILayout.EnumPopup("SDK Verbosity", _options.SdkVerbosity);
                 _options.TelemetrySampleRate =
                     EditorGUILayout.FloatField("Telemetry Sample Rate", _options.TelemetrySampleRate);
                 _options.TelemetrySampleRate = Math.Clamp(_options.TelemetrySampleRate, 0.0f, 100.0f);

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -89,6 +89,7 @@ namespace Datadog.Unity.Editor.iOS
             }
 
             var sdkVersion = DatadogSdk.SdkVersion;
+            var sdkLogLevel = GetSwiftCoreLoggerLevel(options.SdkVerbosity);
 
             var sb = new StringBuilder($@"// Datadog Options File -
 // THIS FILE IS AUTO GENERATED --- changes to this file will be lost!
@@ -100,7 +101,7 @@ import DatadogCrashReporting
 
 @_cdecl(""initializeDatadog"")
 func initializeDatadog() {{
-    Datadog.verbosityLevel = .debug
+    Datadog.verbosityLevel = {sdkLogLevel}
     var config = Datadog.Configuration(
         clientToken: ""{options.ClientToken}"",
         env: ""{env}"",
@@ -276,6 +277,18 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
             };
 
             lines.InsertRange(insertLine, newLines);
+        }
+
+        private static string GetSwiftCoreLoggerLevel(CoreLoggerLevel level)
+        {
+            return level switch
+            {
+                CoreLoggerLevel.Debug => ".debug",
+                CoreLoggerLevel.Warn => ".warn",
+                CoreLoggerLevel.Error => ".error",
+                CoreLoggerLevel.Critical => ".critical",
+                _ => ".warn",
+            };
         }
 
         private static string GetSwiftBatchSize(BatchSize batchSize)

--- a/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
+++ b/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
@@ -6,6 +6,12 @@ import Foundation
 import DatadogCore
 import DatadogInternal
 
+@_cdecl("Datadog_SetSdkVerbosity")
+func Datadog_SetSdkVerbosity(sdkVerbosityInt: Int) {
+    let verbosity = CoreLoggerLevel(rawValue: sdkVerbosityInt)
+    Datadog.verbosityLevel = verbosity
+}
+
 @_cdecl("Datadog_SetTrackingConsent")
 func Datadog_SetTrackingConsent(trackingConsentInt: Int) {
     let trackingConsent: TrackingConsent?

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
@@ -25,6 +25,18 @@ namespace Datadog.Unity.Android
             return siteClass.GetStatic<AndroidJavaObject>(siteName);
         }
 
+        internal static AndroidLogLevel GetAndroidLogLevel(CoreLoggerLevel logLevel)
+        {
+            return logLevel switch
+            {
+                CoreLoggerLevel.Debug => AndroidLogLevel.Debug,
+                CoreLoggerLevel.Warn => AndroidLogLevel.Warn,
+                CoreLoggerLevel.Error => AndroidLogLevel.Error,
+                CoreLoggerLevel.Critical => AndroidLogLevel.Assert,
+                _ => AndroidLogLevel.Debug,
+            };
+        }
+
         internal static AndroidJavaObject GetUploadFrequency(UploadFrequency frequency)
         {
             string frequencyName = frequency switch

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -44,7 +44,7 @@ namespace Datadog.Unity.Android
         public void Init(DatadogConfigurationOptions options)
         {
             var applicationId = options.RumApplicationId == string.Empty ? null : options.RumApplicationId;
-            SetSdkVerbosity(options.SdkVerbosity);
+            SetVerbosity(options.SdkVerbosity);
 
             var environment = options.Env;
             if (environment is null or "")
@@ -143,7 +143,7 @@ namespace Datadog.Unity.Android
             }
         }
 
-        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        public void SetVerbosity(CoreLoggerLevel logLevel)
         {
             _datadogClass.CallStatic("setVerbosity", DatadogConfigurationHelpers.GetAndroidLogLevel(logLevel));
         }

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -44,7 +44,7 @@ namespace Datadog.Unity.Android
         public void Init(DatadogConfigurationOptions options)
         {
             var applicationId = options.RumApplicationId == string.Empty ? null : options.RumApplicationId;
-            _datadogClass.CallStatic("setVerbosity", (int)AndroidLogLevel.Verbose);
+            SetSdkVerbosity(options.SdkVerbosity);
 
             var environment = options.Env;
             if (environment is null or "")
@@ -141,6 +141,11 @@ namespace Datadog.Unity.Android
                 using var crashReportClass = new AndroidJavaClass("com.datadog.android.ndk.NdkCrashReports");
                 crashReportClass.CallStatic("enable");
             }
+        }
+
+        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        {
+            _datadogClass.CallStatic("setVerbosity", DatadogConfigurationHelpers.GetAndroidLogLevel(logLevel));
         }
 
         public void SetTrackingConsent(TrackingConsent trackingConsent)

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -173,6 +173,7 @@ namespace Datadog.Unity
 
         // Base Config
         public bool Enabled;
+        public CoreLoggerLevel SdkVerbosity = CoreLoggerLevel.Warn;
         public bool OutputSymbols;
         public string ClientToken;
         public DatadogSite Site;

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -11,7 +11,7 @@ namespace Datadog.Unity
 {
     internal class DatadogNoOpPlatform : IDatadogPlatform
     {
-        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        public void SetVerbosity(CoreLoggerLevel logLevel)
         {
         }
 

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -11,6 +11,10 @@ namespace Datadog.Unity
 {
     internal class DatadogNoOpPlatform : IDatadogPlatform
     {
+        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        {
+        }
+
         public DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker)
         {
             return new DdNoOpLogger();

--- a/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
@@ -16,7 +16,7 @@ namespace Datadog.Unity
     {
         void Init(DatadogConfigurationOptions options);
 
-        void SetSdkVerbosity(CoreLoggerLevel logLevel);
+        void SetVerbosity(CoreLoggerLevel logLevel);
 
         void SetTrackingConsent(TrackingConsent trackingConsent);
 
@@ -41,8 +41,8 @@ namespace Datadog.Unity
     public enum CoreLoggerLevel
     {
         Debug = 0,
-        Warn = 2,
-        Error = 3,
-        Critical = 4,
+        Warn = 1,
+        Error = 2,
+        Critical = 3,
     }
 }

--- a/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
@@ -16,6 +16,8 @@ namespace Datadog.Unity
     {
         void Init(DatadogConfigurationOptions options);
 
+        void SetSdkVerbosity(CoreLoggerLevel logLevel);
+
         void SetTrackingConsent(TrackingConsent trackingConsent);
 
         DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker);
@@ -31,5 +33,16 @@ namespace Datadog.Unity
         void SendErrorTelemetry(string message, string stack, string kind);
 
         void ClearAllData();
+    }
+
+    /// <summary>
+    /// The logging level for the DatadogSdk Core.
+    /// </summary>
+    public enum CoreLoggerLevel
+    {
+        Debug = 0,
+        Warn = 2,
+        Error = 3,
+        Critical = 4,
     }
 }

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -81,7 +81,7 @@ namespace Datadog.Unity
         {
             InternalHelpers.Wrap("SetSdkVerbosity", () =>
             {
-                _platform.SetSdkVerbosity(logLevel);
+                _platform.SetVerbosity(logLevel);
             });
         }
 

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -74,6 +74,18 @@ namespace Datadog.Unity
         }
 
         /// <summary>
+        /// Sets the verbosity level of the SDK. This will affect the amount of logs that the SDK will output.
+        /// </summary>
+        /// <param name="logLevel">The level of SDK verbosity.</param>
+        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        {
+            InternalHelpers.Wrap("SetSdkVerbosity", () =>
+            {
+                _platform.SetSdkVerbosity(logLevel);
+            });
+        }
+
+        /// <summary>
         /// Sets the tracking consent regarding the data collection for this instance of the Datadog SDK.
         ///
         /// Datadog always defaults to TrackingConsent.Pending, and it is expected that you call this method after

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -39,6 +39,11 @@ namespace Datadog.Unity.iOS
             Datadog_UpdateTelemetryConfiguration(Application.unityVersion);
         }
 
+        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        {
+            Datadog_SetSdkVerbosity((int)logLevel);
+        }
+
         public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
         {
             var jsonAttributes = extraInfo != null ? JsonConvert.SerializeObject(extraInfo) : null;
@@ -87,6 +92,9 @@ namespace Datadog.Unity.iOS
         {
             Datadog_ClearAllData();
         }
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_SetSdkVerbosity(int logLevel);
 
         [DllImport("__Internal")]
         private static extern void Datadog_SetTrackingConsent(int trackingConsent);

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -39,7 +39,7 @@ namespace Datadog.Unity.iOS
             Datadog_UpdateTelemetryConfiguration(Application.unityVersion);
         }
 
-        public void SetSdkVerbosity(CoreLoggerLevel logLevel)
+        public void SetVerbosity(CoreLoggerLevel logLevel)
         {
             Datadog_SetSdkVerbosity((int)logLevel);
         }

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -45,6 +45,7 @@ namespace Datadog.Unity.Editor.Tests
 
             // Base Config
             Assert.IsTrue(options.Enabled);
+            Assert.AreEqual(options.SdkVerbosity, CoreLoggerLevel.Warn);
             Assert.IsFalse(options.OutputSymbols);
             Assert.IsEmpty(options.ClientToken);
             Assert.IsEmpty(options.Env);

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -74,6 +74,25 @@ namespace Datadog.Unity.Editor.iOS
             Assert.IsTrue(sourceLines.First().Trim().StartsWith("\"_dd.source\": \"unity\""));
         }
 
+        [TestCase(CoreLoggerLevel.Debug, ".debug")]
+        [TestCase(CoreLoggerLevel.Warn, ".warn")]
+        [TestCase(CoreLoggerLevel.Error, ".error")]
+        [TestCase(CoreLoggerLevel.Critical, ".critical")]
+        public void GenerationOptionsFileWritesSdkVerbosity(CoreLoggerLevel loggerLevel, string expectedCoreLoggingLevel)
+        {
+            var options = new DatadogConfigurationOptions()
+            {
+                Enabled = true,
+                SdkVerbosity = loggerLevel,
+            };
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var verbosityLevelLines = lines.Where(l => l.Contains("Datadog.verbosityLevel")).ToArray();
+            Assert.AreEqual(1, verbosityLevelLines.Length);
+            Assert.AreEqual($"Datadog.verbosityLevel = {expectedCoreLoggingLevel}", verbosityLevelLines.First().Trim());
+        }
+
         [TestCase(BatchSize.Small, ".small")]
         [TestCase(BatchSize.Medium, ".medium")]
         [TestCase(BatchSize.Large, ".large")]

--- a/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
@@ -15,6 +15,8 @@ public class TestBehavior : MonoBehaviour
     {
         DatadogSdk.Instance.SetTrackingConsent(TrackingConsent.Granted);
 
+        DatadogSdk.Instance.SetSdkVerbosity(CoreLoggerLevel.Debug);
+
         DatadogSdk.Instance.Rum.StartView("Test View", attributes: new()
         {
             { "view_attribute", "active" },


### PR DESCRIPTION
### What and why?

SDK Verbosity was set to `Debug` by default. Change to `Warn` by default and add both a UI control and methods to change the default.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
