### PR TITLE
fix: setVerbosity issue on Android

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Fix `setVerbosity` on Android.
+
 ## 1.1.2
 
 * Fix Datadog Site support in iOS.

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidConfiguration.cs
@@ -25,9 +25,9 @@ namespace Datadog.Unity.Android
             return siteClass.GetStatic<AndroidJavaObject>(siteName);
         }
 
-        internal static AndroidLogLevel GetAndroidLogLevel(CoreLoggerLevel logLevel)
+        internal static int GetAndroidLogLevel(CoreLoggerLevel logLevel)
         {
-            return logLevel switch
+            var androidLogLevel = logLevel switch
             {
                 CoreLoggerLevel.Debug => AndroidLogLevel.Debug,
                 CoreLoggerLevel.Warn => AndroidLogLevel.Warn,
@@ -35,6 +35,7 @@ namespace Datadog.Unity.Android
                 CoreLoggerLevel.Critical => AndroidLogLevel.Assert,
                 _ => AndroidLogLevel.Debug,
             };
+            return (int)androidLogLevel;
         }
 
         internal static AndroidJavaObject GetUploadFrequency(UploadFrequency frequency)

--- a/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
@@ -22,6 +22,8 @@ public class TestBehavior : MonoBehaviour
             { "view_attribute", "active" },
         });
 
+        DatadogSdk.Instance.SetUserInfo("1234", "John Fakename");
+
         var logger = DatadogSdk.Instance.CreateLogger(new DatadogLoggingOptions()
         {
             NetworkInfoEnabled = true,

--- a/samples/Datadog Sample/Packages/packages-lock.json
+++ b/samples/Datadog Sample/Packages/packages-lock.json
@@ -24,11 +24,11 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.2d.animation": {
-      "version": "9.0.3",
+      "version": "9.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "8.0.1",
+        "com.unity.2d.common": "8.0.2",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.collections": "1.1.0",
         "com.unity.modules.animation": "1.0.0",
@@ -37,7 +37,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.0.1",
+      "version": "1.1.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -49,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.common": {
-      "version": "8.0.1",
+      "version": "8.0.2",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -69,12 +69,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.psdimporter": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.animation": "9.0.1",
-        "com.unity.2d.common": "8.0.1",
+        "com.unity.2d.animation": "9.1.0",
+        "com.unity.2d.common": "8.0.2",
         "com.unity.2d.sprite": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -106,7 +106,7 @@
       }
     },
     "com.unity.2d.tilemap.extras": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -127,11 +127,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.8",
+      "version": "1.8.13",
       "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1"
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -164,14 +165,14 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.2d.animation": "9.0.3",
+        "com.unity.2d.animation": "9.1.0",
         "com.unity.2d.pixel-perfect": "5.0.3",
-        "com.unity.2d.psdimporter": "8.0.2",
+        "com.unity.2d.psdimporter": "8.0.4",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.2d.spriteshape": "9.0.2",
         "com.unity.2d.tilemap": "1.0.0",
-        "com.unity.2d.tilemap.extras": "3.1.1",
-        "com.unity.2d.aseprite": "1.0.1"
+        "com.unity.2d.tilemap.extras": "3.1.2",
+        "com.unity.2d.aseprite": "1.1.3"
       }
     },
     "com.unity.ide.rider": {


### PR DESCRIPTION
### What and why?

setVerbosity was being sent a C# enum, which couldn't be converted to JNI, causing unity initialization to fail.

Convert AndroidLogLevel to an int to properly set it in Android.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
