### PR TITLE
fix: Fix Android stack traces / mangling of .so

### DIFF
--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSPlatform.cs
@@ -167,7 +167,8 @@ namespace Datadog.Unity.iOS
 
                     var moduleName = Path.GetFileNameWithoutExtension(imageName);
                     // Strip off weird \u0001 character that appears at the end of module names
-                    moduleName = moduleName.Substring(0, moduleName.Length - 1);
+                    moduleName = moduleName.Replace("\u0001", string.Empty);
+
 
                     // Format of iOS Native stack trace is:
                     // <frame number> <module name> <absolute address> <relative address> + <offset>


### PR DESCRIPTION
### What and why?

Fix a few minor mistakes in native stack trace formatting.

Android translating C# stack traces to native stack traces weren't properly stripping all trailing characters, and weren't adding the correct library name (`libil2cpp.so`) when no image could be found. This fixes both issue.
 
Also make iOS removal of zero character more robust.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
