### PR TITLE
chore: Remove snapshots repository when releasing

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * BREAKING: Send automatically captured errors to RUM instead of Logs.
+* Removed snapshot repository in released Android dependencies file.
 
 ## 1.3.0
 

--- a/tools/scripts/update_versions.py
+++ b/tools/scripts/update_versions.py
@@ -27,8 +27,13 @@ def _update_android_version(version: str):
             print(f"Updating {items[1]} to {version}")
             item.attrib["spec"] = str.join(":", items)
 
-    tree.write(UNITY_DEPENDENCIES_FILE)
+    repository_element = root.find("./androidPackages/repositories")
+    if repository_element is not None:
+        for repo in repository_element.findall("./repository"):
+            if repo.text is not None  and "snapshots" in repo.text:
+                repository_element.remove(repo)
 
+    tree.write(UNITY_DEPENDENCIES_FILE)
 
 def _update_ios_version(version: str):
     tree = et.parse(UNITY_DEPENDENCIES_FILE)


### PR DESCRIPTION
### What and why?

Android uses snapshot dependencies during development, but they aren't desired after release.  Remove the snapshot repository from the dependencies XML when releasing.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
