### PR TITLE
fix: Remove erroneous access of DatadogTrackedWebReference.error

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed a bug that could cause a NullReferenceException when a `DatadogTrackedWebRequest` was canceled.
+* Fixed a bug that could cause a `NullReferenceException` when a `DatadogTrackedWebRequest` was canceled.
 
 ## 1.4.0
 

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Fixed a bug that could cause a NullReferenceException when a `DatadogTrackedWebRequest` was canceled.
+
 ## 1.4.0
 
 * Fix compatibility issues (crash) with Unity 6.


### PR DESCRIPTION
### What and why?

- Addresses: https://github.com/DataDog/dd-sdk-unity/issues/141

`DatadogTrackedWebRequest` is a drop-in replacement for `UnityWebRequest`: when a Unity developer uses our implementation, we defer to the underlying `UnityWebRequest` implementation, but we do some additional preprocessing (injecting trace context headers; starting a RUM resource) and postprocessing (stopping the RUM resource) when the request is sent.

Our postprocessing occurs in response to `UnityWebRequest.completed`: this is where we examine the state of the wrapped `UnityWebRequest` in order to determine which of these things we should do via the RUM SDK:

1. Flag the RUM request as completed successfully because we got a valid HTTP response
2. Flag the RUM request as stopped because we did not get a valid HTTP response
3. Flag the RUM request as stopped because the request was canceled prematurely
4. Record a telemetry error because something went wrong in our implementation

There's a bug with how we're handling case 3: we're successfully detecting that the request has been disposed (and therefore we have no underlying request state to access), but then we're erroneously accessing that nonexistent request state in the process of flagging the RUM request as stopped.

This change simply fixes that bug, while also adding a few descriptive comments to try and make the error-handling logic more self-evident. Code changes:

- Renamed local `tracingHeaders` to `tracingHeaderType`, for clarity
- Added comments to document the method implementation
- In the catch block for NullReferenceException, replaced erroneous use of `error` in the call to `StopResourceWithError`
	- Since we're reporting that the request was cancelled, using a hardcoded string (which simply elaborates on the "RequestDisposed" error type in human-readable terms) seems more appropriate than propagating the details of the `NullReferenceException` (which is just an implementation detail of our wrapper class and could be a red herring to the user)

Other notes:

- I don't particularly love the way that we're detecting premature disposal of the request - i.e. treating _any_ null dereference during the process of resolving the final request state as an indication that the request has been canceled... but since this is a hotfix for a recent release, I'm aiming to be conservative with this change.
- I briefly looked into adding tests to exercise this web-request-wrapping logic and verify that `DatadogTrackedWebRequest` makes the expected RUM SDK calls when the request is canceled, but it looks like we don't currently unit-test `SendWebRequest` itself (presumably because it would require mocking native SDK calls as well as the HTTP client).

refs: RUM-10397

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
