### PR TITLE
chore: Fix failing unit test AndroidCopyMappingCopiesFileIfExists

### DIFF
--- a/packages/Datadog.Unity/Tests/Editor/SymbolAssemblyBuildProcessTest.cs
+++ b/packages/Datadog.Unity/Tests/Editor/SymbolAssemblyBuildProcessTest.cs
@@ -186,7 +186,7 @@ namespace Datadog.Unity.Editor.Tests
             _process.AndroidCopyMappingFile(options, "fake-output-path");
 
             // Then
-            var expectedPath = Path.Join("fake-output-path", "symbols");
+            var expectedPath = Path.Join("fake-output-path", "symbols", "LineNumberMappings.json");
             _fileSystemProxy.Received(1).CopyFile(testPath, expectedPath);
         }
     }


### PR DESCRIPTION
### What and why?

This is a very tiny fix to a unit test that was failing due to what looks like an incorrectly-written assertion.

The test in question exercises `AndroidCopyMappingFile`, which looks for a `LineNumberMappings.json` file in a couple of locations relative to the root of the gradle project, then copies that file to `${gradleRoot}/symbols/LineNumberMappings.json`. The unit test incorrectly asserts that the file should be copied to a destination file path of `${gradleRoot}/symbols`.

Also, the original implementation was kind of hard to follow, and it seems like it contained a potential bug: `mappingsDestPath = Path.Join(path, originFileName)` would seem to set the output path to `${gradleRoot}/LineNumberMappings.json`, which doesn't make much sense given that the function creates a destination directory at `${gradleRoot}/symbols` just before overwriting the destination path. I've rewritten the function to fix this apparent bug and make the intended behavior clearer.

I'd like a sanity check, though: which of these is actually the "correct" path to copy this file to:

- `${gradleRoot}/LineNumberMappings.json` - i.e. where we've presumably been writing the file historically
- `${gradleRoot}/symbols/LineNumberMappings.json` - i.e. where the code seems to want to be writing it

The conventional expectation seems to be that this file goes in the root of the gradle project; I don't see anything to indicate that standard tools outside of our build pipeline look for it in a `symbols` subdirectory or anywhere else. I'm not sure how much it matters, since I'm a little hazy on what downstream tools/processes are meant to consume this file.

By the way, we weren't catching this test failure in CI because the unit test script invokes Unity twice, first for the `EditMode` tests and then for the `PlayMode` tests - and it [ignores the result of the first invocation](https://github.com/DataDog/dd-sdk-unity/blob/develop/tools/scripts/run_unit_test.py#L41-L51). I intend to fix this in a subsequent change, to address [RUM-10499](https://datadoghq.atlassian.net/browse/RUM-10499).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 


[RUM-10499]: https://datadoghq.atlassian.net/browse/RUM-10499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ