### PR TITLE
chore: Use latest EDM4U, resolve dependency version conflicts more loosely

### DIFF
--- a/packages/Datadog.Unity/package.json
+++ b/packages/Datadog.Unity/package.json
@@ -12,6 +12,7 @@
   "type": "library",
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.google.external-dependency-manager": "1.2.178"
-  }
+    "com.google.external-dependency-manager": "1.2.186"
+  },
+  "resolutionStrategy": "highestMinor"
 }


### PR DESCRIPTION
refs: RUM-10675

### What and why?

Per [RUM-10675](https://datadoghq.atlassian.net/browse/RUM-10675), our `package.json` file targets version `1.2.178` of EDM4U (`com.google.external-dependency-manager`). If a user's Unity project targets the same package at a different version (e.g. the latest, `1.2.186`), then UPM fails to resolve the dependency due to the mismatch.

This PR makes two changes to our Unity package's `package.json` file:

- It bumps the target version for EDM4U to the latest, `1.2.186`
    - UPM's `package.json` format _requires_ an explicit SemVer value; it does not support ranges or other constraints
- It specifies a `resolutionStrategy` of `highestMinor`, which will permit UPM to resolve any conflict on our package's dependencies by choosing the newer version, so long as the major version is the same (e.g. any EDM4U tagged `1.x.x` is fine; any Newtonsoft JSON tagged `3.x.x` is fine).

After making the change, I opened a clean copy of each of the four sample/test projects in their respective Unity versions, then verified that dependencies were installed successfully and that each project's `packages-lock.json` file showed version `1.2.186` of EDM4U.

Note that while some of these `<sample-project>/Packages/packages-lock.json` files are versioned in this repo, they are excluded by each project's `.gitignore`, and the canonical recommendation seems to be that `<project>/Packages/` should not be versioned, so I've elected to leave them as-is in this PR.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 


[RUM-10675]: https://datadoghq.atlassian.net/browse/RUM-10675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ