### PR TITLE
feat: Add a warning when running in the Editor

### DIFF
--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -6,11 +6,20 @@ using System.Collections.Generic;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
+using UnityEngine;
 
 namespace Datadog.Unity
 {
     internal class DatadogNoOpPlatform : IDatadogPlatform
     {
+        public DatadogNoOpPlatform()
+        {
+            if (Application.isEditor)
+            {
+                Debug.LogWarning("Datadog SDK is running in Editor mode. No data will be sent to Datadog.");
+            }
+        }
+
         public void SetVerbosity(CoreLoggerLevel logLevel)
         {
         }
@@ -39,7 +48,6 @@ namespace Datadog.Unity
 
         public void SendErrorTelemetry(string message, string stack, string kind)
         {
-
         }
 
         public void Init(DatadogConfigurationOptions options)

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -22,7 +22,7 @@ namespace Datadog.Unity
 
         private DdUnityLogHandler _logHandler;
         private DatadogWorker _worker;
-        private IInternalLogger _internalLogger;
+        private IInternalLogger _internalLogger = new PassThroughInternalLogger();
         private ResourceTrackingHelper _resourceTrackingHelper;
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Datadog.Unity
         {
             InternalHelpers.Wrap("SetUserInfo", () =>
             {
-                _worker.AddMessage(new DdSdkProcessor.SetUserInfoMessage(id, name, email, extraInfo));
+                _worker?.AddMessage(new DdSdkProcessor.SetUserInfoMessage(id, name, email, extraInfo));
             });
         }
 
@@ -133,7 +133,7 @@ namespace Datadog.Unity
         {
             InternalHelpers.Wrap("AddUserExtraInfo", () =>
             {
-                _worker.AddMessage(new DdSdkProcessor.AddUserExtraInfoMessage(extraInfo));
+                _worker?.AddMessage(new DdSdkProcessor.AddUserExtraInfoMessage(extraInfo));
             });
         }
 

--- a/packages/Datadog.Unity/Runtime/InternalLogger.cs
+++ b/packages/Datadog.Unity/Runtime/InternalLogger.cs
@@ -21,6 +21,27 @@ namespace Datadog.Unity.Core
     }
 
     /// <summary>
+    /// The Pass through internal logger is used as a default for when the SDK is not initialized, either
+    /// because Datadog does not support the platform or because we are running in the editor.
+    /// </summary>
+    internal class PassThroughInternalLogger : IInternalLogger
+    {
+        public void Log(DdLogLevel level, string message)
+        {
+            var unityLogLevel = DdLogHelpers.DdLogLevelToLogType(level);
+            Debug.unityLogger.Log(unityLogLevel, IInternalLogger.DatadogTag, message);
+        }
+
+        public void TelemetryError(string message, Exception exception)
+        {
+        }
+
+        public void TelemetryDebug(string message)
+        {
+        }
+    }
+
+    /// <summary>
     /// InternalLogger is used to log messages to users of the DatadogSdk, bypassing sending logs
     /// to Datadog. It is also used for sending telemetry to Datadog about the performance of
     /// the SDK.


### PR DESCRIPTION
### What and why?

Datadog will not send data when run in the editor (or on platforms we don't support, but editor is most common).  Add a warning during boot that mentions this.

refs: RUM-4603

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
