### PR TITLE
Preserve the stacktrace provided by the unity exception if present

### DIFF
--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
@@ -66,7 +66,7 @@ namespace Datadog.Unity.Android
             var javaAttributes = DatadogAndroidHelpers.DictionaryToJavaMap(attributes);
             if (error != null)
             {
-                var nativeStackTrace = _androidPlatform.GetNativeStack(error);
+                var nativeStackTrace = string.IsNullOrEmpty(error.StackTrace) ? _androidPlatform.GetNativeStack(error) : null;
                 if (nativeStackTrace != null)
                 {
                     stack = nativeStackTrace;

--- a/packages/Datadog.Unity/Runtime/iOS/DatadogiOSRum.cs
+++ b/packages/Datadog.Unity/Runtime/iOS/DatadogiOSRum.cs
@@ -64,7 +64,7 @@ namespace Datadog.Unity.iOS
             string stackTrace = null;
             if (error != null)
             {
-                var nativeStackTrace = _platform.GetNativeStack(error);
+                var nativeStackTrace = string.IsNullOrEmpty(error.StackTrace) ? _platform.GetNativeStack(error) : null;
                 if (nativeStackTrace != null)
                 {
                     attributes = attributes == null ? new () : new (attributes);


### PR DESCRIPTION
### What and why?

Unhadled exceptions were generating native stack traces even when we provided a trace within the exception.

### Review checklist

- Support Ticket https://help.datadoghq.com/hc/en-us/requests/1924021
