### PR TITLE
fix: Include iOS post-build task iff build targets iOS

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
-#if UNITY_EDITOR_OSX
+#if UNITY_IOS
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
-#if UNITY_EDITOR_OSX
+#if UNITY_IOS
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
### What and why?

As reported in #161, our custom post-build task for iOS builds confuses these two preprocessor defines:

- `UNITY_IOS`: Defined when the Unity project is being built with iOS as the target platform
- `UNITY_EDITOR_OSX`: Defined when the Unity editor running the build is running on macOS

Currently, the post-build task is conditionally included based on the latter; this PR updates the task (and its associated tests) to use the former.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
