### PR TITLE
chore: Fix play mode unit tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,4 +33,4 @@ unit-test:
     when: always
     expire_in: "30 days"
     reports:
-      junit: $CI_PROJECT_DIR/samples/Datadog Sample/tmp/junit-results.xml
+      junit: $CI_PROJECT_DIR/samples/Datadog Sample/tmp/junit-results*.xml

--- a/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
@@ -107,15 +107,23 @@ namespace Datadog.Unity.Rum.Tests
             // Then
             var traceString = attributes.GetValueOrDefault("_dd.trace_id")?.ToString();
             var spanString = attributes.GetValueOrDefault("_dd.span_id")?.ToString();
-            Assert.IsNotNull(traceString);
-            BigInteger.TryParse(traceString, NumberStyles.HexNumber, null, out var traceId);
-            Assert.IsNotNull(traceId);
-            Assert.LessOrEqual(traceId.GetByteCount(), 128);
+            if (_sampled)
+            {
+                Assert.IsNotNull(traceString);
+                BigInteger.TryParse(traceString, NumberStyles.HexNumber, null, out var traceId);
+                Assert.IsNotNull(traceId);
+                Assert.LessOrEqual(traceId.GetByteCount(), 128);
 
-            Assert.IsNotNull(spanString);
-            BigInteger.TryParse(spanString, NumberStyles.HexNumber, null, out var spanId);
-            Assert.IsNotNull(spanId);
-            Assert.LessOrEqual(spanId.GetByteCount(), 63);
+                Assert.IsNotNull(spanString);
+                BigInteger.TryParse(spanString, NumberStyles.HexNumber, null, out var spanId);
+                Assert.IsNotNull(spanId);
+                Assert.LessOrEqual(spanId.GetByteCount(), 63);
+            }
+            else
+            {
+                Assert.IsNull(traceString);
+                Assert.IsNull(spanString);
+            }
 
             Assert.AreEqual(_sampled ? 1.0f : 0.0f, attributes["_dd.rule_psr"]);
         }
@@ -128,11 +136,7 @@ namespace Datadog.Unity.Rum.Tests
         {
             if (!_sampled)
             {
-                if (headerType == TracingHeaderType.B3 || headerType == TracingHeaderType.B3Multi)
-                {
-                    Assert.Pass("B3 and B3Multi headers don't contain ids when sampled.");
-                    return;
-                }
+                Assert.Pass("DatadogAttributes only filled in sampled requests, so test only applies to sampled requests");
             }
 
             // Given

--- a/tools/scripts/run_unit_test.py
+++ b/tools/scripts/run_unit_test.py
@@ -37,10 +37,17 @@ async def main():
         "-testResults", "tmp/results.xml", "-logFile", "-",
     )
 
+    return_code = await run_unity_command(license_retry_count, license_retry_wait,
+        "-runTests", "-batchMode", "-projectPath", f'"{integration_project_path}"',
+        "-testCategory", "!integration", '-testPlatform', 'PlayMode',
+        "-testResults", "tmp/results-play-mode.xml", "-logFile", "-",
+    )
+
     if token is not None:
         await return_unity_license(token)
 
     transform_nunit_to_junit("../../samples/Datadog Sample/tmp/results.xml", "../../samples/Datadog Sample/tmp/junit-results.xml")
+    transform_nunit_to_junit("../../samples/Datadog Sample/tmp/results-play-mode.xml", "../../samples/Datadog Sample/tmp/junit-results-play-mode.xml")
 
     return return_code
 


### PR DESCRIPTION
### What and why?

There was mistake in the tests that were checking TraceContextInjection. In all cases when a trace is unsampled, Datadog attributes are not filled in, which was a change from the original logic but tests were not updated.

Also make sure play mode unit tests run on CI.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
