### PR TITLE
chore: Add NuGetForUnity.CLI

### DIFF
--- a/samples/Datadog Sample/.config/dotnet-tools.json
+++ b/samples/Datadog Sample/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nugetforunity.cli": {
+      "version": "4.1.1",
+      "commands": [
+        "nugetforunity"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION
### What and why?

This is needed to restore NuGet packages on the CLI. We have a few NuGet packages used for Unit and Integration testing in the sample.

To install the tool, use

```bash
dotnet tool restore
```

Then run with

```bash
dotnet nugetforunity restore .
```

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
