### PR TITLE
feat: Automatically forward errors to RUM instead of Logs

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* BREAKING: Send automatically captured errors to RUM instead of Logs.
+
 ## 1.3.0
 
 * Added an option for detecting non-fatal ANRs on Android.

--- a/packages/Datadog.Unity/Runtime/DatadogSdk.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogSdk.cs
@@ -257,15 +257,16 @@ namespace Datadog.Unity
                     RemoteLogThreshold = DdLogHelpers.LogTypeToDdLogLevel(options.RemoteLogThreshold),
                 };
                 DefaultLogger = CreateLogger(loggingOptions);
-                if (options.ForwardUnityLogs)
-                {
-                    _logHandler = new (DefaultLogger);
-                    _logHandler.Attach();
-                }
 
                 if (options.RumEnabled)
                 {
                     EnableRum(options);
+                }
+
+                if (options.ForwardUnityLogs)
+                {
+                    _logHandler = new (DefaultLogger, options.RumEnabled ? Rum : null);
+                    _logHandler.Attach();
                 }
 
                 _worker.Start();

--- a/packages/Datadog.Unity/Tests/DdUnityLogHandlerTests.cs
+++ b/packages/Datadog.Unity/Tests/DdUnityLogHandlerTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Datadog.Unity.Core;
 using Datadog.Unity.Logs;
+using Datadog.Unity.Rum;
 using Datadog.Unity.Worker;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
@@ -45,7 +46,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
 
             // When
             handler.Attach();
@@ -59,7 +60,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
 
             // When
@@ -74,7 +75,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Critical, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
 
             // When
             handler.Detach();
@@ -84,11 +85,12 @@ namespace Datadog.Unity.Tests
         }
 
         [Test]
-        public void LogExceptionSendsToDatadog()
+        public void LogExceptionSendsToRum_WhenRumIsNotNull()
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Critical, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var rum = Substitute.For<IDdRum>();
+            var handler = new DdUnityLogHandler(datadogLogger, rum);
             handler.Attach();
 
             // When
@@ -97,7 +99,7 @@ namespace Datadog.Unity.Tests
             handler.LogException(exception, context);
 
             // Then
-            datadogLogger.Received().PlatformLog(DdLogLevel.Critical, exception.Message, error: exception);
+            rum.Received().AddError(exception, RumErrorSource.Source);
         }
 
         [Test]
@@ -105,7 +107,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Critical, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
 
             // When
@@ -122,7 +124,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Critical, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
             datadogLogger.When(logger =>
             {
@@ -143,20 +145,20 @@ namespace Datadog.Unity.Tests
         }
 
         [Test]
-        public void LogExceptionSendsToTelemetry_WhenDatadogLoggerFails()
+        public void LogExceptionSendsToTelemetry_WhenDatadogRumFails()
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Critical, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var rum = Substitute.For<IDdRum>();
+            var handler = new DdUnityLogHandler(datadogLogger, rum);
             handler.Attach();
             var expectedException = new Exception();
-            datadogLogger.When(logger =>
+            rum.When(rum =>
             {
-                logger.PlatformLog(
-                    DdLogLevel.Critical,
-                    Arg.Any<string>(),
-                    Arg.Any<Dictionary<string, object>>(),
-                    Arg.Any<Exception>());
+                rum.AddError(
+                    Arg.Any<Exception>(),
+                    RumErrorSource.Source,
+                    Arg.Any<Dictionary<string, object>>());
             }).Do(_ => throw expectedException);
 
             // When
@@ -178,7 +180,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
 
             // When
@@ -196,7 +198,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
             datadogLogger.When(logger =>
             {
@@ -221,7 +223,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
             var expectedException = new Exception();
             datadogLogger.When(logger =>
@@ -252,7 +254,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
 
             // When
@@ -278,7 +280,7 @@ namespace Datadog.Unity.Tests
         {
             // Given
             var datadogLogger = Substitute.ForPartsOf<DdLogger>(DdLogLevel.Debug, 100.0f);
-            var handler = new DdUnityLogHandler(datadogLogger);
+            var handler = new DdUnityLogHandler(datadogLogger, null);
             handler.Attach();
 
             // When

--- a/packages/Datadog.Unity/Tests/Integration/Logging/AutoLoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/AutoLoggingIntegrationTests.cs
@@ -30,14 +30,14 @@ namespace Datadog.Unity.Tests.Integration.Logging
             var task = mockServerHelper.PollRequests(new TimeSpan(0, 0, 30), (serverLog) =>
             {
                 var logs = LogDecoder.LogsFromMockServer(serverLog);
-                return logs.Count >= 4;
+                return logs.Count >= 3;
             });
 
             yield return new WaitUntil(() => task.IsCompleted);
             var serverLog = task.Result;
             var logs = LogDecoder.LogsFromMockServer(serverLog);
 
-            Assert.AreEqual(4, logs.Count);
+            Assert.AreEqual(3, logs.Count);
 
             // The first log is from Unity about `ignoreFailingMessages` being set and can be ignored
             // All other logs have the attribute set
@@ -54,13 +54,6 @@ namespace Datadog.Unity.Tests.Integration.Logging
             var warnLog = logs[2];
             Assert.AreEqual("warn", warnLog.Status);
             Assert.AreEqual("Test warning", warnLog.Message);
-
-            var exceptionLog = logs[3];
-            Assert.AreEqual("critical", exceptionLog.Status);
-            Assert.AreEqual("Error Message", exceptionLog.Message);
-            Assert.AreEqual("Error Message", exceptionLog.ErrorMessage);
-            Assert.AreEqual("System.InvalidOperationException", exceptionLog.ErrorKind);
-            Assert.NotNull(exceptionLog.ErrorStack);
         }
 
         public class TestAutoLoggingMonoBehavior : MonoBehaviour, IMonoBehaviourTest


### PR DESCRIPTION
### What and why?

Previously, we were relying on Logs -> RUM integration to supply errors to RUM. However, doing this means that Error Tracking doesn't create the link from ET to RUM, expecting them to be in the Logs instead.

Instead, if RUM is enabled, send the errors to RUM instead of Logs.

refs: RUM-6778

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
