### PR TITLE
fix: Fix Datadog site support for iOS

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -105,6 +105,7 @@ func initializeDatadog() {{
     var config = Datadog.Configuration(
         clientToken: ""{options.ClientToken}"",
         env: ""{env}"",
+        site: {GetSwiftSite(options.Site)},
         batchSize: {GetSwiftBatchSize(options.BatchSize)},
         uploadFrequency: {GetSwiftUploadFrequency(options.UploadFrequency)},
         batchProcessingLevel: {GetSwiftBatchProcessingLevel(options.BatchProcessingLevel)}
@@ -326,6 +327,20 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
                 VitalsUpdateFrequency.Rare => ".rare",
                 VitalsUpdateFrequency.Frequent => ".frequent",
                 _ => "nil",
+            };
+        }
+
+        private static string GetSwiftSite(DatadogSite site)
+        {
+            return site switch
+            {
+                DatadogSite.Us1 => ".us1",
+                DatadogSite.Us3 => ".us3",
+                DatadogSite.Us5 => ".us5",
+                DatadogSite.Eu1 => ".eu1",
+                DatadogSite.Us1Fed => ".us1_fed",
+                DatadogSite.Ap1 => ".ap1",
+                _ => ".us1"
             };
         }
     }

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -149,6 +149,27 @@ namespace Datadog.Unity.Editor.iOS
             Assert.IsTrue(processingLevelLines.First().Trim().StartsWith($"batchProcessingLevel: {expectedProcessingLevel}"));
         }
 
+        [TestCase(DatadogSite.Us1, ".us1")]
+        [TestCase(DatadogSite.Us3, ".us3")]
+        [TestCase(DatadogSite.Us5, ".us5")]
+        [TestCase(DatadogSite.Ap1, ".ap1")]
+        [TestCase(DatadogSite.Eu1, ".eu1")]
+        [TestCase(DatadogSite.Us1Fed, ".us1_fed")]
+        public void GenerationOptionsFileWritesSite(DatadogSite site, string expectedSite)
+        {
+            var options = new DatadogConfigurationOptions()
+            {
+                Enabled = true,
+                Site = site,
+            };
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var siteLines = lines.Where(l => l.Contains("site:")).ToArray();
+            Assert.AreEqual(1, siteLines.Length);
+            Assert.IsTrue(siteLines.First().Trim().StartsWith($"site: {expectedSite},"));
+        }
+
         [Test]
         public void GenerateOptionsFileDoesNotWriteCrashReportingIfDisabled()
         {


### PR DESCRIPTION
### What and why?

The Datadog site wasn't being added to the configuration object during the XCode build, so everything defaulted to us1

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
