### PR TITLE
fix: Fix iOS custom endpoint

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -143,7 +143,7 @@ func initializeDatadog() {{
 ");
             if (options.CustomEndpoint != string.Empty)
             {
-                sb.AppendLine($@"    logsConfig.customEndpoint = URL(string: ""{options.CustomEndpoint}/logs"")");
+                sb.AppendLine($@"    logsConfig.customEndpoint = URL(string: ""{options.CustomEndpoint}/api/v2/logs"")");
             }
 
             sb.AppendLine("    Logs.enable(with: logsConfig)");
@@ -157,7 +157,7 @@ func initializeDatadog() {{
 ");
                 if (options.CustomEndpoint != string.Empty)
                 {
-                    sb.AppendLine($@"    rumConfig.customEndpoint = URL(string: ""{options.CustomEndpoint}/rum"")");
+                    sb.AppendLine($@"    rumConfig.customEndpoint = URL(string: ""{options.CustomEndpoint}/api/v2/rum"")");
                 }
 
                 if (options.VitalsUpdateFrequency != VitalsUpdateFrequency.None)


### PR DESCRIPTION
### What and why?

Android automatically adds `api/v2` to the site, whereas iOS does not. This can cause problems when trying to work with both platforms on staging.

Fix it so both platforms append `api/v2` to the custom endpoint.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
