### PR TITLE
fix: Remove unused private constant FrameworkLocation

### DIFF
--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -22,7 +22,6 @@ namespace Datadog.Unity.Editor.iOS
     {
         private const string DatadogBlockStart = "// > Datadog Generated Block";
         private const string DatadogBlockEnd = "// < End Datadog Generated Block";
-        private static readonly string FrameworkLocation = "Packages/com.datadoghq.unity/Plugins/iOS";
 
         public int callbackOrder => 1;
 


### PR DESCRIPTION
### What and why?

As reported in #163, the C# compiler reports a pesky warning in `iOS/PostBuildProcess.cs`, because `PostBuildProcess` declares a private string constant, `FrameworkLocation`, which is never referenced.

This PR deletes the declaration of `FrameworkLocation`.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
