### PR TITLE
feat: Add TraceContextInjection option

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add and option to control when trace context headers are injected into web requests (Trace Context Injection).
 * Add support for global log attributes, which adds attributes to logs sent from all loggers.
 
 ## 1.1.3

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -80,6 +80,8 @@ namespace Datadog.Unity.Editor
             _options.SessionSampleRate = Math.Clamp(_options.SessionSampleRate, 0.0f, 100.0f);
             _options.TraceSampleRate =
                 EditorGUILayout.FloatField("Trace Sample Rate", _options.TraceSampleRate);
+            _options.TraceContextInjection =
+                (TraceContextInjection)EditorGUILayout.EnumPopup("Trace Context Injection", _options.TraceContextInjection);
             _options.TraceSampleRate = Math.Clamp(_options.TraceSampleRate, 0.0f, 100.0f);
 
             GUILayout.Space(12.0f);

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -27,6 +27,23 @@ namespace Datadog.Unity
         Ap1,
     }
 
+    /// <summary>
+    /// Defines whether the trace context should be injected into all requests or
+    /// only into requests that are sampled in.
+    /// </summary>
+    public enum TraceContextInjection
+    {
+        /// <summary>
+        /// Injects trace context into all requests regardless of the sampling decision.
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// Injects trace context only into sampled requests.
+        /// </summary>
+        Sampled,
+    }
+
     [Flags]
     public enum TracingHeaderType
     {
@@ -195,6 +212,7 @@ namespace Datadog.Unity
         public VitalsUpdateFrequency VitalsUpdateFrequency = VitalsUpdateFrequency.Average;
         public float SessionSampleRate = 100.0f;
         public float TraceSampleRate = 20.0f;
+        public TraceContextInjection TraceContextInjection = TraceContextInjection.All;
         public List<FirstPartyHostOption> FirstPartyHosts = new ();
 
         // Advanced RUM

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -36,11 +36,13 @@ namespace Datadog.Unity
         /// <summary>
         /// Injects trace context into all requests regardless of the sampling decision.
         /// </summary>
+        [InspectorName("All")]
         All,
 
         /// <summary>
         /// Injects trace context only into sampled requests.
         /// </summary>
+        [InspectorName("Only Sampled")]
         Sampled,
     }
 

--- a/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
@@ -173,7 +173,7 @@ namespace Datadog.Unity.Rum
                     var context = trackingHelper.GenerateTraceContext();
                     trackingHelper.GenerateDatadogAttributes(context, attributes);
                     var headers = new Dictionary<string, string>();
-                    trackingHelper.GenerateTracingHeaders(context, tracingHeaders, headers);
+                    trackingHelper.GenerateTracingHeaders(context, tracingHeaders, trackingHelper.TraceContextInjection, headers);
 
                     foreach (var header in headers)
                     {

--- a/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
@@ -16,6 +16,9 @@ namespace Datadog.Unity.Rum
         private readonly DatadogConfigurationOptions _options;
         private readonly RateBasedSampler _traceSampler;
         private readonly List<FirstPartyHost> _firstPartyHosts;
+        private readonly TraceContextInjection _traceContextInjection;
+
+        public TraceContextInjection TraceContextInjection => _traceContextInjection;
 
         public ResourceTrackingHelper(DatadogConfigurationOptions options)
         {
@@ -24,11 +27,7 @@ namespace Datadog.Unity.Rum
             _firstPartyHosts = options.FirstPartyHosts
                 .Select(x => new FirstPartyHost(x.Host, x.TracingHeaderType))
                 .ToList();
-        }
-
-        public bool ShouldIncludeTrace()
-        {
-            return _traceSampler.Sample();
+            _traceContextInjection = options.TraceContextInjection;
         }
 
         public TraceContext GenerateTraceContext()
@@ -63,72 +62,100 @@ namespace Datadog.Unity.Rum
             return TracingHeaderType.None;
         }
 
-        internal void GenerateTracingHeaders(TraceContext traceContext, TracingHeaderType tracingHeaderType, Dictionary<string, string> headers)
+        internal void GenerateTracingHeaders(
+            TraceContext traceContext,
+            TracingHeaderType tracingHeaderType,
+            TraceContextInjection contextInjection,
+            Dictionary<string, string> headers)
         {
-            var sampledString = traceContext.sampled ? "1" : "0";
+            if (!traceContext.sampled && contextInjection == TraceContextInjection.Sampled)
+            {
+                // Easy out. Don't add any headers if the context is not sampled and we're only injecting sampled.
+                return;
+            }
 
             if ((tracingHeaderType & TracingHeaderType.Datadog) != 0)
             {
-                if (traceContext.sampled)
-                {
-                    headers[DatadogHttpTracingHeaders.TraceId] =
-                        traceContext.traceId.ToString(TraceIdRepresentation.LowDec);
-                    headers[DatadogHttpTracingHeaders.Tags] =
-                        $"{DatadogHttpTracingHeaders.TraceIdTag}={traceContext.traceId.ToString(TraceIdRepresentation.HighHex16Chars)}";
-                    headers[DatadogHttpTracingHeaders.ParentId] =
-                        traceContext.spanId.ToString(TraceIdRepresentation.Dec);
-                }
-
-                headers[DatadogHttpTracingHeaders.Origin] = "rum";
-                headers[DatadogHttpTracingHeaders.SamplingPriority] = sampledString;
+                InjectDatadogHeaders(traceContext, headers);
             }
 
             if ((tracingHeaderType & TracingHeaderType.B3) != 0)
             {
-                if (traceContext.sampled)
-                {
-                    var traceString = traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
-                    var spanString = traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
-                    var headerValue = $"{traceString}-{spanString}-{sampledString}";
-                    if (traceContext.parentSpanId != null)
-                    {
-                        headerValue +=
-                            $"-{traceContext.parentSpanId.Value.ToString(TraceIdRepresentation.Hex16Chars)}";
-                    }
-
-                    headers[OTelHttpTracingHeaders.SingleB3] = headerValue;
-                }
-                else
-                {
-                    headers[OTelHttpTracingHeaders.SingleB3] = sampledString;
-                }
+                InjectB3Headers(traceContext, headers);
             }
 
             if ((tracingHeaderType & TracingHeaderType.B3Multi) != 0)
             {
-                headers[OTelHttpTracingHeaders.MultipleSampled] = sampledString;
-                if (traceContext.sampled)
-                {
-                    headers[OTelHttpTracingHeaders.MultipleTraceId] =
-                        traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
-                    headers[OTelHttpTracingHeaders.MultipleSpanId] =
-                        traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
-                    if (traceContext.parentSpanId != null)
-                    {
-                        headers[OTelHttpTracingHeaders.MultipleParentId] =
-                            traceContext.parentSpanId.Value.ToString(TraceIdRepresentation.Hex16Chars);
-                    }
-                }
+                InjectB3MultiHeaders(traceContext, headers);
             }
 
             if((tracingHeaderType & TracingHeaderType.TraceContext) != 0)
             {
-                var spanString = traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
-                var traceString = traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
-                var tcSampledString = traceContext.sampled ? "01" : "00";
-                headers[W3CTracingHeaders.TraceParent] = $"00-{traceString}-{spanString}-{tcSampledString}";
-                headers[W3CTracingHeaders.TraceState] = $"dd=s:{sampledString};o:rum;p:{spanString}";
+                InjectTraceContextHeaders(traceContext, headers);
             }
+        }
+
+        private static void InjectTraceContextHeaders(TraceContext traceContext, Dictionary<string, string> headers)
+        {
+            var sampledString = traceContext.sampled ? "1" : "0";
+            var spanString = traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
+            var traceString = traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
+            var tcSampledString = traceContext.sampled ? "01" : "00";
+            headers[W3CTracingHeaders.TraceParent] = $"00-{traceString}-{spanString}-{tcSampledString}";
+            headers[W3CTracingHeaders.TraceState] = $"dd=s:{sampledString};o:rum;p:{spanString}";
+        }
+
+        private static void InjectB3MultiHeaders(TraceContext traceContext, Dictionary<string, string> headers)
+        {
+            headers[OTelHttpTracingHeaders.MultipleSampled] = traceContext.sampled ? "1" : "0";;
+            if (traceContext.sampled)
+            {
+                headers[OTelHttpTracingHeaders.MultipleTraceId] =
+                    traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
+                headers[OTelHttpTracingHeaders.MultipleSpanId] =
+                    traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
+                if (traceContext.parentSpanId != null)
+                {
+                    headers[OTelHttpTracingHeaders.MultipleParentId] =
+                        traceContext.parentSpanId.Value.ToString(TraceIdRepresentation.Hex16Chars);
+                }
+            }
+        }
+
+        private static void InjectB3Headers(TraceContext traceContext, Dictionary<string, string> headers)
+        {
+            var sampledString = traceContext.sampled ? "1" : "0";
+            if (traceContext.sampled)
+            {
+                var traceString = traceContext.traceId.ToString(TraceIdRepresentation.Hex32Chars);
+                var spanString = traceContext.spanId.ToString(TraceIdRepresentation.Hex16Chars);
+                var headerValue = $"{traceString}-{spanString}-{sampledString}";
+                if (traceContext.parentSpanId != null)
+                {
+                    headerValue +=
+                        $"-{traceContext.parentSpanId.Value.ToString(TraceIdRepresentation.Hex16Chars)}";
+                }
+
+                headers[OTelHttpTracingHeaders.SingleB3] = headerValue;
+            }
+            else
+            {
+                headers[OTelHttpTracingHeaders.SingleB3] = sampledString;
+            }
+        }
+
+        private void InjectDatadogHeaders(
+            TraceContext traceContext,
+            Dictionary<string, string> headers)
+        {
+            headers[DatadogHttpTracingHeaders.TraceId] =
+                traceContext.traceId.ToString(TraceIdRepresentation.LowDec);
+            headers[DatadogHttpTracingHeaders.Tags] =
+                $"{DatadogHttpTracingHeaders.TraceIdTag}={traceContext.traceId.ToString(TraceIdRepresentation.HighHex16Chars)}";
+            headers[DatadogHttpTracingHeaders.ParentId] =
+                traceContext.spanId.ToString(TraceIdRepresentation.Dec);
+            headers[DatadogHttpTracingHeaders.Origin] = "rum";
+            headers[DatadogHttpTracingHeaders.SamplingPriority] = traceContext.sampled ? "1" : "0";
         }
 
         private static class DatadogAttributeKeys

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -67,6 +67,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.AreEqual(VitalsUpdateFrequency.Average, options.VitalsUpdateFrequency);
             Assert.AreEqual(100.0f, options.SessionSampleRate);
             Assert.AreEqual(20.0f, options.TraceSampleRate);
+            Assert.AreEqual(TraceContextInjection.All, options.TraceContextInjection);
             Assert.AreEqual(20.0f, options.TelemetrySampleRate);
         }
     }


### PR DESCRIPTION
### What and why?

TraceContextInjection adds the ability for users to select whether or not trace contexts are injected into request headers for every request or only on those requests that are sampled in for tracing.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
