### PR TITLE
feat!: Use deterministic trace sampling

### DIFF
--- a/packages/Datadog.Unity/Runtime/DeterministicTraceSampler.cs
+++ b/packages/Datadog.Unity/Runtime/DeterministicTraceSampler.cs
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+
+namespace Datadog.Unity
+{
+    /// <summary>
+    /// Implements deterministic sampling decisions based on request ID, using the same logic as the implementation in
+    /// dd-go.
+    /// </summary>
+    internal class DeterministicTraceSampler
+    {
+        private const ulong KnuthFactor = 1111111111111111111;
+        private const ulong MaxTraceID = ulong.MaxValue;
+
+        private readonly float _sampleRate;
+        private readonly ulong _threshold;
+
+        /// <param name="sampleRate">Fraction of traces that should be sampled; in the range [0..1].</param>
+        public DeterministicTraceSampler(float sampleRate)
+        {
+            _sampleRate = Math.Clamp(sampleRate, 0.0f, 1.0f);
+            _threshold = (ulong)((float)MaxTraceID * _sampleRate);
+        }
+
+        /// <summary>
+        /// Determines whether a trace with the given ID should be sampled.
+        /// </summary>
+        /// <param name="traceIdLow64">The lower 64 bits of the trace ID.</param>
+        /// <returns>True if the trace with the given ID should be sampled.</returns>
+        public bool SampleByTraceId(ulong traceIdLow64)
+        {
+            // Clamp to 1.0, always sampled
+            if (_sampleRate >= 1.0f)
+            {
+                return true;
+            }
+
+            // Clamp to 0.0, never sampled
+            if (_sampleRate <= 0.0f)
+            {
+                return false;
+            }
+
+            // In C#, ulong is always 64 bits, and integer overflow is handled by wrapping (i.e. we take the lower 64
+            // bits of the result value; the rest are truncated): we rely on this behavior for our Knuth multiplicative
+            // hash, so declare it unchecked to be explicit
+            unchecked
+            {
+                // We multiply our input value by a large magic constant, which gives us a pseudo-random value (lhs)
+                // that's distributed evenly across the range of uint64; and then we check it against a threshold
+                // representing X% of the uint64 range, where X is our configured sample rate
+                return traceIdLow64 * KnuthFactor < _threshold;
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/DeterministicTraceSampler.cs.meta
+++ b/packages/Datadog.Unity/Runtime/DeterministicTraceSampler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c9da47d8862c4346aa385649d1a8b81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
@@ -14,7 +14,7 @@ namespace Datadog.Unity.Rum
     internal class ResourceTrackingHelper
     {
         private readonly DatadogConfigurationOptions _options;
-        private readonly RateBasedSampler _traceSampler;
+        private readonly DeterministicTraceSampler _traceSampler;
         private readonly List<FirstPartyHost> _firstPartyHosts;
         private readonly TraceContextInjection _traceContextInjection;
 
@@ -23,7 +23,7 @@ namespace Datadog.Unity.Rum
         public ResourceTrackingHelper(DatadogConfigurationOptions options)
         {
             _options = options;
-            _traceSampler = new RateBasedSampler(options.TraceSampleRate / 100.0f);
+            _traceSampler = new DeterministicTraceSampler(options.TraceSampleRate / 100.0f);
             _firstPartyHosts = options.FirstPartyHosts
                 .Select(x => new FirstPartyHost(x.Host, x.TracingHeaderType))
                 .ToList();
@@ -32,11 +32,12 @@ namespace Datadog.Unity.Rum
 
         public TraceContext GenerateTraceContext()
         {
+            var traceId = TracingUuid.Create128Bit();
             return new TraceContext(
-                TracingUuid.Create128Bit(),
+                traceId,
                 TracingUuid.Create63Bit(),
                 null,
-                _traceSampler.Sample());
+                _traceSampler.SampleByTraceId(traceId.Low64));
         }
 
         internal void GenerateDatadogAttributes(TraceContext traceContext, Dictionary<string, object> attributes)

--- a/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/TracingUuid.cs
@@ -37,6 +37,8 @@ namespace Datadog.Unity.Rum
         private readonly ulong _high;
         private readonly ulong _low;
 
+        public ulong Low64 => _low;
+
         public TracingUuid(ulong high, ulong low)
         {
             _high = high;

--- a/packages/Datadog.Unity/Tests/DeterministicTraceSamplerTests.cs
+++ b/packages/Datadog.Unity/Tests/DeterministicTraceSamplerTests.cs
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using NUnit.Framework;
+
+namespace Datadog.Unity.Tests
+{
+    public class DeterministicTraceSamplerTests
+    {
+        [Test]
+        public void SampleByTraceId_WithZeroRate_ReturnsFalse()
+        {
+            // Given
+            var sampler = new DeterministicTraceSampler(0.0f);
+
+            // When
+            var result = sampler.SampleByTraceId(12345ul);
+
+            // Then
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void SampleByTraceId_WithFullRate_ReturnsTrue()
+        {
+            // Given
+            var sampler = new DeterministicTraceSampler(1.0f);
+
+            // When
+            var result = sampler.SampleByTraceId(12345ul);
+
+            // Then
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void SampleByTraceId_WithSameTraceId_ReturnsSameResult()
+        {
+            // Given
+            var sampler = new DeterministicTraceSampler(0.5f);
+            var traceId = 12345ul;
+
+            // When
+            var result1 = sampler.SampleByTraceId(traceId);
+            var result2 = sampler.SampleByTraceId(traceId);
+
+            // Then
+            Assert.AreEqual(result1, result2);
+        }
+
+        [Test]
+        public void SampleByTraceId_WithKnownValues_ReturnsExpectedResults()
+        {
+            // Test cases based on Knuth hashing behavior
+            var sampler = new DeterministicTraceSampler(0.2f); // 20% sampling rate
+
+            // These specific values should produce known results with the Knuth hasher
+            Assert.IsTrue(sampler.SampleByTraceId(1ul));
+            Assert.IsFalse(sampler.SampleByTraceId(ulong.MaxValue));
+        }
+
+        [Test]
+        public void SampleByTraceId_ClampsSampleRate()
+        {
+            // Given - rates outside valid range
+            var samplerNegative = new DeterministicTraceSampler(-0.5f);
+            var samplerAboveOne = new DeterministicTraceSampler(1.5f);
+
+            // When/Then - negative rate acts like 0
+            Assert.IsFalse(samplerNegative.SampleByTraceId(12345ul));
+
+            // When/Then - rate above 1 acts like 1
+            Assert.IsTrue(samplerAboveOne.SampleByTraceId(12345ul));
+        }
+
+        [Test]
+        public void SampleByTraceId_MatchesReferenceImplementation()
+        {
+            // Test cases generated using the dd-trace-go implementation
+            // Reference: https://go.dev/play/p/CUrDJtze8E_e
+            var testCases = new[]
+            {
+                (traceId: 5577006791947779410ul, sampleRate: 0.940509f, expected: true),
+                (traceId: 15352856648520921629ul, sampleRate: 0.437714f, expected: true),
+                (traceId: 3916589616287113937ul, sampleRate: 0.686823f, expected: true),
+                (traceId: 894385949183117216ul, sampleRate: 0.300912f, expected: true),
+                (traceId: 12156940908066221323ul, sampleRate: 0.46889f, expected: true),
+                (traceId: 9828766684487745566ul, sampleRate: 0.156519f, expected: false),
+                (traceId: 4751997750760398084ul, sampleRate: 0.81364f, expected: false),
+                (traceId: 11199607447739267382ul, sampleRate: 0.380657f, expected: false),
+                (traceId: 6263450610539110790ul, sampleRate: 0.218553f, expected: false),
+                (traceId: 1874068156324778273ul, sampleRate: 0.360871f, expected: false),
+            };
+
+            foreach (var (traceId, sampleRate, expected) in testCases)
+            {
+                // Given
+                var sampler = new DeterministicTraceSampler(sampleRate);
+
+                // When
+                var result = sampler.SampleByTraceId(traceId);
+
+                // Then
+                Assert.AreEqual(expected, result,
+                    $"TraceId {traceId} with rate {sampleRate:P} should be {expected} but was {result}");
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/DeterministicTraceSamplerTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/DeterministicTraceSamplerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b889e45da168946bda2b56ebdc4030ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
refs: RUM-7040

### What and why?

The PR makes the RUM implementation's sampling decisions for traces deterministic based on trace ID (while still respecting the configured trace sample rate), as described in [RUM-7040](https://datadoghq.atlassian.net/browse/RUM-7040).

Code changes:

- `DeterministicTraceSampler` implements the same Knuth-multiplicative-hash-based approach used in `dd-go`, giving us deterministic sampling decisions based on the trace ID
    - New unit tests exercise `SampleByTraceId()` and use the same set of test values as in `dd-sdk-flutter` to verify that this implementation produces the same results as our Dart and Go implementations
- `TracingUuid` now exposes its lower 64 bits _(scandalous!)_ via a `Low64` property, so that value can be directly examined when making trace sampling decisions
- `ResourceTrackingHelper` (used by the RUM implementation) now uses `DeterministicTraceSampler` instead of `RateBasedSampler`
    - `RateBasedSampler` is still used to make sampling decisions for logs

Staged for merge into `aforsythe/pending-v3`, a branch representing changes slated for release alongside v3 of the iOS and Android SDKs _(which will be v2 of the Unity SDK, unless we want to double-bump our version for consistency)_. `develop` will remain compatible with dd-sdk-unity v1.x.x until we merge `aforsythe/pending-v3` into `develop`.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 


[RUM-7040]: https://datadoghq.atlassian.net/browse/RUM-7040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ