### PR TITLE
feat: Add the ability to customize service name

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add and option to control when trace context headers are injected into web requests (Trace Context Injection).
 * Add support for global log attributes, which adds attributes to logs sent from all loggers.
+* Add the ability to customize your Service Name from the Datadog Options dialog.
 
 ## 1.1.3
 

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationOptionsExtensions.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationOptionsExtensions.cs
@@ -25,6 +25,7 @@ namespace Datadog.Unity.Editor
                 options.ClientToken = string.Empty;
                 options.Enabled = true;
                 options.Env = string.Empty;
+                options.ServiceName = string.Empty;
                 options.OutputSymbols = false;
                 options.Site = DatadogSite.Us1;
                 options.CustomEndpoint = string.Empty;

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -49,8 +49,8 @@ namespace Datadog.Unity.Editor
 
             _options.ClientToken = EditorGUILayout.TextField("Client Token", _options.ClientToken);
             _options.Env = EditorGUILayout.TextField("Env", _options.Env);
+            _options.ServiceName = EditorGUILayout.TextField("Service Name", _options.ServiceName);
             _options.Site = (DatadogSite)EditorGUILayout.EnumPopup("Datadog Site", _options.Site);
-            _options.CustomEndpoint = EditorGUILayout.TextField("Custom Endpoint", _options.CustomEndpoint);
             _options.BatchSize = (BatchSize)EditorGUILayout.EnumPopup("Batch Size", _options.BatchSize);
             _options.UploadFrequency = (UploadFrequency)EditorGUILayout.EnumPopup("Upload Frequency", _options.UploadFrequency);
             _options.BatchProcessingLevel = (BatchProcessingLevel)EditorGUILayout.EnumPopup("Batch Processing Level", _options.BatchProcessingLevel);
@@ -118,6 +118,7 @@ namespace Datadog.Unity.Editor
             _showAdvancedOptions = EditorGUILayout.BeginFoldoutHeaderGroup(_showAdvancedOptions, "Advanced RUM Options");
             if (_showAdvancedOptions)
             {
+                _options.CustomEndpoint = EditorGUILayout.TextField("Custom Endpoint", _options.CustomEndpoint);
                 _options.SdkVerbosity = (CoreLoggerLevel)EditorGUILayout.EnumPopup("SDK Verbosity", _options.SdkVerbosity);
                 _options.TelemetrySampleRate =
                     EditorGUILayout.FloatField("Telemetry Sample Rate", _options.TelemetrySampleRate);

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -88,6 +88,8 @@ namespace Datadog.Unity.Editor.iOS
                 env = "prod";
             }
 
+            var serviceName = options.ServiceName;
+
             var sdkVersion = DatadogSdk.SdkVersion;
             var sdkLogLevel = GetSwiftCoreLoggerLevel(options.SdkVerbosity);
 
@@ -106,7 +108,14 @@ func initializeDatadog() {{
         clientToken: ""{options.ClientToken}"",
         env: ""{env}"",
         site: {GetSwiftSite(options.Site)},
-        batchSize: {GetSwiftBatchSize(options.BatchSize)},
+");
+
+            if (!(serviceName is null or ""))
+            {
+                sb.AppendLine($"        service: \"{serviceName}\",");
+            }
+
+            sb.Append($@"        batchSize: {GetSwiftBatchSize(options.BatchSize)},
         uploadFrequency: {GetSwiftUploadFrequency(options.UploadFrequency)},
         batchProcessingLevel: {GetSwiftBatchProcessingLevel(options.BatchProcessingLevel)}
     )

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -52,12 +52,14 @@ namespace Datadog.Unity.Android
                 environment = "prod";
             }
 
+            var serviceName = options.ServiceName == string.Empty ? null : options.ServiceName;
+
             using var configBuilder = new AndroidJavaObject(
                 "com.datadog.android.core.configuration.Configuration$Builder",
                 options.ClientToken,
                 environment,
                 string.Empty, // Variant Name
-                null // Service Name
+                serviceName // Service Name
             );
             configBuilder.Call<AndroidJavaObject>("useSite", DatadogConfigurationHelpers.GetSite(options.Site));
             configBuilder.Call<AndroidJavaObject>("setBatchSize", DatadogConfigurationHelpers.GetBatchSize(options.BatchSize));

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -197,6 +197,7 @@ namespace Datadog.Unity
         public string ClientToken;
         public DatadogSite Site;
         public string Env;
+        public string ServiceName;
         public string CustomEndpoint;
         public BatchSize BatchSize;
         public UploadFrequency UploadFrequency;

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -49,6 +49,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.IsFalse(options.OutputSymbols);
             Assert.IsEmpty(options.ClientToken);
             Assert.IsEmpty(options.Env);
+            Assert.IsEmpty(options.ServiceName);
             Assert.AreEqual(DatadogSite.Us1, options.Site);
             Assert.IsEmpty(options.CustomEndpoint);
             Assert.AreEqual(BatchSize.Medium, options.BatchSize);

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -341,6 +341,30 @@ namespace Datadog.Unity.Editor.iOS
         }
 
         [Test]
+        public void GenerateOptionsFileDoesNotWriteEmptyService()
+        {
+            var options = new DatadogConfigurationOptions();
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var serviceLines = lines.Where(l => l.Contains("service: ")).ToArray();
+            Assert.IsEmpty(serviceLines);
+        }
+
+        [Test]
+        public void GenerateOptionsFileAddsService()
+        {
+            var options = new DatadogConfigurationOptions();
+            options.ServiceName = "service-from-options";
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var serviceLines = lines.Where(l => l.Contains("service: ")).ToArray();
+            Assert.AreEqual(1, serviceLines.Length);
+            Assert.AreEqual($"service: \"service-from-options\",", serviceLines.First().Trim());
+        }
+
+        [Test]
         public void GenerateOptionsFileWritesEnvFromOptions()
         {
             var options = new DatadogConfigurationOptions()


### PR DESCRIPTION
### What and why?

Add the ability to customize the default service name in Datadog Options.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
