### PR TITLE
fix: Render DatadogInitialization.swift correctly

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -194,9 +194,11 @@ func initializeDatadog() {{
             {
                 sb.AppendLine();
                 sb.AppendLine("    CrashReporting.enable()");
-                sb.AppendLine("}");
-                sb.AppendLine();
             }
+
+            // Close `func initializeDatadog() {`
+            sb.AppendLine("}");
+            sb.AppendLine();
 
             File.WriteAllText(path, sb.ToString());
         }


### PR DESCRIPTION
### What and why?

As reported in #162, `iOS/PostBuildProcess.cs` contains a bug in the function that renders a `DatadogInitialization.swift` file based on the project's Datadog SDK settings: the top-level closing brace that matches `func initializeDatadog() {` is emitted conditionally, only when crash reporting is enabled.

This PR ensures that the closing brace is always written.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
