### PR TITLE
feat!: Use TraceContextInjection.Sampled by default

### DIFF
--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -243,7 +243,7 @@ namespace Datadog.Unity
         public VitalsUpdateFrequency VitalsUpdateFrequency = VitalsUpdateFrequency.Average;
         public float SessionSampleRate = 100.0f;
         public float TraceSampleRate = 20.0f;
-        public TraceContextInjection TraceContextInjection = TraceContextInjection.All;
+        public TraceContextInjection TraceContextInjection = TraceContextInjection.Sampled;
         public List<FirstPartyHostOption> FirstPartyHosts = new ();
         public NonFatalAnrDetectionOption TrackNonFatalAnrs = NonFatalAnrDetectionOption.Disabled;
         public bool TrackNonFatalAppHangs = false;

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -242,7 +242,7 @@ namespace Datadog.Unity
         public bool AutomaticSceneTracking;
         public VitalsUpdateFrequency VitalsUpdateFrequency = VitalsUpdateFrequency.Average;
         public float SessionSampleRate = 100.0f;
-        public float TraceSampleRate = 20.0f;
+        public float TraceSampleRate = 100.0f;
         public TraceContextInjection TraceContextInjection = TraceContextInjection.Sampled;
         public List<FirstPartyHostOption> FirstPartyHosts = new ();
         public NonFatalAnrDetectionOption TrackNonFatalAnrs = NonFatalAnrDetectionOption.Disabled;

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -69,7 +69,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.AreEqual(VitalsUpdateFrequency.Average, options.VitalsUpdateFrequency);
             Assert.AreEqual(100.0f, options.SessionSampleRate);
             Assert.AreEqual(20.0f, options.TraceSampleRate);
-            Assert.AreEqual(TraceContextInjection.All, options.TraceContextInjection);
+            Assert.AreEqual(TraceContextInjection.Sampled, options.TraceContextInjection);
             Assert.AreEqual(20.0f, options.TelemetrySampleRate);
             Assert.AreEqual(NonFatalAnrDetectionOption.Disabled, options.TrackNonFatalAnrs);
             Assert.AreEqual(false, options.TrackNonFatalAppHangs);

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.IsTrue(options.AutomaticSceneTracking);
             Assert.AreEqual(VitalsUpdateFrequency.Average, options.VitalsUpdateFrequency);
             Assert.AreEqual(100.0f, options.SessionSampleRate);
-            Assert.AreEqual(20.0f, options.TraceSampleRate);
+            Assert.AreEqual(100.0f, options.TraceSampleRate);
             Assert.AreEqual(TraceContextInjection.Sampled, options.TraceContextInjection);
             Assert.AreEqual(20.0f, options.TelemetrySampleRate);
             Assert.AreEqual(NonFatalAnrDetectionOption.Disabled, options.TrackNonFatalAnrs);


### PR DESCRIPTION
refs: RUM-10731

### What and why?

This PR changes the default value for `TraceContextInjection` to `TraceContextInjection.Sampled`.

Staged for merge into `aforsythe/pending-v3` and tagged a breaking change, given that it changes the default behavior of the SDK.

#### Note re: code changes vs. asset changes

Changing the default `TraceContextInjection` value in code (as this PR does) will ensure that when the Datadog SDK is added to a new Unity project, its initial settings will use `TraceContextInjection.Sampled`.

However, if a project that already uses the Datadog SDK upgrades to the latest version, it will continue to use the existing settings that were previously serialized to its `DatadogSettings.asset` file: the project’s Datadog Settings will _not_ automatically update to use `TraceContextInjection.Sampled` as a result of the upgrade.

If we want this change to automatically apply to the `DatadogSettings` saved in existing projects, let me know and I can make that happen. However, I'm inclined to believe that it's more prudent to go with this simple fix, then communicate the rationale behind this change via release notes and give users the opportunity to make the change deliberately if they so choose.

#### Quick question re: default sample rate changes

To quote the description of [RUM-10731](https://datadoghq.atlassian.net/browse/RUM-10731):

> To align with the Browser SDK, as part of the Joint Sampling initiative, we will make the default setting for the network tracing to use `TraceContextInjection.Sampled` **_and use a default sampling rate of 100%_**

I'm not sure exactly what "use a default sampling rate of 100%" refers to- it could mean that we want the _trace_ sample rate to default to 100%, or perhaps it means the _session_ sample rate?

The [corresponding dd-sdk-flutter change](https://github.com/DataDog/dd-sdk-flutter/pull/772/files#diff-ba3dcf8df093fa9f17537cafc1fbd1c97acad2b1ead205e8e4c411d2262a26ebR87-R88) retains the existing defaults of 100% for sessions and 20% for traces, so I've done the same here.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 


[RUM-10731]: https://datadoghq.atlassian.net/browse/RUM-10731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ