### PR TITLE
fix: Fix Android-only C# compile errors in DatadogAndroidRum.cs

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Fix C# compile errors that affected Android builds.
+
 ## 1.4.2
 
 * Add a new `ErrorInfo` class that can be used in place of `Exception` when passing errors to the `DatadogSdk` API.

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidRum.cs
@@ -67,7 +67,7 @@ namespace Datadog.Unity.Android
             // it instead stashes error type in a specially-named '_dd.error_type' attribute: if we have an error
             // type and it doesn't conflict with an existing value in the attributes, add it
             const string INTERNAL_ERROR_TYPE_ATTRIBUTE_NAME = "_dd.error_type";
-            if (!string.IsNullOrEmpty(error?.Type) && !attributes?.ContainsKey(INTERNAL_ERROR_TYPE_ATTRIBUTE_NAME))
+            if (!string.IsNullOrEmpty(error?.Type) && !attributes?.ContainsKey(INTERNAL_ERROR_TYPE_ATTRIBUTE_NAME) != true)
             {
                 attributes ??= new Dictionary<string, object>();
                 attributes[INTERNAL_ERROR_TYPE_ATTRIBUTE_NAME] = error.Type;
@@ -77,9 +77,9 @@ namespace Datadog.Unity.Android
             var javaAttributes = DatadogAndroidHelpers.DictionaryToJavaMap(attributes);
 
             // Attempt to resolve a native stack trace via IL2CPP, if applicable
-            if (error != null)
+            if (error != null && error.Exception != null)
             {
-                var nativeStackTrace = _androidPlatform.GetNativeStack(error);
+                var nativeStackTrace = _androidPlatform.GetNativeStack(error.Exception);
                 if (nativeStackTrace != null)
                 {
                     stack = nativeStackTrace;


### PR DESCRIPTION
refs: RUM-10780

### What and why?

Unfortunately, there are still Android-only build issues in the latest release. We released `1.4.2` today to fix a Gradle plugin version mismatch that was blocking Android builds. That release also included [this change](https://github.com/DataDog/dd-sdk-unity/pull/144), which introduced some C# compile errors that only appear in Android builds. Those errors should have been caught earlier, but they flew under the radar due to the same CI flaw that caused the Gradle plugin error to go undetected.

This PR fixes those errors, properly unblocking Android builds. Once this PR is merged, I will release it (and no other changes) as version `1.4.3`.

Worth noting: [the `package-android` CI job](https://gitlab.ddbuild.io/DataDog/dd-sdk-unity/-/jobs/1024258904) indeed succeeded and produced an `.apk`.

More details in [RUM-10780](https://datadoghq.atlassian.net/browse/RUM-10780).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 


[RUM-10780]: https://datadoghq.atlassian.net/browse/RUM-10780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ