### PR TITLE
fix: Wrap object pool to be thread safe

### DIFF
--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
@@ -13,11 +13,12 @@ namespace Datadog.Unity.Android
     internal class DatadogAndroidRum : IDdRum
     {
         private readonly AndroidJavaObject _rum;
-        private DatadogAndroidPlatform _androidPlatform;
+        private readonly DatadogAndroidPlatform _androidPlatform;
 
         public DatadogAndroidRum(IDatadogPlatform platform, AndroidJavaObject rum)
         {
             _rum = rum;
+            _androidPlatform = platform as DatadogAndroidPlatform;
         }
 
         public void StartView(string key, string name = null, Dictionary<string, object> attributes = null)

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -60,7 +60,10 @@ namespace Datadog.Unity
         internal IInternalLogger InternalLogger
         {
             get { return _internalLogger;  }
-            set { _internalLogger = value; }
+            set
+            {
+                _internalLogger = value ?? new PassThroughInternalLogger();
+            }
         }
 
         internal ResourceTrackingHelper ResourceTrackingHelper => _resourceTrackingHelper;

--- a/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/DdSdkProcessor.cs
@@ -85,7 +85,7 @@ namespace Datadog.Unity.Worker
         // TODO: This should be moved from the core_sdk as it actually applies to Logs.
         internal class AddGlobalAttributesMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<AddGlobalAttributesMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddGlobalAttributesMessage> _pool = new (
                 createFunc: () => new AddGlobalAttributesMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddGlobalAttributesMessage()
@@ -116,7 +116,7 @@ namespace Datadog.Unity.Worker
 
         internal class RemoveGlobalAttributeMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<RemoveGlobalAttributeMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<RemoveGlobalAttributeMessage> _pool = new (
                 createFunc: () => new RemoveGlobalAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private RemoveGlobalAttributeMessage()

--- a/packages/Datadog.Unity/Runtime/InternalLogger.cs
+++ b/packages/Datadog.Unity/Runtime/InternalLogger.cs
@@ -105,7 +105,7 @@ namespace Datadog.Unity.Core
 
         internal class TelemetryDebugMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<TelemetryDebugMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<TelemetryDebugMessage> _pool = new (
                 createFunc: () => new TelemetryDebugMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private TelemetryDebugMessage()
@@ -138,7 +138,7 @@ namespace Datadog.Unity.Core
 
         internal class TelemetryErrorMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<TelemetryErrorMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<TelemetryErrorMessage> _pool = new (
                 createFunc: () => new TelemetryErrorMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private TelemetryErrorMessage()

--- a/packages/Datadog.Unity/Runtime/Logs/DdLogProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DdLogProcessor.cs
@@ -43,7 +43,7 @@ namespace Datadog.Unity.Logs
 
         internal class LogMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<LogMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<LogMessage> _pool = new (
                 createFunc: () => new LogMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private LogMessage()
@@ -89,7 +89,7 @@ namespace Datadog.Unity.Logs
 
         internal class AddTagMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<AddTagMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddTagMessage> _pool = new (
                 createFunc: () => new AddTagMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddTagMessage()
@@ -128,7 +128,7 @@ namespace Datadog.Unity.Logs
 
         internal class RemoveTagMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<RemoveTagMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<RemoveTagMessage> _pool = new (
                 createFunc: () => new RemoveTagMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private RemoveTagMessage()
@@ -163,7 +163,7 @@ namespace Datadog.Unity.Logs
 
         internal class RemoveTagsWithKeyMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<RemoveTagsWithKeyMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<RemoveTagsWithKeyMessage> _pool = new (
                 createFunc: () => new RemoveTagsWithKeyMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private RemoveTagsWithKeyMessage()
@@ -198,7 +198,7 @@ namespace Datadog.Unity.Logs
 
         internal class AddAttributeMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<AddAttributeMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddAttributeMessage> _pool = new (
                 createFunc: () => new AddAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddAttributeMessage()
@@ -237,7 +237,7 @@ namespace Datadog.Unity.Logs
 
         internal class RemoveAttributeMessage : IDatadogWorkerMessage
         {
-            private static ObjectPool<RemoveAttributeMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<RemoveAttributeMessage> _pool = new (
                 createFunc: () => new RemoveAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private RemoveAttributeMessage()

--- a/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
@@ -228,6 +228,12 @@ namespace Datadog.Unity.Rum
                                 break;
                         }
                     }
+                    catch (NullReferenceException e)
+                    {
+                        // This webrequest was disposed before the operation completed. This is not a telemetry
+                        // error, but we should stop the resource.
+                        DatadogSdk.Instance.Rum.StopResourceWithError(rumKey, "RequestDisposed", error);
+                    }
                     catch (Exception e)
                     {
                         DatadogSdk.Instance.InternalLogger?.TelemetryError("Error stopping RUM resource.", e);

--- a/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
@@ -101,7 +101,7 @@ namespace Datadog.Unity.Rum
 
         internal class StartViewMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StartViewMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StartViewMessage> _pool = new (
                 createFunc: () => new StartViewMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StartViewMessage()
@@ -141,7 +141,7 @@ namespace Datadog.Unity.Rum
 
         internal class StopViewMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StopViewMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StopViewMessage> _pool = new (
                 createFunc: () => new StopViewMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StopViewMessage()
@@ -177,7 +177,7 @@ namespace Datadog.Unity.Rum
 
         internal class AddUserActionMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<AddUserActionMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddUserActionMessage> _pool = new (
                 createFunc: () => new AddUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddUserActionMessage()
@@ -216,7 +216,7 @@ namespace Datadog.Unity.Rum
 
         internal class StartUserActionMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StartUserActionMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StartUserActionMessage> _pool = new (
                 createFunc: () => new StartUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StartUserActionMessage()
@@ -255,7 +255,7 @@ namespace Datadog.Unity.Rum
 
         internal class StopUserActionMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StopUserActionMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StopUserActionMessage> _pool = new (
                 createFunc: () => new StopUserActionMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StopUserActionMessage()
@@ -294,7 +294,7 @@ namespace Datadog.Unity.Rum
 
         internal class AddErrorMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<AddErrorMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddErrorMessage> _pool = new (
                 createFunc: () => new AddErrorMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddErrorMessage()
@@ -334,7 +334,7 @@ namespace Datadog.Unity.Rum
 
         internal class AddAttributeMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<AddAttributeMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddAttributeMessage> _pool = new (
                 createFunc: () => new AddAttributeMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddAttributeMessage()
@@ -368,7 +368,7 @@ namespace Datadog.Unity.Rum
 
         internal class RemoveAttributeMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<RemoveAttributeMessage> _pool = new (createFunc: () => new RemoveAttributeMessage());
+            private static readonly ThreadSafeObjectPool<RemoveAttributeMessage> _pool = new (createFunc: () => new RemoveAttributeMessage());
 
             private RemoveAttributeMessage()
             {
@@ -392,7 +392,7 @@ namespace Datadog.Unity.Rum
 
         internal class StartResourceLoadingMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StartResourceLoadingMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StartResourceLoadingMessage> _pool = new (
                 createFunc: () => new StartResourceLoadingMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StartResourceLoadingMessage()
@@ -435,7 +435,7 @@ namespace Datadog.Unity.Rum
 
         internal class StopResourceLoadingMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StopResourceLoadingMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StopResourceLoadingMessage> _pool = new (
                 createFunc: () => new StopResourceLoadingMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StopResourceLoadingMessage()
@@ -482,7 +482,7 @@ namespace Datadog.Unity.Rum
 
         internal class StopResourceLoadingWithErrorMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<StopResourceLoadingWithErrorMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<StopResourceLoadingWithErrorMessage> _pool = new (
                 createFunc: () => new StopResourceLoadingWithErrorMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private StopResourceLoadingWithErrorMessage()
@@ -529,7 +529,7 @@ namespace Datadog.Unity.Rum
 
         internal class AddFeatureFlagEvaluationMessage : DdRumWorkerMessage
         {
-            private static ObjectPool<AddFeatureFlagEvaluationMessage> _pool = new (
+            private static readonly ThreadSafeObjectPool<AddFeatureFlagEvaluationMessage> _pool = new (
                 createFunc: () => new AddFeatureFlagEvaluationMessage(), actionOnRelease: (obj) => obj.Reset());
 
             private AddFeatureFlagEvaluationMessage()

--- a/packages/Datadog.Unity/Runtime/Worker/ThreadSafeObjectPool.cs
+++ b/packages/Datadog.Unity/Runtime/Worker/ThreadSafeObjectPool.cs
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+using System;
+using UnityEngine.Pool;
+
+namespace Datadog.Unity.Worker
+{
+    public class ThreadSafeObjectPool<T> : IDisposable, IObjectPool<T>
+        where T : class
+    {
+        private readonly object _lock = new ();
+        private readonly ObjectPool<T> _pool;
+
+        public ThreadSafeObjectPool(
+            Func<T> createFunc,
+            Action<T> actionOnGet = null,
+            Action<T> actionOnRelease = null,
+            Action<T> actionOnDestroy = null,
+            bool collectionCheck = true,
+            int defaultCapacity = 10,
+            int maxSize = 10000)
+        {
+            _pool = new (createFunc, actionOnGet, actionOnRelease, actionOnDestroy, collectionCheck, defaultCapacity,
+                maxSize);
+        }
+
+        public int CountInactive
+        {
+            get
+            {
+                lock(_lock)
+                {
+                    return _pool.CountInactive;
+                }
+            }
+        }
+
+        public T Get()
+        {
+            lock (_lock)
+            {
+                return _pool.Get();
+            }
+        }
+
+        public PooledObject<T> Get(out T v)
+        {
+            lock (_lock)
+            {
+                return _pool.Get(out v);
+            }
+        }
+
+        public void Release(T element)
+        {
+            lock (_lock)
+            {
+                _pool.Release(element);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _pool.Clear();
+            }
+        }
+
+        public void Dispose() => this.Clear();
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Worker/ThreadSafeObjectPool.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Worker/ThreadSafeObjectPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eda198ca94714446a16fc3653cc87519
+timeCreated: 1729006656

--- a/tools/scripts/run_integration_test.py
+++ b/tools/scripts/run_integration_test.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------
 
 import argparse
+import asyncio
 import subprocess
 import os
 import threading
@@ -45,7 +46,7 @@ def modify_datadog_settings(local_server_address):
         settings_file.writelines(data)
 
 
-def main():
+async def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("--platform", choices=['ios', 'android'], help="The platform to run integration tests on.")
     arg_parser.add_argument("--launch-simulator", action='store_true', help="Whether to launch a simulator or emulator before running tests.")
@@ -89,8 +90,8 @@ def main():
     license_retry_count = args.retry
     license_retry_wait = args.retry_wait
 
-    run_unity_command(license_retry_count, license_retry_wait,
-        "-runTests", "-batchMode", "-projectPath", integration_project_path,
+    await run_unity_command(license_retry_count, license_retry_wait,
+        "-runTests", "-batchMode", "-projectPath", f'"{integration_project_path}"',
         "-buildTarget", args.platform,
         "-testCategory", "integration", "-testPlatform", args.platform,
         "-testResults", "tmp/results.xml", "-logFile", "-",
@@ -102,4 +103,6 @@ def main():
     pass
 
 if __name__ == "__main__":
-    main()
+    task = main()
+    res = asyncio.get_event_loop().run_until_complete(task)
+    exit(res)


### PR DESCRIPTION
### What and why?

We're seeing some telemetry concerning NullReferenceExceptions for things that should never have null values. In the case of DatadogTrackedWebRequest, one way this can happen is if the underlying web request is disposed, at which point our completion handler is called but `result` is `null`, resulting in the exception.

Since this is a potentially expected error, I've added a catch for it and I stop the resource appropriately.

The second seems to have to do with our use of object pooling for messages. Object pools are not thread safe, so I've created a wrapper around the object pool to ensure we're not getting pooled objects that are in bad states if customers use attempt to use them from multiple threads.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
