### PR TITLE
feat: Add global log attributes

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Add support for global log attributes, which adds attributes to logs sent from all loggers.
+
 ## 1.1.3
 
 * Fix `setVerbosity` on Android.

--- a/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
+++ b/packages/Datadog.Unity/Plugins/iOS/Datadog_Bridge.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import DatadogCore
+import DatadogLogs
 import DatadogInternal
 
 @_cdecl("Datadog_SetSdkVerbosity")
@@ -24,6 +25,29 @@ func Datadog_SetTrackingConsent(trackingConsentInt: Int) {
 
     if let trackingConsent = trackingConsent {
         Datadog.set(trackingConsent: trackingConsent)
+    }
+}
+
+@_cdecl("Datadog_AddLogsAttributes")
+func Datadog_AddLogsAttributes(jsonAttributes: CString?) {
+    guard let jsonAttributes = jsonAttributes else {
+        return
+    }
+
+    let decodedAttributes = decodeJsonAttributes(fromCString: jsonAttributes);
+    for attr in decodedAttributes {
+        Logs.addAttribute(forKey: attr.key, value: attr.value)
+    }
+}
+
+@_cdecl("Datadog_RemoveLogsAttributes")
+func Datadog_RemoveLogsAttributes(key: CString?) {
+    guard let key = key else {
+        return
+    }
+
+    if let swiftKey = String(cString: key, encoding: .utf8) {
+        Logs.removeAttribute(forKey: swiftKey)
     }
 }
 

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -192,6 +192,22 @@ namespace Datadog.Unity.Android
             return new DdWorkerProxyLogger(worker, innerLogger);
         }
 
+        public void AddLogsAttributes(Dictionary<string, object> attributes)
+        {
+            using var logsClass = new AndroidJavaClass("com.datadog.android.log.Logs");
+            foreach (var attr in attributes)
+            {
+                AndroidJavaObject javaValue = DatadogAndroidHelpers.ObjectToJavaObject(attr.Value);
+                logsClass.CallStatic("addAttribute", attr.Key, javaValue);
+            }
+        }
+
+        public void RemoveLogsAttribute(string key)
+        {
+            using var logsClass = new AndroidJavaClass("com.datadog.android.log.Logs");
+            logsClass.CallStatic("removeAttribute", key);
+        }
+
         public IDdRum InitRum(DatadogConfigurationOptions options)
         {
             using var globalRumMonitorClass = new AndroidJavaClass("com.datadog.android.rum.GlobalRumMonitor");

--- a/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogNoopPlatform.cs
@@ -29,6 +29,14 @@ namespace Datadog.Unity
             return new DdNoOpLogger();
         }
 
+        public void AddLogsAttributes(Dictionary<string, object> attributes)
+        {
+        }
+
+        public void RemoveLogsAttribute(string key)
+        {
+        }
+
         public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
         {
         }

--- a/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogPlatform.cs
@@ -22,6 +22,10 @@ namespace Datadog.Unity
 
         DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker);
 
+        void AddLogsAttributes(Dictionary<string, object> attributes);
+
+        void RemoveLogsAttribute(string key);
+
         void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo);
 
         void AddUserExtraInfo(Dictionary<string, object> extraInfo);

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -163,6 +163,63 @@ namespace Datadog.Unity
         }
 
         /// <summary>
+        /// Add a custom attribute to all future logs sent by all loggers.
+        ///
+        /// Values can be nested up to 10 levels deep. Keys using more than 10 levels will be sanitized by SDK.
+        /// </summary>
+        /// <param name="key">The key of the attribute to add.</param>
+        /// <param name="value">The value of the attribute.</param>
+        public void AddLogsAttribute(string key, object value)
+        {
+            if (key == null)
+            {
+                _internalLogger.Log(DdLogLevel.Warn, "Attempting to add `null` key to logs attributes. Ignoring.");
+                return;
+            }
+
+            InternalHelpers.Wrap("AddLogsAttribute", () =>
+            {
+                _worker?.AddMessage(DdSdkProcessor.AddGlobalAttributesMessage.Create(new Dictionary<string, object> { { key, value } }));
+            });
+        }
+
+        /// <summary>
+        /// Add multiple custom attribute to all future logs sent by all loggers. This call will replace values
+        /// on previous attributes if they exit.
+        ///
+        /// Values can be nested up to 10 levels deep. Keys using more than 10 levels will be sanitized by SDK.
+        /// </summary>
+        /// <param name="attributes">A map of custom attributes.</param>
+        public void AddLogsAttributes(Dictionary<string, object> attributes)
+        {
+            InternalHelpers.Wrap("AddLogsAttributes", () =>
+            {
+                _worker?.AddMessage(DdSdkProcessor.AddGlobalAttributesMessage.Create(attributes));
+            });
+        }
+
+        /// <summary>
+        /// Remove a custom attribute from all future logs sent by all loggers.
+        ///
+        /// Previous logs won't lose the attribute value associated with this [key] if
+        /// they were created prior to this call.
+        /// </summary>
+        /// <param name="key">The key of the attribute to remove.</param>
+        public void RemoveLogsAttribute(string key)
+        {
+            if (key == null)
+            {
+                _internalLogger.Log(DdLogLevel.Warn, "Attempting to remove `null` key from logs attributes. Ignoring.");
+                return;
+            }
+
+            InternalHelpers.Wrap("AddLogsAttributes", () =>
+            {
+                _worker?.AddMessage(DdSdkProcessor.RemoveGlobalAttributeMessage.Create(key));
+            });
+        }
+
+        /// <summary>
         /// Clear all data currently stored by the Datadog SDK.
         /// </summary>
         public void ClearAllData()

--- a/packages/Datadog.Unity/Runtime/InternalHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/InternalHelpers.cs
@@ -19,7 +19,7 @@ namespace Datadog.Unity
         Assert = 7,
     }
 
-    public static class InternalHelpers
+    internal static class InternalHelpers
     {
         public static void Wrap(string functionName, Action action)
         {
@@ -48,6 +48,17 @@ namespace Datadog.Unity
                 DdLogLevel.Critical => AndroidLogLevel.Assert,
                 _ => AndroidLogLevel.Debug,
             };
+        }
+    }
+
+    internal static class DictionaryHelpers
+    {
+        public static void Copy<K, V>(this Dictionary<K, V> self, Dictionary<K, V> other)
+        {
+            foreach (var kvp in other)
+            {
+                self[kvp.Key] = kvp.Value;
+            }
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -73,6 +73,29 @@ namespace Datadog.Unity.iOS
             return new DdWorkerProxyLogger(worker, innerLogger);
         }
 
+        public void AddLogsAttributes(Dictionary<string, object> attributes)
+        {
+            if (attributes == null)
+            {
+                SendErrorTelemetry("Unexpected null passed to AddLogsAttributes", null, "DatadogUnityError");
+                return;
+            }
+
+            var jsonAttributes = JsonConvert.SerializeObject(attributes);
+            Datadog_AddLogsAttributes(jsonAttributes);
+        }
+
+        public void RemoveLogsAttribute(string key)
+        {
+            if (key == null)
+            {
+                // Not an error, but don't bother calling to platform
+                return;
+            }
+
+            Datadog_RemoveLogsAttributes(key);
+        }
+
         public IDdRum InitRum(DatadogConfigurationOptions options)
         {
             return new DatadogiOSRum();
@@ -101,6 +124,12 @@ namespace Datadog.Unity.iOS
 
         [DllImport("__Internal")]
         private static extern void Datadog_SetUserInfo(string id, string name, string email, string extraInfo);
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_AddLogsAttributes(string attributes);
+
+        [DllImport("__Internal")]
+        private static extern void Datadog_RemoveLogsAttributes(string key);
 
         [DllImport("__Internal")]
         private static extern void Datadog_AddUserExtraInfo(string extraInfo);

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -51,6 +51,8 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("logging.service", debugLog.ServiceName);
             Assert.AreEqual("string value", (string)debugLog.RawJson["logger-attribute1"]);
             Assert.AreEqual(1000, (long)debugLog.RawJson["logger-attribute2"]);
+            Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-1"));
+            Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
             Assert.Contains("tag1:tag-value", debugLog.Tags);
             Assert.Contains("tag1:second-value", debugLog.Tags);
             Assert.Contains("my-tag", debugLog.Tags);
@@ -65,6 +67,8 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.Contains("tag1:second-value", debugLog.Tags);
             CollectionAssert.DoesNotContain(infoLog.Tags, "my-tag");
             Assert.AreEqual("string value", (string)infoLog.RawJson["logger-attribute1"]);
+            Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
+            Assert.AreEqual(1255, (long)infoLog.RawJson["global-attribute-2"]);
             Assert.AreEqual(1000, (long)infoLog.RawJson["logger-attribute2"]);
             var nestedAttribute = infoLog.RawJson["nestedAttribute"] as JObject;
             Assert.AreEqual("test", (string)nestedAttribute["internal"]);
@@ -78,6 +82,8 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.Contains("tag1:second-value", debugLog.Tags);
             CollectionAssert.DoesNotContain(warnLog.Tags, "my-tag");
             Assert.AreEqual("string value", (string)warnLog.RawJson["logger-attribute1"]);
+            Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
+            Assert.AreEqual(1255, (long)infoLog.RawJson["global-attribute-2"]);
             Assert.AreEqual(1000, (long)warnLog.RawJson["logger-attribute2"]);
             Assert.AreEqual(10.34, (double)warnLog.RawJson["doubleAttribute"]);
 
@@ -90,6 +96,8 @@ namespace Datadog.Unity.Tests.Integration.Logging
             CollectionAssert.DoesNotContain(errorLog.Tags, "my-tag");
             Assert.IsFalse(errorLog.RawJson.ContainsKey("logger-attribute1"));
             Assert.AreEqual(1000, (long)errorLog.RawJson["logger-attribute2"]);
+            Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
+            Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
             Assert.AreEqual("value", (string)errorLog.RawJson["attribute"]);
             Assert.AreEqual("user-id", errorLog.UserId);
             Assert.AreEqual("user-name", errorLog.UserName);
@@ -106,6 +114,8 @@ namespace Datadog.Unity.Tests.Integration.Logging
             CollectionAssert.DoesNotContain(exceptionLog.Tags, "my-tag");
             Assert.IsFalse(exceptionLog.RawJson.ContainsKey("logger-attribute1"));
             Assert.AreEqual(1000, (long)exceptionLog.RawJson["logger-attribute2"]);
+            Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
+            Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
             Assert.AreEqual("System.InvalidOperationException", exceptionLog.ErrorKind);
             Assert.AreEqual("Error Message", exceptionLog.ErrorMessage);
             Assert.NotNull(exceptionLog.ErrorStack);
@@ -145,6 +155,11 @@ namespace Datadog.Unity.Tests.Integration.Logging
                 logger.Debug("debug message", new() { { "stringAttribute", "string" } });
 
                 logger.RemoveTag("my-tag");
+                DatadogSdk.Instance.AddLogsAttributes(new Dictionary<string, object>()
+                {
+                    { "global-attribute-1", "value-1" },
+                    { "global-attribute-2", 1255 },
+                });
                 logger.Info("info message", new()
                 {
                     {
@@ -159,6 +174,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
 
                 logger.RemoveAttribute("logger-attribute1");
                 logger.RemoveTagsWithKey("tag1");
+                DatadogSdk.Instance.RemoveLogsAttribute("global-attribute-2");
 
                 DatadogSdk.Instance.SetUserInfo("user-id", "user-name", extraInfo: new()
                 {


### PR DESCRIPTION
### What and why?

This allows uses to set global attributes that are add to all loggers.

Because there is no "Logs" object in this SDK, this has been added to the global DatadogSdk instance.

refs: RUM-3073

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
