### PR TITLE
feat: Warn and discard null values passed to worker proxies

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * BREAKING: Send automatically captured errors to RUM instead of Logs.
 * Removed snapshot repository in released Android dependencies file.
+* Add `null` checking and warning logs in worker proxies to surface potential issues closer to the call site.
 
 ## 1.3.0
 

--- a/packages/Datadog.Unity/Runtime/Logs/DDWorkerProxyLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Logs/DDWorkerProxyLogger.cs
@@ -23,32 +23,79 @@ namespace Datadog.Unity.Logs
 
         public override void AddAttribute(string key, object value)
         {
+            if (key == null)
+            {
+                LogNullWarning("AddAttribute", "key");
+                return;
+            }
+
+            if (value == null)
+            {
+                LogNullWarning("AddAttribute", "value");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.AddAttributeMessage.Create(_logger, key, value));
         }
 
         public override void AddTag(string tag, string value = null)
         {
+            if (tag == null)
+            {
+                LogNullWarning("AddTag", "tag");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.AddTagMessage.Create(_logger, tag, value));
         }
 
         public override void RemoveAttribute(string key)
         {
+            if (key == null)
+            {
+                LogNullWarning("RemoveAttribute", "key");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.RemoveAttributeMessage.Create(_logger, key));
         }
 
         public override void RemoveTag(string tag)
         {
+            if (tag == null)
+            {
+                LogNullWarning("RemoveTag", "tag");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.RemoveTagMessage.Create(_logger, tag));
         }
 
         public override void RemoveTagsWithKey(string key)
         {
+            if (key == null)
+            {
+                LogNullWarning("RemoveTagsWithKey", "key");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.RemoveTagsWithKeyMessage.Create(_logger, key));
         }
 
         internal override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, Exception error = null)
         {
+            if (message == null)
+            {
+                LogNullWarning("PlatformLog", "message");
+                return;
+            }
+
             _worker.AddMessage(DdLogsProcessor.LogMessage.Create(_logger, level, message, attributes, error));
+        }
+
+        private void LogNullWarning(string methodName, string parameter)
+        {
+            UnityEngine.Debug.LogWarning($"[Datadog] {methodName} called with null parameter: {parameter}.");
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdWorkerProxyRum.cs
@@ -21,6 +21,12 @@ namespace Datadog.Unity.Rum
 
         public void StartView(string key, string name = null, Dictionary<string, object> attributes = null)
         {
+            if (key == null)
+            {
+                LogNullWarning("StartView", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("StartView",
                 () =>
                 {
@@ -30,12 +36,24 @@ namespace Datadog.Unity.Rum
 
         public void StopView(string key, Dictionary<string, object> attributes = null)
         {
+            if (key == null)
+            {
+                LogNullWarning("StopView", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("StopView",
                 () => { _worker.AddMessage(DdRumProcessor.StopViewMessage.Create(_dateProvider.Now, key, attributes)); });
         }
 
         public void AddAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
+            if (name == null)
+            {
+                LogNullWarning("AddAction", "name");
+                return;
+            }
+
             InternalHelpers.Wrap("AddAction",
                 () =>
                 {
@@ -46,6 +64,12 @@ namespace Datadog.Unity.Rum
 
         public void StartAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
+            if (name == null)
+            {
+                LogNullWarning("StartAction", "name");
+                return;
+            }
+
             InternalHelpers.Wrap("StartAction",
                 () =>
                 {
@@ -56,6 +80,12 @@ namespace Datadog.Unity.Rum
 
         public void StopAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
         {
+            if (name == null)
+            {
+                LogNullWarning("StopAction", "name");
+                return;
+            }
+
             InternalHelpers.Wrap("StopAction",
                 () =>
                 {
@@ -66,6 +96,12 @@ namespace Datadog.Unity.Rum
 
         public void AddError(Exception error, RumErrorSource source, Dictionary<string, object> attributes = null)
         {
+            if (error == null)
+            {
+                LogNullWarning("AddError", "error");
+                return;
+            }
+
             InternalHelpers.Wrap("StopView",
                 () =>
                 {
@@ -77,6 +113,18 @@ namespace Datadog.Unity.Rum
         public void StartResource(string key, RumHttpMethod httpMethod, string url,
             Dictionary<string, object> attributes = null)
         {
+            if (key == null)
+            {
+                LogNullWarning("StartResource", "key");
+                return;
+            }
+
+            if (url == null)
+            {
+                LogNullWarning("StartResource", "url");
+                return;
+            }
+
             InternalHelpers.Wrap("StartResource",
                 () =>
                 {
@@ -89,6 +137,12 @@ namespace Datadog.Unity.Rum
         public void StopResource(string key, RumResourceType kind, int? statusCode = null, long? size = null,
             Dictionary<string, object> attributes = null)
         {
+            if (key == null)
+            {
+                LogNullWarning("StopResource", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("StopResource",
                 () =>
                 {
@@ -101,6 +155,16 @@ namespace Datadog.Unity.Rum
         public void StopResourceWithError(string key, string errorType, string errorMessage,
             Dictionary<string, object> attributes = null)
         {
+            if (key == null)
+            {
+                LogNullWarning("StopResourceWithError", "key");
+                return;
+            }
+
+            // Default error message and type
+            errorType ??= "(unknown error type)";
+            errorMessage ??= "(no error message)";
+
             InternalHelpers.Wrap("StopResourceWithError",
                 () =>
                 {
@@ -124,18 +188,36 @@ namespace Datadog.Unity.Rum
 
         public void AddAttribute(string key, object value)
         {
+            if (key == null)
+            {
+                LogNullWarning("AddAttribute", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("AddAttribute",
                 () => { _worker.AddMessage(DdRumProcessor.AddAttributeMessage.Create(key, value)); });
         }
 
         public void RemoveAttribute(string key)
         {
+            if (key == null)
+            {
+                LogNullWarning("RemoveAttribute", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("RemoveAttribute",
                 () => { _worker.AddMessage(DdRumProcessor.RemoveAttributeMessage.Create(key)); });
         }
 
         public void AddFeatureFlagEvaluation(string key, object value)
         {
+            if (key == null)
+            {
+                LogNullWarning("AddFeatureFlagEvaluation", "key");
+                return;
+            }
+
             InternalHelpers.Wrap("AddFeatureFlagEvaluation",
                 () => { _worker.AddMessage(DdRumProcessor.AddFeatureFlagEvaluationMessage.Create(key, value)); });
         }
@@ -144,6 +226,11 @@ namespace Datadog.Unity.Rum
         {
             InternalHelpers.Wrap("StopSession",
                 () => { _worker.AddMessage(new DdRumProcessor.StopSessionMessage()); });
+        }
+
+        private void LogNullWarning(string methodName, string parameter)
+        {
+            UnityEngine.Debug.LogWarning($"[Datadog] {methodName} called with null parameter: {parameter}.");
         }
     }
 }


### PR DESCRIPTION
### What and why?

Certain values cannot or should not be null when passed to the Worker Proxy classes. While many of the system libraries check this, the logs they'll generate are too far from the call site to be useful. Move the checks further up into the worker proxies both for safety and also to show the warnings as close to the call site as possible.

refs: RUM-7947

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
