### PR TITLE
fix: Isolate Datadog to the `UnityFramework`

### DIFF
--- a/packages/Datadog.Unity/Editor/DatadogDependencies.xml
+++ b/packages/Datadog.Unity/Editor/DatadogDependencies.xml
@@ -12,9 +12,9 @@
     </androidPackage>
   </androidPackages>
   <iosPods>
-    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
-    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
-    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
-    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" addToAllTargets="true" />
+    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" />
+    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" />
+    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" />
+    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="2.9.0" />
   </iosPods>
 </dependencies>

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -43,6 +43,7 @@ namespace Datadog.Unity.Editor.iOS
                 pbxProject.ReadFromFile(projectPath);
 
                 var mainTarget = pbxProject.GetUnityMainTargetGuid();
+                var frameworkTarget = pbxProject.GetUnityFrameworkTargetGuid();
 
                 var initializationFile = Path.Combine("MainApp", "DatadogInitialization.swift");
                 var initializationPath = Path.Combine(pathToProject, initializationFile);
@@ -54,9 +55,9 @@ namespace Datadog.Unity.Editor.iOS
                 {
                     pbxProject.AddBuildProperty(mainTarget, "SWIFT_VERSION", "5");
                 }
-                pbxProject.AddFileToBuild(mainTarget, initializationFileGuid);
+                pbxProject.AddFileToBuild(frameworkTarget, initializationFileGuid);
 
-                AddInitializationToMain(Path.Combine(pathToProject, "MainApp", "main.mm"), datadogOptions);
+                AddInitializationToAppController(Path.Combine(pathToProject, "Classes", "UnityAppController.mm"), datadogOptions);
 
                 if (datadogOptions.OutputSymbols)
                 {
@@ -64,7 +65,6 @@ namespace Datadog.Unity.Editor.iOS
                 }
 
                 // disable embed swift libs - prevents "UnityFramework.framework contains disallowed file 'Frameworks'."
-                var frameworkTarget = pbxProject.GetUnityFrameworkTargetGuid();
                 pbxProject.SetBuildProperty(frameworkTarget, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
 
                 var projectInString = pbxProject.WriteToString();
@@ -208,11 +208,11 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
             pbxProject.AddShellScriptBuildPhase(mainTarget, CopyPhaseName, "/bin/bash", copyDsymScript.ToString());
         }
 
-        internal static void AddInitializationToMain(string pathToMain, DatadogConfigurationOptions options)
+        internal static void AddInitializationToAppController(string pathToMain, DatadogConfigurationOptions options)
         {
             if (!File.Exists(pathToMain))
             {
-                throw new FileNotFoundException("Could not find Unity main.", pathToMain);
+                throw new FileNotFoundException("Could not find UnityAppController.", pathToMain);
             }
 
             var mainText = new List<string>(File.ReadAllLines(pathToMain));
@@ -261,12 +261,8 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
                     DatadogBlockEnd,
             });
 
-            int autoReleaseLine = lines.FindIndex(0, x => x.Trim().Contains("@autoreleasepool"));
-            int insertLine = autoReleaseLine + 1;
-            if (lines[insertLine].Trim() == "{")
-            {
-                insertLine += 1;
-            }
+            int applicationLaunchLog = lines.FindIndex(0, x => x.Trim().Contains("::printf(\"-> applicationDidFinishLaunching()\\n\");"));
+            int insertLine = applicationLaunchLog + 1;
 
             var newLines = new List<string>()
             {

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -325,7 +325,7 @@ namespace Datadog.Unity.Editor.iOS
                 Enabled = true
             };
 
-            PostBuildProcess.AddInitializationToMain(_mainFilePath, options);
+            PostBuildProcess.AddInitializationToAppController(_mainFilePath, options);
 
             string fileContents = File.ReadAllText(_mainFilePath);
 
@@ -345,7 +345,7 @@ namespace Datadog.Unity.Editor.iOS
         public void RemoveDatadogBlocksRemovesDatadogBlocks()
         {
             var options = new DatadogConfigurationOptions();
-            PostBuildProcess.AddInitializationToMain(_mainFilePath, options);
+            PostBuildProcess.AddInitializationToAppController(_mainFilePath, options);
 
             var fileContents = File.ReadAllLines(_mainFilePath);
             var cleanContents = PostBuildProcess.RemoveDatadogBlocks(new List<string>(fileContents));


### PR DESCRIPTION
### What and why?

The Datadog SDK added itself to both the `Unity-iPhone` and `UnityFramework` targets in Cocoapods, because the Bridge needed to be in UnityFramework, and initialization was in `Unity-iPhone`. With static linking (EDM4U's default) this caused issues with two copies of the SDK being loaded at the same time.

Using Dynamic Linking caused some weird issues where PLCrashReporter couldn't be found when certain linker flags were set, and breaks some pods that require static linking.

So, we've isolated the DatadogSDK to UnityFramework by initializing it in `applicaiton:didFinishLaunchingWithOptions` instead of in `main` which allows us to use static linking (the EDM4U default) and not have duplicate SDK issues.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
