### PR TITLE
fix: Improve compatibility with Unity 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Build/
 samples/Datadog Sample/Assets/Resources/DatadogSettings.asset
 .vscode/settings.json
 *.keystore
+test_scaffolds/6000 LTS/.utmp

--- a/packages/Datadog.Unity/Editor/SymbolAssemblyBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/SymbolAssemblyBuildProcess.cs
@@ -88,6 +88,12 @@ namespace Datadog.Unity.Editor
                             _fileSystemProxy.CreateDirectory(mappingsDestPath);
                         }
 
+                        var originFileName = Path.GetFileName(mappingLocation);
+                        if (!string.IsNullOrEmpty(originFileName))
+                        {
+                            mappingsDestPath = Path.Join(path, originFileName);
+                        }
+
                         Debug.Log("Copying IL2CPP mappings file...");
                         _fileSystemProxy.CopyFile(mappingsSrcPath, mappingsDestPath);
                         foundFile = true;

--- a/packages/Datadog.Unity/Runtime/Il2CppErrorHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Il2CppErrorHelper.cs
@@ -85,14 +85,14 @@ namespace Datadog.Unity
 
         private static IntPtr GcHandleGetTarget(IntPtr gchandle)
         {
-            #if UNITY_2023
+            #if UNITY_2023_OR_NEWER || UNITY_6000_0_OR_NEWER
             return il2cpp_gchandle_get_target(gchandle);
             #else
             return il2cpp_gchandle_get_target(gchandle.ToInt32());
             #endif
         }
 
-#if UNITY_2023
+#if UNITY_2023_OR_NEWER || UNITY_6000_0_OR_NEWER
         [DllImport("__Internal")]
         private static extern IntPtr il2cpp_gchandle_get_target(IntPtr gchandle);
 


### PR DESCRIPTION
### What and why?

Native stack mapping was using pre-Unity 2023 APIs as they didn't correctly look for Unity 6.

Copying symbol files during Android build did not correctly take into account not having a full file name.

refs: #136, RUM-10267

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
