### PR TITLE
cherrypick: Backport conditional compilation in TrackedWebRequest to 1.3.x release line

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,7 @@ include:
 
 variables:
   # TODO: Detect unity location in script.
-  UNITY_HOME: "/Applications/Unity/Unity.app/Contents/"
-  UNITY_PATH: "$UNITY_HOME/MacOS/Unity"
+  UNITY_VERSION: "2022.3.54f1"
   UNITY_SUPPORT_PATH: "/Library/Application Support/Unity/config"
 
 
@@ -13,12 +12,17 @@ stages:
 
 .shared:
   install-dependencies:
-    - pip install saxonche
+    - echo 'Installing Unity Hub...'
+    - brew install --cask unity-hub
+    - echo 'Installing Unity Editor and Modules...'
+    # This can fail if Unity is already installed, so || true
+    - /Applications/Unity\ Hub.app/Contents/MacOS/Unity\ Hub -- --headless install --version "$UNITY_VERSION" --module ios android --architecture arm64 --childModules || true
   create-server-config:
     - vault login -method=aws -no-print
     - export UNITY_SERVER_CONFIG=$(vault kv get -field=config kv/aws/arn:aws:iam::486234852809:role/ci-dd-sdk-unity/server-config)
     - mkdir -p "$UNITY_SUPPORT_PATH"
-    - printf "%s\n" "$UNITY_SERVER_CONFIG" > "$UNITY_SUPPORT_PATH/services-config.json"
+    - printf "%s\n" "$UNITY_SERVER_CONFIG" > sudo tee "$UNITY_SUPPORT_PATH/services-config.json"
+    - sudo chmod -R +r "$UNITY_SUPPORT_PATH"
 
 unit-test:
   stage: unit-test
@@ -28,7 +32,9 @@ unit-test:
   script:
     - !reference [.shared, install-dependencies]
     - !reference [.shared, create-server-config]
-    - cd tools/scripts && python ./run_unit_test.py
+    - cd $CI_PROJECT_DIR/tools/scripts
+    - python3 -m venv venv && ./venv/bin/pip3 install -r requirements.txt
+    - ./venv/bin/python3 ./run_unit_test.py
   artifacts:
     when: always
     expire_in: "30 days"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include:
 
 variables:
   # TODO: Detect unity location in script.
-  UNITY_VERSION: "2022.3.54f1"
+  UNITY_VERSION: "2022.3.56f1"
   UNITY_SUPPORT_PATH: "/Library/Application Support/Unity/config"
 
 

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Conditionally compile portions of TrackedWebRequest for Unity 2021.x.
+* Conditionally compile portions of `TrackedWebRequest` for Unity 2021.x.
 
 ## 1.3.0
 

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Conditionally compile portions of TrackedWebRequest for Unity 2021.x
+
 ## 1.3.0
 
 * Added an option for detecting non-fatal ANRs on Android.

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Conditionally compile portions of TrackedWebRequest for Unity 2021.x
+* Conditionally compile portions of TrackedWebRequest for Unity 2021.x.
 
 ## 1.3.0
 

--- a/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace Datadog.Unity.Rum
@@ -294,7 +295,47 @@ namespace Datadog.Unity.Rum
         {
             return new DatadogTrackedWebRequest(UnityWebRequest.Head(uri));
         }
+#if UNITY_2021
+        public static DatadogTrackedWebRequest Post(string url, string postData)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(url, postData));
+        }
 
+        public static DatadogTrackedWebRequest Post(Uri uri, string postData)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(uri, postData));
+        }
+
+        public static DatadogTrackedWebRequest Post(string url, WWWForm form)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(url, form));
+        }
+
+        public static DatadogTrackedWebRequest Post(Uri uri, WWWForm form)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(uri, form));
+        }
+
+        public static DatadogTrackedWebRequest Post(string url, List<IMultipartFormSection> form)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(url, form));
+        }
+
+        public static DatadogTrackedWebRequest Post(Uri url, List<IMultipartFormSection> form)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(url, form));
+        }
+
+        public static DatadogTrackedWebRequest Post(string uri, List<IMultipartFormSection> form, byte[] boundary)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(uri, form, boundary));
+        }
+
+        public static DatadogTrackedWebRequest Post(Uri uri, List<IMultipartFormSection> form, byte[] boundary)
+        {
+            return new DatadogTrackedWebRequest(UnityWebRequest.Post(uri, form, boundary));
+        }
+#elif UNITY_2022_OR_NEWER
         public static DatadogTrackedWebRequest Post(string url, string postData, string contentType)
         {
             return new DatadogTrackedWebRequest(UnityWebRequest.Post(url, postData, contentType));
@@ -314,5 +355,6 @@ namespace Datadog.Unity.Rum
         {
             return new DatadogTrackedWebRequest(UnityWebRequest.PostWwwForm(uri, form));
         }
+#endif
     }
 }

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -1,0 +1,4 @@
+aiofiles==24.1.0
+GitPython==3.1.43
+PyGithub==2.5.0
+saxonche==12.5.0

--- a/tools/scripts/unity_helpers.py
+++ b/tools/scripts/unity_helpers.py
@@ -17,21 +17,29 @@ from typing import Optional
 UNITY_LICENSE_ERROR = "No valid Unity Editor license found. Please activate your license."
 LICENSE_STATE_RE = re.compile(r'License lease state: "\w+" with token: "(?P<token>.+)"')
 
+DEFAULT_UNITY_VERSION = "2022.3.55f1"
+
 def start_android_emulator():
     pass
+
+def get_unity_home():
+    unity_version = DEFAULT_UNITY_VERSION
+    if "UNITY_VERSION" in os.environ:
+        unity_version = os.environ["UNITY_VERSION"]
+    unity_home = f"/Applications/Unity/Hub/Editor/{unity_version}/Unity.app/Contents"
+    if "UNITY_HOME" in os.environ:
+        unity_home = os.environ["UNITY_HOME"]
+    return unity_home
 
 def get_unity_path(version: str = "2022.3.42f1"):
     if "UNITY_PATH" in os.environ and os.environ['UNITY_PATH'] is not None:
         return os.environ['UNITY_PATH']
     # REVISIT: Only get the Mac version for now
-    return f"/Applications/Unity/Hub/Editor/{version}/Unity.app/Contents/MacOS/Unity"
+    return f"{get_unity_home()}/MacOS/Unity"
 
 def get_license_server_path():
     # REVISIT: Only get the Mac version for now
-    unity_home = "/Applications/Unity/Hub/Editor/2022.3.42f1/Unity.app/Contents"
-    if "UNITY_HOME" in os.environ:
-        unity_home = os.environ["UNITY_HOME"]
-    return f"{unity_home}/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"
+    return f"{get_unity_home()}/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"
 
 async def _read_stream(stream, callback):
     while True:


### PR DESCRIPTION
### What and why?

We're going to backport 2021 support while to 1.3.x, as the next version of the SDK will likely be 2.0 because of the breaking changes involved with error reporting.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
