### PR TITLE
chore: Refactor Python scripts to fix linting errors, add mypy

### DIFF
--- a/tools/scripts/.gitignore
+++ b/tools/scripts/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .schemas/
 
 venv/
+.mypy_cache/

--- a/tools/scripts/android_helpers.py
+++ b/tools/scripts/android_helpers.py
@@ -8,7 +8,6 @@
 
 import datetime
 import io
-import json
 import os
 import re
 import subprocess
@@ -41,6 +40,7 @@ def _run(args: list[str], write_std_out: bool = False) -> str:
                                start_new_session=True,
                                universal_newlines=True)
     output = io.StringIO()
+    assert process.stdout
     for line in process.stdout:
         if write_std_out:
             print(line)
@@ -123,11 +123,12 @@ def launch_android_emulator(api_level: Optional[str], emulator_name: Optional[st
     elif api_level is not None:
         emulator_name = f"ci_emu_api_{api_level}"
         need_emulator_create = not _emulator_exists(emulator_name)
+    assert emulator_name is not None
 
     if need_emulator_create:
         package = f"system-images;android-{api_level};{AVD_TAG};{AVD_ABI}"
         if should_update:
-            print("Updating emlators with sdkmanager")
+            print("Updating emulators with sdkmanager")
             # TODO: pipe in "Yes"
             _run([_get_sdk_manager(), "--verbose", "emulator"], True)
 

--- a/tools/scripts/ios_helpers.py
+++ b/tools/scripts/ios_helpers.py
@@ -9,7 +9,6 @@
 import fileinput
 import io
 import json
-import selectors
 import subprocess
 from typing import Optional
 
@@ -30,6 +29,7 @@ def _xcrun(*args) -> str:
                                start_new_session=True,
                                universal_newlines=True)
     output = io.StringIO()
+    assert process.stdout
     for line in process.stdout:
         output.write(line)
 

--- a/tools/scripts/release_package.py
+++ b/tools/scripts/release_package.py
@@ -15,7 +15,7 @@ import shutil
 import git
 import github as gh
 
-import update_versions as uv
+import unity_dependencies
 
 REPO_ROOT = "../../"
 PACKAGE_LOCATION = f"{REPO_ROOT}packages/Datadog.Unity"
@@ -76,27 +76,12 @@ def _modify_assembly_info_version(dest: str, version: str):
             else:
                 print(line, end='')
 
-def _update_android_versions(version: str, github_token: str):
-    if version is None:
-        # Need to get the latest version from Github
-        gh_auth = gh.Auth.Token(github_token)
-        github = gh.Github(auth=gh_auth)
-
-        repo = github.get_repo("Datadog/dd-sdk-android")
-        release = repo.get_latest_release()
-        version = release.tag_name
-        print(f"Read latest Android SDK release as {version}")
-
-        github.close()
-
-    uv._update_android_version(version)
-
 def _update_native_sdk_versions(version: str, arg_ios_version:str, arg_android_version: str, native_sdk_versions_path: str):
-    ios_version = arg_ios_version or _get_current_ios_version()
-    android_version = arg_android_version or _get_current_android_version()
+    ios_version = arg_ios_version or unity_dependencies.get_current_ios_version()
+    android_version = arg_android_version or unity_dependencies.get_current_android_version()
 
     if not ios_version or not android_version:
-        print(f"Error: Some native versions could not be retrieved, aborting creation of {dest_native_sdk_versions}")
+        print(f"Error: Some native versions could not be retrieved, aborting creation of {native_sdk_versions_path}")
 
     if not os.path.exists(native_sdk_versions_path):
         lines = [
@@ -245,14 +230,14 @@ def main():
     _modify_assembly_info_version(PACKAGE_LOCATION, version)
     if args.ios_version:
         print(f'Updating iOS to version {args.ios_version} and rebuilding.')
-        uv._update_ios_version(args.ios_version)
+        unity_dependencies.update_ios_version(args.ios_version)
     if args.android_version:
         print(f'Updating Android to version {args.android_version} and rebuilding.')
-        _update_android_versions(args.android_version, github_token)
+        unity_dependencies.update_android_version(args.android_version)
 
     print(f"Updating NATIVE_SDK_VERSIONS.md...")
     dest_native_sdk_versions = os.path.join(REPO_ROOT, 'NATIVE_SDK_VERSIONS.md')
-    _update_native_sdk_versions(version, arg.ios_version, args.android_version, dest_native_sdk_versions)
+    _update_native_sdk_versions(version, args.ios_version, args.android_version, dest_native_sdk_versions)
 
     if not args.no_commit:
         print(f"Tagging source repo with {version}")

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -2,3 +2,4 @@ aiofiles==24.1.0
 GitPython==3.1.43
 PyGithub==2.5.0
 saxonche==12.5.0
+mypy==1.16.0

--- a/tools/scripts/run_integration_test.py
+++ b/tools/scripts/run_integration_test.py
@@ -74,6 +74,7 @@ async def main():
 
     # Find the IP address we started on
     local_server_address = None
+    assert mock_server.stdout
     for line in iter(mock_server.stdout.readline, ''):
         print(f'[mock_server] {line}', end='')
         if line.strip().startswith("* Running on"):

--- a/tools/scripts/unity_dependencies.py
+++ b/tools/scripts/unity_dependencies.py
@@ -1,0 +1,74 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2023-Present Datadog, Inc.
+# -----------------------------------------------------------
+
+# Helpers for reading from and writing to DatadogDepdendencies.xml, which keeps
+# track of the target SDK versions for Android and iOS
+
+import xml.etree.ElementTree as et
+
+UNITY_PLUGIN_PATH = "../../packages/Datadog.Unity/Plugins"
+UNITY_DEPENDENCIES_FILE = "../../packages/Datadog.Unity/Editor/DatadogDependencies.xml"
+
+def update_android_version(version: str):
+    tree = et.parse(UNITY_DEPENDENCIES_FILE)
+    root = tree.getroot()
+
+    for item in root.findall("./androidPackages/androidPackage"):
+        if "spec" in item.attrib and item.attrib['spec'].startswith("com.datadoghq"):
+            spec = item.attrib["spec"]
+            items = spec.split(":")
+            items[2] = version
+            print(f"Updating {items[1]} to {version}")
+            item.attrib["spec"] = str.join(":", items)
+
+    repository_element = root.find("./androidPackages/repositories")
+    if repository_element is not None:
+        for repo in repository_element.findall("./repository"):
+            if repo.text is not None  and "snapshots" in repo.text:
+                repository_element.remove(repo)
+
+    tree.write(UNITY_DEPENDENCIES_FILE)
+
+def update_ios_version(version: str):
+    tree = et.parse(UNITY_DEPENDENCIES_FILE)
+    root = tree.getroot()
+
+    for item in root.findall("./iosPods/iosPod"):
+        if "name" in item.attrib and item.attrib['name'].startswith("Datadog"):
+            item.attrib["version"] = version
+
+    tree.write(UNITY_DEPENDENCIES_FILE)
+
+def get_current_android_version():
+    tree = et.parse(UNITY_DEPENDENCIES_FILE)
+    root = tree.getroot()
+    version = None
+
+    for item in root.findall("./androidPackages/androidPackage"):
+        if "spec" in item.attrib and item.attrib['spec'].startswith("com.datadoghq"):
+            spec = item.attrib["spec"]
+            items = spec.split(":")
+            if version == None: 
+                version = items[2]
+            elif version != items[2]:
+                print(f"Warning: Found mismatching Android versions: {version} =/= {items[2]}")
+
+    return version
+
+def get_current_ios_version():
+    tree = et.parse(UNITY_DEPENDENCIES_FILE)
+    root = tree.getroot()
+    version = None
+
+    for item in root.findall("./iosPods/iosPod"):
+        if "name" in item.attrib and item.attrib['name'].startswith("Datadog"):
+            fileVersion = item.attrib["version"]
+            if version == None: 
+                version = fileVersion
+            elif version != fileVersion:
+                print(f"Warning: Found mismatching iOS versions: {version} =/= {fileVersion}")
+
+    return version

--- a/tools/scripts/unity_helpers.py
+++ b/tools/scripts/unity_helpers.py
@@ -10,9 +10,8 @@ import argparse
 import asyncio
 import os
 import re
-import subprocess
 import time
-from saxonche import PySaxonProcessor
+from saxonche import PySaxonProcessor # type: ignore
 from typing import Optional
 
 UNITY_HUB_PATH = "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
@@ -135,7 +134,7 @@ async def get_unity_license() -> Optional[str]:
 
 async def return_unity_license(token: str):
     cmd = f'{get_license_server_path()} --return-floating {token}'
-    process = await asyncio.create_subprocess_shell (cmd, env=env, stdout=asyncio.subprocess.STDOUT)
+    process = await asyncio.create_subprocess_shell (cmd, stdout=asyncio.subprocess.STDOUT)
 
     return_code = await process.wait()
 

--- a/tools/scripts/update_versions.py
+++ b/tools/scripts/update_versions.py
@@ -10,72 +10,9 @@
 # native libraries
 
 import argparse
-import xml.etree.ElementTree as et
 
-UNITY_PLUGIN_PATH = "../../packages/Datadog.Unity/Plugins"
-UNITY_DEPENDENCIES_FILE = "../../packages/Datadog.Unity/Editor/DatadogDependencies.xml"
+import unity_dependencies
 
-def _update_android_version(version: str):
-    tree = et.parse(UNITY_DEPENDENCIES_FILE)
-    root = tree.getroot()
-
-    for item in root.findall("./androidPackages/androidPackage"):
-        if "spec" in item.attrib and item.attrib['spec'].startswith("com.datadoghq"):
-            spec = item.attrib["spec"]
-            items = spec.split(":")
-            items[2] = version
-            print(f"Updating {items[1]} to {version}")
-            item.attrib["spec"] = str.join(":", items)
-
-    repository_element = root.find("./androidPackages/repositories")
-    if repository_element is not None:
-        for repo in repository_element.findall("./repository"):
-            if repo.text is not None  and "snapshots" in repo.text:
-                repository_element.remove(repo)
-
-    tree.write(UNITY_DEPENDENCIES_FILE)
-
-def _update_ios_version(version: str):
-    tree = et.parse(UNITY_DEPENDENCIES_FILE)
-    root = tree.getroot()
-
-    for item in root.findall("./iosPods/iosPod"):
-        if "name" in item.attrib and item.attrib['name'].startswith("Datadog"):
-            item.attrib["version"] = version
-
-    tree.write(UNITY_DEPENDENCIES_FILE)
-
-
-def _get_current_android_version():
-    tree = et.parse(UNITY_DEPENDENCIES_FILE)
-    root = tree.getroot()
-    version = None
-
-    for item in root.findall("./androidPackages/androidPackage"):
-        if "spec" in item.attrib and item.attrib['spec'].startswith("com.datadoghq"):
-            spec = item.attrib["spec"]
-            items = spec.split(":")
-            if version == None: 
-                version = items[2]
-            elif version != items[2]:
-                print(f"Warning: Found mismatching Android versions: {version} =/= {items[2]}")
-
-    return version
-
-def _get_current_ios_version():
-    tree = et.parse(UNITY_DEPENDENCIES_FILE)
-    root = tree.getroot()
-    version = None
-
-    for item in root.findall("./iosPods/iosPod"):
-        if "name" in item.attrib and item.attrib['name'].startswith("Datadog"):
-            fileVersion = item.attrib["version"]
-            if version == None: 
-                version = fileVersion
-            elif version != fileVersion:
-                print(f"Warning: Found mismatching iOS versions: {version} =/= {fileVersion}")
-
-    return version
 
 def main():
     arg_parser = argparse.ArgumentParser()
@@ -85,9 +22,9 @@ def main():
     args = arg_parser.parse_args()
 
     if args.platform == "android":
-        _update_android_version(args.version)
+        unity_dependencies.update_android_version(args.version)
     elif args.platform == "ios":
-        _update_ios_version(args.version)
+        unity_dependencies.update_ios_version(args.version)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Factor out functions that read/write DatadogDependencies.xml to new `unity_dependencies.py` file
- Add mypy as a dependency for tools/scripts
- Remove unused imports
- Annotate saxonche import to suppress import-untyped warning; it has no type stubs
- Fix a few missing/erroneous variable references
- Add asserts/conditionals where values of type `Optional[T]` were being used implicitly

### What and why?

This PR is a minor refactor of the internal scripts in `tools/scripts` intended to fix a handful of Python type errors. In addition to fixing those linting errors, it also adds mypy as a dependency for command-line type checking.

**mypy** is a commonly-used tool for linting and type-checking Python code. After installing dependencies (`pip install -r requirements.txt`) in a venv, you can run `mypy .` to validate that the python source rooted at the current directory has no detectable errors.

For context: I was getting acquainted with the `release_package.py` script, and I noticed that it calls a couple of undefined functions, `_get_current_ios_version` and `_get_current_android_version` (which are defined, unreferenced, in a separate file). This PR fixes that issue by establishing `unity_dependencies.py`, which abstracts access to the `DatadogDependencies.xml` file. I figured I'd clean up the remaining linter errors while I was at it.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
