### PR TITLE
feat: Support 128-bit trace ids

### DIFF
--- a/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
@@ -33,9 +33,8 @@ namespace Datadog.Unity.Rum
 
         public TraceContext GenerateTraceContext()
         {
-            // For now, generate 63-bit trace ids and span ids.
             return new TraceContext(
-                TracingUuid.Create63Bit(),
+                TracingUuid.Create128Bit(),
                 TracingUuid.Create63Bit(),
                 null,
                 _traceSampler.Sample());
@@ -46,7 +45,7 @@ namespace Datadog.Unity.Rum
             attributes[DatadogAttributeKeys.RulePsr] = _options.TraceSampleRate / 100.0f;
             if (traceContext.sampled)
             {
-                attributes[DatadogAttributeKeys.TraceId] = traceContext.traceId.ToString(TraceIdRepresentation.Dec);
+                attributes[DatadogAttributeKeys.TraceId] = traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
                 attributes[DatadogAttributeKeys.SpanId] = traceContext.spanId.ToString(TraceIdRepresentation.Dec);
             }
         }
@@ -73,7 +72,9 @@ namespace Datadog.Unity.Rum
                 if (traceContext.sampled)
                 {
                     headers[DatadogHttpTracingHeaders.TraceId] =
-                        traceContext.traceId.ToString(TraceIdRepresentation.Dec);
+                        traceContext.traceId.ToString(TraceIdRepresentation.LowDec);
+                    headers[DatadogHttpTracingHeaders.Tags] =
+                        $"{DatadogHttpTracingHeaders.TraceIdTag}={traceContext.traceId.ToString(TraceIdRepresentation.HighHex16Chars)}";
                     headers[DatadogHttpTracingHeaders.ParentId] =
                         traceContext.spanId.ToString(TraceIdRepresentation.Dec);
                 }
@@ -143,6 +144,9 @@ namespace Datadog.Unity.Rum
             public const string ParentId = "x-datadog-parent-id";
             public const string SamplingPriority = "x-datadog-sampling-priority";
             public const string Origin = "x-datadog-origin";
+            public const string Tags = "x-datadog-tags";
+
+            public const string TraceIdTag = "_dd.p.tid";
         }
 
         private static class OTelHttpTracingHeaders

--- a/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
@@ -9,9 +9,22 @@ namespace Datadog.Unity.Rum
 {
     internal enum TraceIdRepresentation
     {
+        // Decimal string representation of the entire TraceId
         Dec,
+
+        // Decimal string representation of the low 64-bits of the TraceId
+        LowDec,
+
+        // Hexadecimal string representation of the entire TraceId, with no padding
         Hex,
+
+        // Hexadecimal string representation of the low 64-bits TraceId, padded to 16 characters
         Hex16Chars,
+
+        // Hexadecimal string representation of the high 64-bits TraceId, padded to 16 characters
+        HighHex16Chars,
+
+        // Hexadecimal string representation of the entire TraceId, padded to 32 characters
         Hex32Chars,
     }
 
@@ -41,8 +54,14 @@ namespace Datadog.Unity.Rum
             {
                 default:
                 case TraceIdRepresentation.Dec:
-                    var bigInteger = (BigInteger)_high << 64 | _low;
+                    var bigInteger = ((BigInteger)_high << 64) | _low;
                     return bigInteger.ToString();
+
+                case TraceIdRepresentation.LowDec:
+                    return $"{_low}";
+
+                case TraceIdRepresentation.HighHex16Chars:
+                    return $"{_high:x16}";
 
                 case TraceIdRepresentation.Hex:
                 case TraceIdRepresentation.Hex16Chars:

--- a/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
@@ -104,12 +105,12 @@ namespace Datadog.Unity.Rum.Tests
             if (_sampled)
             {
                 Assert.IsNotNull(traceString);
-                BigInteger.TryParse(traceString, out var traceId);
+                BigInteger.TryParse(traceString, NumberStyles.HexNumber, null, out var traceId);
                 Assert.IsNotNull(traceId);
-                Assert.LessOrEqual(traceId.GetByteCount(), 63);
+                Assert.LessOrEqual(traceId.GetByteCount(), 128);
 
                 Assert.IsNotNull(spanString);
-                BigInteger.TryParse(spanString, out var spanId);
+                BigInteger.TryParse(spanString, NumberStyles.HexNumber, null, out var spanId);
                 Assert.IsNotNull(spanId);
                 Assert.LessOrEqual(spanId.GetByteCount(), 63);
             }
@@ -120,6 +121,91 @@ namespace Datadog.Unity.Rum.Tests
             }
 
             Assert.AreEqual(_sampled ? 1.0f : 0.0f, attributes["_dd.rule_psr"]);
+        }
+
+        [TestCase(TracingHeaderType.Datadog)]
+        [TestCase(TracingHeaderType.B3)]
+        [TestCase(TracingHeaderType.B3Multi)]
+        [TestCase(TracingHeaderType.TraceContext)]
+        public void DatadogAttributesAndTracingHeadersHaveSameValue(TracingHeaderType headerType)
+        {
+            // Given
+            var headers = new Dictionary<string, string>();
+            var attributes = new Dictionary<string, object>();
+            var context = _trackingHelper.GenerateTraceContext();
+
+            // When
+            _trackingHelper.GenerateDatadogAttributes(context, attributes);
+            _trackingHelper.GenerateTracingHeaders(context, headerType, headers);
+
+            // Then
+            var traceString = attributes.GetValueOrDefault("_dd.trace_id")?.ToString();
+            var spanString = attributes.GetValueOrDefault("_dd.span_id")?.ToString();
+            if (_sampled)
+            {
+                Assert.IsNotNull(traceString);
+                BigInteger.TryParse(traceString, NumberStyles.HexNumber, null, out var attributeTraceId);
+
+                Assert.IsNotNull(spanString);
+                BigInteger.TryParse(spanString, out var attributeSpanId);
+
+                GetIdsFromHeaders(headers, headerType, out var headerTraceId, out var headerSpanId);
+                Assert.AreEqual(headerTraceId, attributeTraceId);
+                Assert.AreEqual(headerSpanId, attributeSpanId);
+            }
+            else
+            {
+                Assert.IsNull(traceString);
+                Assert.IsNull(spanString);
+            }
+
+            Assert.AreEqual(_sampled ? 1.0f : 0.0f, attributes["_dd.rule_psr"]);
+        }
+
+        private void GetIdsFromHeaders(Dictionary<string, string> headers, TracingHeaderType headerType, out BigInteger traceId, out BigInteger spanId)
+        {
+            switch (headerType)
+            {
+                case TracingHeaderType.Datadog:
+                {
+                    BigInteger.TryParse(headers["x-datadog-trace-id"], out traceId);
+                    BigInteger.TryParse(headers["x-datadog-parent-id"], out spanId);
+                    var tagsHeader = headers.GetValueOrDefault("x-datadog-tags");
+                    var tagParts = tagsHeader?.Split("=");
+                    BigInteger.TryParse(tagParts[1], NumberStyles.HexNumber, null, out var highTraceId);
+                    highTraceId <<= 64;
+                    traceId += highTraceId;
+                    break;
+                }
+
+                case TracingHeaderType.B3:
+                {
+                    var header = headers["b3"];
+                    var headerParts = header.Split("-");
+                    BigInteger.TryParse(headerParts[0], NumberStyles.HexNumber, null, out traceId);
+                    BigInteger.TryParse(headerParts[1], NumberStyles.HexNumber, null, out spanId);
+                    break;
+                }
+
+                case TracingHeaderType.B3Multi:
+                {
+                    BigInteger.TryParse(headers["X-B3-TraceId"], NumberStyles.HexNumber, null, out traceId);
+                    BigInteger.TryParse(headers["X-B3-SpanId"], NumberStyles.HexNumber, null, out spanId);
+                    break;
+                }
+
+                case TracingHeaderType.TraceContext:
+                {
+                    var traceparent = headers["traceparent"];
+                    var headerParts = traceparent.Split("-");
+                    BigInteger.TryParse(headerParts[1], NumberStyles.HexNumber, null, out traceId);
+                    BigInteger.TryParse(headerParts[2], NumberStyles.HexNumber, null, out spanId);
+                    break;
+                }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(headerType), headerType, null);
+            }
         }
 
         private static void VerifyHeaders(Dictionary<string, string> headers, TracingHeaderType tracingHeaderType, bool sampled)
@@ -135,8 +221,19 @@ namespace Datadog.Unity.Rum.Tests
                     Assert.AreEqual("rum", headers["x-datadog-origin"]);
                     var traceString = headers.GetValueOrDefault("x-datadog-trace-id");
                     var spanString = headers.GetValueOrDefault("x-datadog-parent-id");
+                    var tagsHeader = headers.GetValueOrDefault("x-datadog-tags");
+                    var tagParts = tagsHeader?.Split("=");
                     if (sampled)
                     {
+                        Assert.IsNotNull(tagParts);
+                        if (tagParts != null)
+                        {
+                            Assert.AreEqual(tagParts[0], "_dd.p.tid");
+                            BigInteger.TryParse(tagParts[1], NumberStyles.HexNumber, null, out var highTraceInt);
+                            Assert.NotNull(highTraceInt);
+                            Assert.LessOrEqual(highTraceInt.GetByteCount(), 64);
+                        }
+
                         BigInteger.TryParse(traceString, out traceInt);
                         BigInteger.TryParse(spanString, out spanInt);
                     }
@@ -155,8 +252,8 @@ namespace Datadog.Unity.Rum.Tests
                     if (sampled)
                     {
                         var headerParts = header.Split("-");
-                        BigInteger.TryParse(headerParts[0], System.Globalization.NumberStyles.HexNumber, null, out traceInt);
-                        BigInteger.TryParse(headerParts[1], System.Globalization.NumberStyles.HexNumber, null, out spanInt);
+                        BigInteger.TryParse(headerParts[0], NumberStyles.HexNumber, null, out traceInt);
+                        BigInteger.TryParse(headerParts[1], NumberStyles.HexNumber, null, out spanInt);
                         Assert.AreEqual(32, headerParts[0].Length);
                         Assert.AreEqual(16, headerParts[1].Length);
                         Assert.AreEqual(headerParts[2], sampleString);
@@ -176,10 +273,10 @@ namespace Datadog.Unity.Rum.Tests
                     var spanString = headers.GetValueOrDefault("X-B3-SpanId");
                     if (sampled)
                     {
-                        BigInteger.TryParse(traceString, System.Globalization.NumberStyles.HexNumber, null,
+                        BigInteger.TryParse(traceString, NumberStyles.HexNumber, null,
                             out traceInt);
                         Assert.AreEqual(32, traceString.Length);
-                        BigInteger.TryParse(spanString, System.Globalization.NumberStyles.HexNumber, null,
+                        BigInteger.TryParse(spanString, NumberStyles.HexNumber, null,
                             out traceInt);
                         Assert.AreEqual(16, spanString.Length);
                     }
@@ -197,8 +294,8 @@ namespace Datadog.Unity.Rum.Tests
                     var traceparent = headers["traceparent"];
                     var headerParts = traceparent.Split("-");
                     Assert.AreEqual("00", headerParts[0]);
-                    BigInteger.TryParse(headerParts[1], System.Globalization.NumberStyles.HexNumber, null, out traceInt);
-                    BigInteger.TryParse(headerParts[2], System.Globalization.NumberStyles.HexNumber, null, out spanInt);
+                    BigInteger.TryParse(headerParts[1], NumberStyles.HexNumber, null, out traceInt);
+                    BigInteger.TryParse(headerParts[2], NumberStyles.HexNumber, null, out spanInt);
                     Assert.AreEqual(sampled ? "01" : "00", headerParts[3]);
 
                     var tracestate = headers["tracestate"];
@@ -219,7 +316,7 @@ namespace Datadog.Unity.Rum.Tests
             }
 
             Assert.NotNull(traceInt);
-            Assert.LessOrEqual(traceInt.GetByteCount(), 63);
+            Assert.LessOrEqual(traceInt.GetByteCount(), tracingHeaderType == TracingHeaderType.Datadog ? 64 : 128);
 
             Assert.NotNull(spanInt);
             Assert.LessOrEqual(spanInt.GetByteCount(), 63);

--- a/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
@@ -151,7 +151,9 @@ namespace Datadog.Unity.Rum.Tests
 
                 GetIdsFromHeaders(headers, headerType, out var headerTraceId, out var headerSpanId);
                 Assert.AreEqual(headerTraceId, attributeTraceId);
+                Assert.AreEqual(context.traceId.ToString(TraceIdRepresentation.Hex), traceString);
                 Assert.AreEqual(headerSpanId, attributeSpanId);
+                Assert.AreEqual(context.spanId.ToString(TraceIdRepresentation.Dec), spanString);
             }
             else
             {

--- a/packages/Datadog.Unity/Tests/Rum/TracingUUIDTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/TracingUUIDTest.cs
@@ -39,6 +39,21 @@ namespace Datadog.Unity.Rum.Tests
         }
 
         [Test]
+        [TestCase(0ul, 224ul, "224")]
+        [TestCase(13ul, 115257ul, "115257")]
+        public void TracingUuidLowDecRepresentationsAreCorrect(ulong high, ulong low, string expected)
+        {
+            // Given
+            var uuid = new TracingUuid(high, low);
+
+            // When
+            var str = uuid.ToString(TraceIdRepresentation.LowDec);
+
+            // Then
+            Assert.AreEqual(expected, str);
+        }
+
+        [Test]
         [TestCase(0ul, 0x2fee4ul, "2fee4")]
         [TestCase(0xf1aul, 0x14e255ul, "f1a000000000014e255")]
         public void TracingUuidHexRepresentationsAreCorrect(ulong high, ulong low, string expected)
@@ -84,6 +99,21 @@ namespace Datadog.Unity.Rum.Tests
         }
 
         [Test]
+        [TestCase(0ul, 0x2fee4ul, "0000000000000000")]
+        [TestCase(0xf1aul, 0x14e255ul, "0000000000000f1a")]
+        public void TracingUuidHexHighHexRepresentationsAreCorrect(ulong high, ulong low, string expected)
+        {
+            // Given
+            var uuid = new TracingUuid(high, low);
+
+            // When
+            var str = uuid.ToString(TraceIdRepresentation.HighHex16Chars);
+
+            // Then
+            Assert.AreEqual(expected, str);
+        }
+
+        [Test]
         [Repeat(25)]
         public void CreateTracingUuid63BitSucceeds()
         {
@@ -115,7 +145,7 @@ namespace Datadog.Unity.Rum.Tests
 
             // Then
             var str = uuid.ToString(TraceIdRepresentation.Hex);
-            Assert.Less(str.Length, 17);
+            Assert.LessOrEqual(str.Length, 16);
         }
 
         [Test]
@@ -126,11 +156,11 @@ namespace Datadog.Unity.Rum.Tests
             // appear flaky at any point, it is likely that we need to re-check the logic.
 
             // When
-            var uuid = TracingUuid.Create64Bit();
+            var uuid = TracingUuid.Create128Bit();
 
             // Then
             var str = uuid.ToString(TraceIdRepresentation.Hex);
-            Assert.Less(str.Length, 63);
+            Assert.LessOrEqual(str.Length, 32);
             Assert.Greater(str.Length, 0);
         }
     }


### PR DESCRIPTION
### What and why?

Adding support for 128-bit trace ids in DatadogTrackedWebRequest

Adding tests to ensure that the values generated for headers are the same as values generated for Datadog attributes.

refs: RUM-2757

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
