### PR TITLE
feat: Improve WebGL support for Logs / RUM

### DIFF
--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -141,6 +141,7 @@ namespace Datadog.Unity.Editor
             {
                 _options.FirstPartyHosts.Add(new FirstPartyHostOption());
             }
+
             EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.Space();
@@ -155,6 +156,7 @@ namespace Datadog.Unity.Editor
                     new GUIContent("Telemetry Sample Rate", DatadogHelpStrings.TelemetrySampleRateTooltip), _options.TelemetrySampleRate);
                 _options.TelemetrySampleRate = Math.Clamp(_options.TelemetrySampleRate, 0.0f, 100.0f);
             }
+
             EditorGUILayout.EndFoldoutHeaderGroup();
 
             EditorGUI.EndDisabledGroup();

--- a/packages/Datadog.Unity/Plugins/WebGL/DatadogCore.jslib
+++ b/packages/Datadog.Unity/Plugins/WebGL/DatadogCore.jslib
@@ -23,7 +23,7 @@ let ddCoreLib = {
         if (DD_RUM) {
             DD_RUM.setTrackingConsent(trackingConsent)
         }
-    }
+    },
 
     DDCore_SetUserProperties: function(properties) {
         let preopertiesStr = UTF8ToString(properties);

--- a/packages/Datadog.Unity/Plugins/WebGL/DatadogLogs.jslib
+++ b/packages/Datadog.Unity/Plugins/WebGL/DatadogLogs.jslib
@@ -8,11 +8,11 @@ let ddLogsLib = {
         let configStr = UTF8ToString(jsonConfiguration);
         let config = JSON.parse(configStr);
         this._activeLoggers = {}
-        DD_LOGS.init(config)
+        DD_LOGS.init(config);
     },
 
     DDLogs_CreateLogger: function (loggerId, configuration) {
-        let loggerIdStr = UTF8ToString(loggerId)
+        let loggerIdStr = UTF8ToString(loggerId);
         let configStr = UTF8ToString(configuration);
         let jsConfig = JSON.parse(configStr);
 
@@ -28,17 +28,17 @@ let ddLogsLib = {
         let attributesStr = UTF8ToString(attributes);
         let jsAttributes = JSON.parse(attributesStr) ?? {};
         for (var key in jsAttributes) {
-            DD_LOGS.setGlobalContextProperty(key, jsAttributes[key])
+            DD_LOGS.setGlobalContextProperty(key, jsAttributes[key]);
         }
     },
 
     DDLogs_RemoveGlobalAttribute: function(key) {
         let keyStr = UTF8ToString(key);
-        DD_LOGS.removeGlobalContextProperty(keyStr)
+        DD_LOGS.removeGlobalContextProperty(keyStr);
     },
 
     DDLogs_Log: function (loggerId, message, level, errorKind, errorMessage, errorStackTrace, attributes) {
-        let loggerIdStr = UTF8ToString(loggerId)
+        let loggerIdStr = UTF8ToString(loggerId);
         let logger = this._activeLoggers[loggerIdStr];
         if (!logger) {
             return;
@@ -63,29 +63,52 @@ let ddLogsLib = {
             UTF8ToString(message), jsAttributes, UTF8ToString(level), jsError);
     },
 
-    DDLogs_AddAttribute: function (loggerId, jsonAttribute) {
-        let loggerIdStr = UTF8ToString(loggerId)
+    DDLogs_AddTag: function (loggerId, tag, value) {
+        let loggerIdStr = UTF8ToString(loggerId);
         let logger = this._activeLoggers[loggerIdStr];
         if (!logger) {
             return;
         }
 
-        let attributesStr = UTF8ToString(jsonAttribute)
-        let attributes = JSON.parse(attributesStr)
+        let tagStr = UTF8ToString(tag);
+        let valueStr = UTF8ToString(value);
+        logger.addTag(tagStr, valueStr);
+    },
+
+    DDLogs_RemoveTagsWithKey: function (loggerId, tag) {
+        let loggerIdStr = UTF8ToString(loggerId);
+        let logger = this._activeLoggers[loggerIdStr];
+        if (!logger) {
+            return;
+        }
+
+        let tagStr = UTF8ToString(tag);
+        logger.removeTagsWithKey(tagStr);
+    },
+
+    DDLogs_AddAttribute: function (loggerId, jsonAttribute) {
+        let loggerIdStr = UTF8ToString(loggerId);
+        let logger = this._activeLoggers[loggerIdStr];
+        if (!logger) {
+            return;
+        }
+
+        let attributesStr = UTF8ToString(jsonAttribute);
+        let attributes = JSON.parse(attributesStr);
         for (var key in attributes) {
-            logger.setContextProperty(key, attributes[key])
+            logger.setContextProperty(key, attributes[key]);
         }
     },
 
     DDLogs_RemoveAttribute: function(loggerId, key) {
-        let loggerIdStr = UTF8ToString(loggerId)
+        let loggerIdStr = UTF8ToString(loggerId);
         let logger = this._activeLoggers[loggerIdStr];
         if (!logger) {
             return;
         }
 
-        let attributeKey = UTF8ToString(key)
-        logger.removeContextProperty(attributeKey)
+        let attributeKey = UTF8ToString(key);
+        logger.removeContextProperty(attributeKey);
     }
 };
 

--- a/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
+++ b/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
@@ -18,6 +18,10 @@ let ddRumLib = {
         };
 
         // Init internal helpers
+        this.extractEventTimestamp = (attributes) => {
+            return attributes['_dd.timestamp']
+        };
+
         this.getEventRelativeTime = (timestampMs) => {
             if (this._navigationStart === undefined) {
                 this._navigationStart = window.performance.timing.navigationStart;
@@ -55,22 +59,84 @@ let ddRumLib = {
         DD_RUM.removeGlobalContextProperty(key);
     },
 
-    DDRum_AddError: function(rawErrorKind, rawErrorMessage, rawErrorStackTrace, rawAttributes) {
+    DDRum_AddError: function(rawErrorKind, rawErrorMessage, rawErrorStackTrace, rawErrorSource, rawAttributes) {
+        let id = crypto.randomUUID();
         let attributesStr = UTF8ToString(rawAttributes);
         let attributes = JSON.parse(attributesStr) ?? {};
 
-        let jsError = null;
-        jsError = new Error(UTF8ToString(rawErrorMessage));
-        jsError.name = UTF8ToString(rawErrorKind);
-        jsError.stack = UTF8ToString(rawErrorStackTrace);
+        let timestampMs = this.extractEventTimestamp(attributes);
+        let eventTime = this.getEventRelativeTime(timestampMs);
 
-        let fingerprint = attributes['_dd.error.fingerprint'];
-        if (fingerprint) {
-            attributes.remove('_dd.error.fingerprint');
-            attributes['error.fingerprint'] = fingerprint;
+        let source = UTF8ToString(rawErrorSource);
+        let message = UTF8ToString(rawErrorMessage);
+        let errorType = UTF8ToString(rawErrorKind);
+        let stack = null;
+        if (rawErrorStackTrace) {
+            stack = UTF8ToString(rawErrorStackTrace);
         }
 
-        DD_RUM.addError(jsError, attributes);
+        let fingerprint = attributes['_dd.error.fingerprint'];
+
+        this.addEvent(
+            eventTime,
+            {
+                date: timestampMs,
+                type: 'error',
+                context: attributes,
+                error: {
+                    id,
+                    message,
+                    source,
+                    stack,
+                    type: errorType,
+                    fingerprint
+                },
+            },
+            {}
+        );
+    },
+
+    DDRum_AddResourceError: function(rawMethod, rawUrl, rawErrorKind, rawErrorMessage, rawErrorStackTrace, rawAttributes) {
+        let id = crypto.randomUUID();
+        let attributesStr = UTF8ToString(rawAttributes);
+        let attributes = JSON.parse(attributesStr) ?? {};
+
+        let timestampMs = this.extractEventTimestamp(attributes);
+        let eventTime = this.getEventRelativeTime(timestampMs);
+
+        let method = UTF8ToString(rawMethod);
+        let url = UTF8ToString(rawUrl);
+        let message = UTF8ToString(rawErrorMessage);
+        let errorType = UTF8ToString(rawErrorKind);
+        let stack = null;
+        if (rawErrorStackTrace) {
+            stack = UTF8ToString(rawErrorStackTrace);
+        }
+
+        let fingerprint = attributes['_dd.error.fingerprint'];
+
+        this.addEvent(
+            eventTime,
+            {
+                date: timestampMs,
+                type: 'error',
+                context: attributes,
+                error: {
+                    id,
+                    message,
+                    source: 'network',
+                    stack,
+                    type: errorType,
+                    fingerprint,
+                    resource: {
+                        method,
+                        url,
+                        status_code: 0,
+                    },
+                },
+            },
+            {},
+        );
     },
 
     DDRum_AddTiming: function(rawName) {
@@ -86,14 +152,14 @@ let ddRumLib = {
 
         let attributes = JSON.parse(attributesStr);
 
-        let timestampMs = attributes['_dd.timestamp'];
+        let timestampMs = this.extractEventTimestamp(attributes);
         let eventTime = this.getEventRelativeTime(timestampMs);
 
         this.addEvent(
             eventTime,
             {
                 type: 'action',
-                date: eventTime,
+                date: timestampMs,
                 context: attributes,
                 action: {
                     id,
@@ -105,8 +171,21 @@ let ddRumLib = {
             },
             {},
         );
+    },
 
-        //DD_RUM.addAction(name, attributes);
+    DDRum_AddResource: function(rawEvent) {
+        let eventStr = UTF8ToString(rawEvent);
+        let event = JSON.parse(eventStr);
+
+        let attributes = event.context;
+        let timestampMs = this.extractEventTimestamp(attributes);
+        let eventTime = this.getEventRelativeTime(timestampMs);
+
+        this.addEvent(
+            eventTime,
+            event,
+            {},
+        );
     },
 
     DDRum_AddFeatureFlagEvaluation: function(rawAttribute) {

--- a/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
+++ b/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
@@ -9,8 +9,37 @@ let ddRumLib = {
             return false;
         }
 
+        let self = this;
+        this._rumPlugin = {
+            name: 'DatadogUnityWeb',
+            onRumStart: function(options) {
+                self.addEvent = options.addEvent;
+            }
+        };
+
+        // Init internal helpers
+        this.getEventRelativeTime = (timestampMs) => {
+            if (this._navigationStart === undefined) {
+                this._navigationStart = window.performance.timing.navigationStart;
+            }
+
+            if (!this._navigationStart) {
+                return timestampMs;
+            }
+            return (timestampMs - this._navigationStart);
+        };
+
         let configStr = UTF8ToString(rawConfiguration);
         let config = JSON.parse(configStr);
+        // Replace regex strings in allowedTracingUrls with actual JS RegExp
+        config.allowedTracingUrls = config.allowedTracingUrls.map((val) => {
+            return {
+                match: RegExp(val.match),
+                propagatorTypes: val.propagatorTypes
+            };
+        });
+        config.plugins = [this._rumPlugin];
+
         DD_RUM.init(config);
         return true;
     },
@@ -49,12 +78,35 @@ let ddRumLib = {
         DD_RUM.addTiming(name);
     },
 
-    DDRum_AddAction: function(rawName, rawAttributes) {
+    DDRum_AddAction: function(rawType, rawName, rawAttributes) {
+        let id = crypto.randomUUID();
         let name = UTF8ToString(rawName);
+        let type = UTF8ToString(rawType);
         let attributesStr = UTF8ToString(rawAttributes);
+
         let attributes = JSON.parse(attributesStr);
 
-        DD_RUM.addAction(name, attributes);
+        let timestampMs = attributes['_dd.timestamp'];
+        let eventTime = this.getEventRelativeTime(timestampMs);
+
+        this.addEvent(
+            eventTime,
+            {
+                type: 'action',
+                date: eventTime,
+                context: attributes,
+                action: {
+                    id,
+                    type,
+                    target: {
+                        name
+                    }
+                }
+            },
+            {},
+        );
+
+        //DD_RUM.addAction(name, attributes);
     },
 
     DDRum_AddFeatureFlagEvaluation: function(rawAttribute) {
@@ -76,7 +128,7 @@ let ddRumLib = {
 
     DDRum_StopSession: function() {
         DD_RUM.stopSession();
-    },
+    }
 };
 
 mergeInto(LibraryManager.library, ddRumLib);

--- a/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
+++ b/packages/Datadog.Unity/Plugins/WebGL/DatadogRum.jslib
@@ -24,7 +24,12 @@ let ddRumLib = {
 
         this.getEventRelativeTime = (timestampMs) => {
             if (this._navigationStart === undefined) {
-                this._navigationStart = window.performance.timing.navigationStart;
+                if (window.performance.timeOrigin) {
+                    this._navigationStart = window.performance.timeOrigin;
+
+                } else {
+                    this._navigationStart = window.performance.timing.navigationStart;
+                }
             }
 
             if (!this._navigationStart) {

--- a/packages/Datadog.Unity/README.md
+++ b/packages/Datadog.Unity/README.md
@@ -18,7 +18,7 @@ openupm add com.datadoghq.unity
 
 1. Install [External Dependency Manager for Unity (EDM4U)](https://github.com/googlesamples/unity-jar-resolver). This can be done using [Open UPM](https://openupm.com/packages/com.google.external-dependency-manager/).
 
-2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package](https://github.com/DataDog/unity-package).  The package url is `https://github.com/DataDog/unity-package.git`.
+2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package](https://github.com/DataDog/unity-package). The package url is `https://github.com/DataDog/unity-package.git`.
 
 4. Configure your project to use [Gradle templates](https://docs.unity3d.com/Manual/gradle-templates.html), and enable both `Custom Main Template` and `Custom Gradle Properties Template`.
 

--- a/packages/Datadog.Unity/Runtime/ErrorInfo.cs
+++ b/packages/Datadog.Unity/Runtime/ErrorInfo.cs
@@ -46,7 +46,7 @@ namespace Datadog.Unity
             // Cache error details pulled from exception
             if (e != null)
             {
-                Type = e.GetType().Name ?? DefaultErrorType;
+                Type = e.GetType().FullName ?? DefaultErrorType;
                 Message = e.Message ?? string.Empty;
                 StackTrace = e.StackTrace;
             }

--- a/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DatadogTrackedWebRequest.cs
@@ -167,6 +167,11 @@ namespace Datadog.Unity.Rum
 
         public UnityWebRequestAsyncOperation SendWebRequest()
         {
+        // The browser SDK takes care of tracing requests for us, as UnityWebRequest uses fetch/XHR under the hood,
+        // so we can just directly pass through this call without any additional logic
+#if UNITY_WEBGL
+            return _innerRequest.SendWebRequest();
+#else
             // Determine if the request we're about to send should have tracing headers injected
             var trackingHelper = DatadogSdk.Instance.ResourceTrackingHelper;
             var tracingHeaderType = trackingHelper?.HeaderTypesForHost(_innerRequest.uri) ?? TracingHeaderType.None;
@@ -258,6 +263,7 @@ namespace Datadog.Unity.Rum
             };
 
             return operation;
+#endif
         }
 
         public string GetRequestHeader(string name)

--- a/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/DdRumProcessor.cs
@@ -11,7 +11,7 @@ namespace Datadog.Unity.Rum
 {
     internal class DdRumProcessor : IDatadogWorkerProcessor
     {
-        private const string DdRumTimestampAttribute = "_dd.timestamp";
+        internal const string DdRumTimestampAttribute = "_dd.timestamp";
 
         public const string RumTargetName = "rum";
 

--- a/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
@@ -224,6 +224,13 @@ namespace Datadog.Unity.Rum
 
         public bool IsMatch(Uri uri)
         {
+            // If the port is not the default port, it should be included in the regex and therefore
+            // should be included in the match request
+            if (!uri.IsDefaultPort)
+            {
+                return _regex.IsMatch($"{uri.Host}:{uri.Port}");
+            }
+
             return _regex.IsMatch(uri.Host);
         }
     }

--- a/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Rum/ResourceTrackingHelper.cs
@@ -158,7 +158,7 @@ namespace Datadog.Unity.Rum
             headers[DatadogHttpTracingHeaders.SamplingPriority] = traceContext.sampled ? "1" : "0";
         }
 
-        private static class DatadogAttributeKeys
+        internal static class DatadogAttributeKeys
         {
             public const string TraceId = "_dd.trace_id";
             public const string SpanId = "_dd.span_id";

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
@@ -44,7 +44,7 @@ namespace Datadog.Unity.WebGL
 
             if ((headerType & TracingHeaderType.TraceContext) != 0)
             {
-                result.Add("trace-context");
+                result.Add("tracecontext");
             }
 
             if ((headerType & TracingHeaderType.B3) != 0)

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
@@ -2,6 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using System.Collections.Generic;
+using Datadog.Unity.Rum;
+
 namespace Datadog.Unity.WebGL
 {
     internal static class DatadogWebGLHelpers
@@ -28,6 +31,52 @@ namespace Datadog.Unity.WebGL
                 TrackingConsent.NotGranted => "not-granted",
                 TrackingConsent.Granted => "granted",
                 _ => "not-granted"
+            };
+        }
+
+        internal static List<string> ToWebValue(this TracingHeaderType headerType)
+        {
+            var result = new List<string>();
+            if ((headerType & TracingHeaderType.Datadog) != 0)
+            {
+                result.Add("datadog");
+            }
+
+            if ((headerType & TracingHeaderType.TraceContext) != 0)
+            {
+                result.Add("trace-context");
+            }
+
+            if ((headerType & TracingHeaderType.B3) != 0)
+            {
+                result.Add("b3");
+            }
+
+            if ((headerType & TracingHeaderType.B3Multi) != 0)
+            {
+                result.Add("b3multi");
+            }
+
+            return result;
+        }
+
+        internal static string ToWebValue(this TraceContextInjection contextInjection)
+        {
+            return contextInjection switch
+            {
+                TraceContextInjection.All => "all",
+                _ => "sampled"
+            };
+        }
+
+        internal static string ToWebValue(this RumUserActionType actionType)
+        {
+            return actionType switch
+            {
+                RumUserActionType.Tap => "tap",
+                RumUserActionType.Scroll => "scroll",
+                RumUserActionType.Swipe => "swipe",
+                _ => "custom"
             };
         }
     }

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLHelpers.cs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using System;
 using System.Collections.Generic;
 using Datadog.Unity.Rum;
 
@@ -77,6 +78,50 @@ namespace Datadog.Unity.WebGL
                 RumUserActionType.Scroll => "scroll",
                 RumUserActionType.Swipe => "swipe",
                 _ => "custom"
+            };
+        }
+
+        internal static string ToWebValue(this RumResourceType resourceType)
+        {
+            return resourceType switch
+            {
+                RumResourceType.Image => "image",
+                RumResourceType.Xhr => "xhr",
+                RumResourceType.Beacon => "beacon",
+                RumResourceType.Fetch => "fetch",
+                RumResourceType.Media => "media",
+                RumResourceType.Font => "font",
+                RumResourceType.Document => "document",
+                RumResourceType.Css => "css",
+                RumResourceType.Js => "js",
+                RumResourceType.Native => "native",
+                _ => "other",
+            };
+        }
+
+        internal static string ToWebValue(this RumHttpMethod method)
+        {
+            return method switch
+            {
+                RumHttpMethod.Get => "GET",
+                RumHttpMethod.Post => "POST",
+                RumHttpMethod.Put => "PUT",
+                RumHttpMethod.Delete => "DELETE",
+                RumHttpMethod.Head => "HEAD",
+                RumHttpMethod.Patch => "PATCH",
+                _ => "get",
+            };
+        }
+
+        internal static string ToWebValue(this RumErrorSource source)
+        {
+            return source switch
+            {
+                RumErrorSource.Source => "source",
+                RumErrorSource.Network => "network",
+                RumErrorSource.WebView => "webview",
+                RumErrorSource.Console => "console",
+                _ => "custom",
             };
         }
     }

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLLogger.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLLogger.cs
@@ -22,17 +22,17 @@ namespace Datadog.Unity.WebGL
 
         public override void AddTag(string tag, string value = null)
         {
-            // Not implemented on Web
+            DDLogs_AddTag(_loggerId, tag, value);
         }
 
         public override void RemoveTag(string tag)
         {
-            // Not implemented on Web
+            DDLogs_RemoveTagsWithKey(_loggerId, tag);
         }
 
         public override void RemoveTagsWithKey(string key)
         {
-            // Not implemented on Web
+            DDLogs_RemoveTagsWithKey(_loggerId, key);
         }
 
         public override void AddAttribute(string key, object value)
@@ -90,6 +90,12 @@ namespace Datadog.Unity.WebGL
         [DllImport("__Internal")]
         private static extern void DDLogs_Log(string loggerId, string message, string level, string errorKind,
             string errorMessage, string errorStackTrace, string attributes);
+
+        [DllImport("__Internal")]
+        private static extern void DDLogs_AddTag(string loggerId, string tag, string value);
+
+        [DllImport("__Internal")]
+        private static extern void DDLogs_RemoveTagsWithKey(string loggerId, string tag);
 
         [DllImport("__Internal")]
         private static extern void DDLogs_AddAttribute(string loggerId, string jsonAttribute);

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
@@ -5,40 +5,25 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Datadog.Unity.Rum;
 using Newtonsoft.Json;
+using UnityEngine;
 
 namespace Datadog.Unity.WebGL
 {
     public class DatadogWebGLRum : IDdRumInternal
     {
-        private class AllowedTracingUrl
-        {
-            public string match { get; set; }
-            public List<string> propagatorTypes { get; set; }
-        }
+        // The DateProvider is needed here to get timestamps in nanoseconds for resource tracking. It can
+        // be used in Web safely only because web does not have multithreading.
+        private readonly IDateProvider _dateProvider;
+        private readonly ResourceTracker _resourceTracker = new ();
 
-        private class BrowerSdkConfig
+        public DatadogWebGLRum(IDateProvider dateProvider = null)
         {
-            public string applicationId { get; set; }
-            public string clientToken { get; set; }
-            public string site { get; set; }
-            public float sessionSampleRate { get; set; }
-            public float sessionReplaySampleRate { get; set; } = 0f;
-            public string service { get; set; }
-            public string env { get; set; }
-            public string version { get; set; }
-            public string proxy { get; set; }
-            public List<AllowedTracingUrl> allowedTracingUrls { get; set; }
-            public float traceSampleRate { get; set; }
-            public string traceContextInjection { get; set; }
-            public bool trackFrustrations { get; set; }
-            public bool trackViewsManually { get; set; } = true;
-            public bool trackResources { get; set; }
-            public bool trackLongTasks { get; set; }
-            public List<string> enableExperimentalFeatures { get; set; } = new List<string>();
+            _dateProvider = dateProvider ?? new DefaultDateProvider();
         }
 
         public void Init(DatadogConfigurationOptions options)
@@ -146,33 +131,86 @@ namespace Datadog.Unity.WebGL
                 error.Type,
                 error.Message,
                 error.StackTrace,
+                source.ToWebValue(),
                 attributesJson);
         }
 
-        public void StartResource(string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes = null)
+        public void StartResource(string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes)
         {
-            // Browser SDK does not support manual resource tracking
+            // Pull out the timestamp from attributes
+            var timestamp = _dateProvider.Now;
+            _resourceTracker.StartResource(timestamp, key, httpMethod, url, attributes);
         }
 
-        public void StopResource(string key, RumResourceType kind, int? statusCode = null, long? size = null,
+        public void StopResource(
+            string key,
+            RumResourceType kind,
+            int? statusCode = null,
+            long? size = null,
             Dictionary<string, object> attributes = null)
         {
-            // Browser SDK does not support manual resource tracking
+            var timestamp = _dateProvider.Now;
+            var resourceInfo = _resourceTracker.StopResource(timestamp, key, kind, statusCode, size, attributes);
+            if (resourceInfo == null)
+            {
+                return;
+            }
+
+            var uuid = Guid.NewGuid().ToString();
+
+            var dd = ExtractDdData(resourceInfo.Attributes);
+
+            // Create and serialize the RUM resource event.
+            // Because longs can't be sent to JavaScript easily, we put them in the attributes
+            // to be serialized as part of the JSON.
+            var date = new DateTimeOffset(timestamp).ToUnixTimeMilliseconds();
+            resourceInfo.Attributes[DdRumProcessor.DdRumTimestampAttribute] = date;
+
+            // Ticks are 100 ns each by standard .NET definition. This is the best resolution we can get
+            // prior to .NET 7 which adds DateTime.TotalNanoseconds.
+            var durationNs = (resourceInfo.StopTimestamp - resourceInfo.StartTimestamp).Value.Ticks * 100;
+            var resourceEvent = new WebResourceEvent()
+            {
+                date = date,
+                resource = new ()
+                {
+                    id = uuid,
+                    type = resourceInfo.Kind.ToWebValue(),
+                    url = resourceInfo.Url,
+                    duration = durationNs,
+                    method = resourceInfo.Method.ToWebValue(),
+                    status_code = resourceInfo.StatusCode,
+                    size = resourceInfo.Size,
+                },
+                dd = dd,
+                context = resourceInfo.Attributes,
+            };
+            var resourceEventJson = JsonConvert.SerializeObject(resourceEvent);
+
+            DDRum_AddResource(resourceEventJson);
         }
 
         public void StopResourceWithError(string key, string errorType, string errorMessage, Dictionary<string, object> attributes = null)
         {
-            // Browser SDK does not support manual resource tracking
+            StopResourceWithError(key, new ErrorInfo(errorType, errorMessage), attributes);
         }
 
         public void StopResource(string key, Exception error, Dictionary<string, object> attributes = null)
         {
-            // Browser SDK does not support manual resource tracking
+            StopResourceWithError(key, new ErrorInfo(error), attributes);
         }
 
         public void StopResourceWithError(string key, ErrorInfo error, Dictionary<string, object> attributes = null)
         {
-            // Browser SDK does not support manual resource tracking
+            var timestamp = _dateProvider.Now;
+            var resourceInfo = _resourceTracker.StopResourceWithError(timestamp, key, error.Type, error.Message, attributes);
+            if (resourceInfo == null)
+            {
+                return;
+            }
+
+            var attributesJson = JsonConvert.SerializeObject(resourceInfo.Attributes);
+            DDRum_AddResourceError(resourceInfo.Method.ToWebValue(), resourceInfo.Url, resourceInfo.ErrorType, resourceInfo.ErrorMessage, error.StackTrace, attributesJson);
         }
 
         public void AddAttribute(string key, object value)
@@ -230,6 +268,90 @@ namespace Datadog.Unity.WebGL
             // Browser SDK does not support frame rate tracking
         }
 
+        private WebResourceEventDdData ExtractDdData(Dictionary<string, object> attributes)
+        {
+            if (attributes == null)
+            {
+                return null;
+            }
+
+            attributes.TryGetValue(ResourceTrackingHelper.DatadogAttributeKeys.TraceId, out var traceId);
+            attributes.Remove(ResourceTrackingHelper.DatadogAttributeKeys.TraceId);
+            attributes.TryGetValue(ResourceTrackingHelper.DatadogAttributeKeys.SpanId, out var spanId);
+            attributes.Remove(ResourceTrackingHelper.DatadogAttributeKeys.SpanId);
+            attributes.TryGetValue(ResourceTrackingHelper.DatadogAttributeKeys.RulePsr, out var rulePsr);
+            attributes.Remove(ResourceTrackingHelper.DatadogAttributeKeys.RulePsr);
+
+            return new ()
+            {
+                trace_id = traceId as string,
+                span_id = spanId as string,
+                rule_psr = (float?)rulePsr,
+                discarded = false,
+            };
+        }
+
+        // Disable warning about fields being lower case to match the JSON we need to produce for web
+#pragma warning disable SA1307 // Public fields must begin with upper-case letter
+#pragma warning disable SA1310 // Field names must not contain underscore
+        private class AllowedTracingUrl
+        {
+            public string match { get; set; }
+            public List<string> propagatorTypes { get; set; }
+        }
+
+        private class BrowerSdkConfig
+        {
+            public string applicationId { get; set; }
+            public string clientToken { get; set; }
+            public string site { get; set; }
+            public float sessionSampleRate { get; set; }
+            public float sessionReplaySampleRate { get; set; } = 0f;
+            public string service { get; set; }
+            public string env { get; set; }
+            public string version { get; set; }
+            public string proxy { get; set; }
+            public List<AllowedTracingUrl> allowedTracingUrls { get; set; }
+            public float traceSampleRate { get; set; }
+            public string traceContextInjection { get; set; }
+            public bool trackFrustrations { get; set; }
+            public bool trackViewsManually { get; set; } = true;
+            public bool trackResources { get; set; }
+            public bool trackLongTasks { get; set; }
+            public List<string> enableExperimentalFeatures { get; set; } = new List<string>();
+        }
+
+        private class WebResourceEvent
+        {
+            public long date { get; set; }
+            public string type { get; set; } = "resource";
+            public WebResourceEventData resource { get; set; }
+            public Dictionary<string, object> context { get; set; }
+            public WebResourceEventDdData dd { get; set; }
+        }
+
+        private class WebResourceEventDdData
+        {
+            public string trace_id { get; set; }
+            public string span_id { get; set; }
+            public float? rule_psr { get; set; }
+            public bool discarded { get; set; }
+        }
+
+        private class WebResourceEventData
+        {
+            public string id { get; set; }
+            public string type { get; set; }
+            public string url { get; set; }
+            public long duration { get; set; }
+            public string method { get; set; }
+
+            public int? status_code { get; set; }
+            public long? size { get; set; }
+        }
+#pragma warning restore SA1310
+#pragma warning restore SA1307
+
         [DllImport("__Internal")]
         private static extern bool DDRum_InitRum(string configurationJson);
 
@@ -246,7 +368,14 @@ namespace Datadog.Unity.WebGL
         private static extern void DDRum_AddAction(string type, string name, string attributeJson);
 
         [DllImport("__Internal")]
-        private static extern void DDRum_AddError(string errorKind, string errorMessage, string errorStackTrace, string attributeJson);
+        private static extern void DDRum_AddError(string errorKind, string errorMessage, string errorStackTrace, string errorSource, string attributeJson);
+
+        [DllImport("__Internal")]
+        private static extern void DDRum_AddResource(string resourceEventJson);
+
+        [DllImport("__Internal")]
+        private static extern void DDRum_AddResourceError(string method, string url, string errorKind,
+            string errorMessage, string errorStackTrace, string attributes);
 
         [DllImport("__Internal")]
         private static extern void DDRum_AddFeatureFlagEvaluation(string attributeJson);

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Datadog.Unity.Rum;
 using Newtonsoft.Json;
 
@@ -12,6 +14,12 @@ namespace Datadog.Unity.WebGL
 {
     public class DatadogWebGLRum : IDdRumInternal
     {
+        private class AllowedTracingUrl
+        {
+            public string match { get; set; }
+            public List<string> propagatorTypes { get; set; }
+        }
+
         private class BrowerSdkConfig
         {
             public string applicationId { get; set; }
@@ -23,7 +31,7 @@ namespace Datadog.Unity.WebGL
             public string env { get; set; }
             public string version { get; set; }
             public string proxy { get; set; }
-            // TODO: allowedTracingUrls
+            public List<AllowedTracingUrl> allowedTracingUrls { get; set; }
             public float traceSampleRate { get; set; }
             public string traceContextInjection { get; set; }
             public bool trackFrustrations { get; set; }
@@ -35,6 +43,17 @@ namespace Datadog.Unity.WebGL
 
         public void Init(DatadogConfigurationOptions options)
         {
+            var allowedTracingUrls = options.FirstPartyHosts.Select((e) =>
+            {
+                // Match http and https, and any subdomains (consistent with other platforms)
+                var hostRegex = $@"^http[s]?:\/\/(.*\.)*{Regex.Escape(e.Host)}\/";
+                return new AllowedTracingUrl()
+                {
+                    match = e.Host,
+                    propagatorTypes = e.TracingHeaderType.ToWebValue(),
+                };
+            }).ToList();
+
             var browserSdkConfig = new BrowerSdkConfig
             {
                 applicationId = options.RumApplicationId,
@@ -50,8 +69,11 @@ namespace Datadog.Unity.WebGL
                 trackResources = true,
                 trackLongTasks = true,
                 proxy = options.CustomEndpoint,
+                allowedTracingUrls = allowedTracingUrls,
+                traceContextInjection = options.TraceContextInjection.ToWebValue(),
             };
             var configurationJson = JsonConvert.SerializeObject(browserSdkConfig);
+
             // TODO: Check the return value of this
             DDRum_InitRum(configurationJson);
         }
@@ -92,6 +114,7 @@ namespace Datadog.Unity.WebGL
             }
 
             DDRum_AddAction(
+                type.ToWebValue(),
                 name,
                 attributesJson);
         }
@@ -220,7 +243,7 @@ namespace Datadog.Unity.WebGL
         private static extern void DDRum_AddTiming(string name);
 
         [DllImport("__Internal")]
-        private static extern void DDRum_AddAction(string name, string attributeJson);
+        private static extern void DDRum_AddAction(string type, string name, string attributeJson);
 
         [DllImport("__Internal")]
         private static extern void DDRum_AddError(string errorKind, string errorMessage, string errorStackTrace, string attributeJson);

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
@@ -147,6 +147,11 @@ namespace Datadog.Unity.WebGL
             // Browser SDK does not support manual resource tracking
         }
 
+        public void StopResourceWithError(string key, ErrorInfo error, Dictionary<string, object> attributes = null)
+        {
+            // Browser SDK does not support manual resource tracking
+        }
+
         public void AddAttribute(string key, object value)
         {
             if (key == null)

--- a/packages/Datadog.Unity/Runtime/WebGL/ResourceTracker.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/ResourceTracker.cs
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using Datadog.Unity.Rum;
+using UnityEngine;
+
+namespace Datadog.Unity.WebGL
+{
+    /// <summary>
+    /// Tracks resource start and stop calls for the Web platform, to properly
+    /// send resource events to the Browser SDK.
+    /// </summary>
+    public class ResourceTracker
+    {
+        private readonly Dictionary<string, ResourceInfo> _activeResources = new ();
+
+        public void StartResource(DateTime timestamp, string key, RumHttpMethod httpMethod, string url, Dictionary<string, object> attributes)
+        {
+            if (_activeResources.ContainsKey(key))
+            {
+                return;
+            }
+
+            var resourceInfo = new ResourceInfo(timestamp, key, httpMethod, url, attributes);
+            _activeResources.Add(key, resourceInfo);
+        }
+
+        public ResourceInfo StopResource(
+            DateTime timestamp,
+            string key,
+            RumResourceType kind,
+            int? statusCode = null,
+            long? size = null,
+            Dictionary<string, object> attributes = null)
+        {
+            if (!_activeResources.ContainsKey(key))
+            {
+                return null;
+            }
+
+            var resourceInfo = _activeResources[key];
+            _activeResources.Remove(key);
+            resourceInfo.Stop(timestamp, kind, statusCode, size, attributes);
+
+            return resourceInfo;
+        }
+
+        public ResourceInfo StopResourceWithError(
+            DateTime timestamp,
+            string key,
+            string errorType,
+            string errorMessage,
+            Dictionary<string, object> attributes = null)
+        {
+            if (!_activeResources.ContainsKey(key))
+            {
+                return null;
+            }
+
+            var resourceInfo = _activeResources[key];
+            _activeResources.Remove(key);
+            resourceInfo.StopWithError(timestamp, errorType, errorMessage, attributes);
+
+            return resourceInfo;
+        }
+
+        public class ResourceInfo
+        {
+            public DateTime StartTimestamp { get; private set; }
+
+            public DateTime? StopTimestamp { get; private set; }
+
+            public string Key { get; private set; }
+
+            public RumHttpMethod Method { get; private set; }
+
+            public string Url { get; private set; }
+
+            public Dictionary<string, object> Attributes { get; private set; }
+
+            public RumResourceType Kind { get; private set; } = RumResourceType.Other;
+
+            public int? StatusCode { get; private set; }
+
+            public long? Size { get; private set; }
+
+            public string ErrorType { get; private set; }
+
+            public string ErrorMessage { get; private set; }
+
+            public ResourceInfo(
+                DateTime timestamp,
+                string key,
+                RumHttpMethod rumHttpMethod,
+                string url,
+                Dictionary<string, object> attributes)
+            {
+                StartTimestamp = timestamp;
+                Key = key;
+                Method = rumHttpMethod;
+                Url = url;
+                Attributes = attributes ?? new Dictionary<string, object>();
+            }
+
+            public void Stop(
+                DateTime timestamp,
+                RumResourceType kind,
+                int? statusCode = null,
+                long? size = null,
+                Dictionary<string, object> attributes = null)
+            {
+                StopTimestamp = timestamp;
+                Kind = kind;
+                StatusCode = statusCode;
+                Size = size;
+                if (attributes != null)
+                {
+                    MergeAttributes(attributes);
+                }
+            }
+
+            public void StopWithError(
+                DateTime timestamp,
+                string errorType,
+                string errorMessage,
+                Dictionary<string, object> attributes = null)
+            {
+                StopTimestamp = timestamp;
+                ErrorType = errorType;
+                ErrorMessage = errorMessage;
+                if (attributes != null)
+                {
+                    MergeAttributes(attributes);
+                }
+            }
+
+            private void MergeAttributes(Dictionary<string, object> source)
+            {
+                foreach (var kvp in source)
+                {
+                    Attributes[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/WebGL/ResourceTracker.cs.meta
+++ b/packages/Datadog.Unity/Runtime/WebGL/ResourceTracker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 86b3290b79cc412f97e8ff6e1772a36d
+timeCreated: 1756473456

--- a/packages/Datadog.Unity/Tests/ErrorInfoTests.cs
+++ b/packages/Datadog.Unity/Tests/ErrorInfoTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Unity.Tests
 
             Assert.NotNull(err);
             Assert.NotNull(err.Exception);
-            Assert.AreEqual("InvalidCastException", err.Type);
+            Assert.AreEqual("System.InvalidCastException", err.Type);
             Assert.AreEqual("very bad cast", err.Message);
             StringAssert.Contains("at Datadog.Unity.Tests.ErrorInfoTests.FunctionThatThrows () [0x", err.StackTrace);
         }

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -55,10 +55,10 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", debugLog.ServiceName);
+#endif
             Assert.Contains("tag1:tag-value", debugLog.Tags);
             Assert.Contains("tag1:second-value", debugLog.Tags);
             Assert.Contains("my-tag", debugLog.Tags);
-#endif
             Assert.AreEqual("not_silent_logger", debugLog.LoggerName);
             Assert.AreEqual("string", debugLog.RawJson["stringAttribute"]);
 
@@ -67,10 +67,10 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("info message", infoLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", infoLog.ServiceName);
+#endif
             Assert.Contains("tag1:tag-value", infoLog.Tags);
             Assert.Contains("tag1:second-value", debugLog.Tags);
             CollectionAssert.DoesNotContain(infoLog.Tags, "my-tag");
-#endif
             Assert.AreEqual("string value", (string)infoLog.RawJson["logger-attribute1"]);
             Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
             Assert.AreEqual(1255, (long)infoLog.RawJson["global-attribute-2"]);
@@ -84,10 +84,10 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("warn message", warnLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", warnLog.ServiceName);
+#endif
             Assert.Contains("tag1:tag-value", warnLog.Tags);
             Assert.Contains("tag1:second-value", debugLog.Tags);
             CollectionAssert.DoesNotContain(warnLog.Tags, "my-tag");
-#endif
             Assert.AreEqual("string value", (string)warnLog.RawJson["logger-attribute1"]);
             Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
             Assert.AreEqual(1255, (long)infoLog.RawJson["global-attribute-2"]);
@@ -99,10 +99,10 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("error message", errorLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", errorLog.ServiceName);
+#endif
             CollectionAssert.DoesNotContain(errorLog.Tags, "tag1:tag-value");
             CollectionAssert.DoesNotContain(errorLog.Tags, "tag1:second-value");
             CollectionAssert.DoesNotContain(errorLog.Tags, "my-tag");
-#endif
             Assert.IsFalse(errorLog.RawJson.ContainsKey("logger-attribute1"));
             Assert.AreEqual(1000, (long)errorLog.RawJson["logger-attribute2"]);
             Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
@@ -119,10 +119,10 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("Warning: this error occurred", exceptionLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", exceptionLog.ServiceName);
+#endif
             CollectionAssert.DoesNotContain(exceptionLog.Tags, "tag1:tag-value");
             CollectionAssert.DoesNotContain(exceptionLog.Tags, "tag1:second-value");
             CollectionAssert.DoesNotContain(exceptionLog.Tags, "my-tag");
-#endif
             Assert.AreEqual("System.InvalidOperationException", exceptionLog.ErrorKind);
             Assert.IsFalse(exceptionLog.RawJson.ContainsKey("logger-attribute1"));
             Assert.AreEqual(1000, (long)exceptionLog.RawJson["logger-attribute2"]);

--- a/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
+++ b/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
@@ -9,7 +9,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using System.Web;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -64,7 +63,7 @@ namespace Datadog.Unity.Tests.Integration
                     }
                     catch (Exception e)
                     {
-                        Debug.Log($"Caught an exception deserializing response: {e}.");
+                        Debug.Log($"Caught an exception deserializing response: {e}\n{e.StackTrace}");
                     }
                 }
 

--- a/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumResourceEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumResourceEventDecoder.cs
@@ -23,6 +23,10 @@ namespace Datadog.Unity.Tests.Integration.Rum.Decoders
 
         public int Size => jsonGetProp<int>(rumEvent, "resource.size");
 
+        public string TraceId => jsonGetProp<string>(rumEvent, "_dd.trace_id");
+
+        public string SpanId => jsonGetProp<string>(rumEvent, "_dd.span_id");
+
         public RumResourceEventDecoder(JObject rawJson)
             : base(rawJson)
         {

--- a/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumSessionDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumSessionDecoder.cs
@@ -4,6 +4,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Unity.Rum;
+using UnityEngine;
 
 namespace Datadog.Unity.Tests.Integration.Rum.Decoders
 {
@@ -35,21 +37,32 @@ namespace Datadog.Unity.Tests.Integration.Rum.Decoders
             // Add other events to their view visits
             foreach (var rumEvent in orderedEvents.Where(e => e is not RumViewEventDecoder))
             {
-                RumViewVisit visit;
-                switch (rumEvent)
+                string viewId = rumEvent switch
                 {
-                    case RumActionEventDecoder actionEvent:
-                        visit = viewVisitsById[actionEvent.ViewInfo.Id];
-                        visit?.ActionEvents.Add(actionEvent);
-                        break;
-                    case RumErrorEventDecoder errorEvent:
-                        visit = viewVisitsById[errorEvent.ViewInfo.Id];
-                        visit?.ErrorEvents.Add(errorEvent);
-                        break;
-                    case RumResourceEventDecoder resourceEvent:
-                        visit = viewVisitsById[resourceEvent.ViewInfo.Id];
-                        visit?.ResourceEvents.Add(resourceEvent);
-                        break;
+                    RumActionEventDecoder actionEvent => actionEvent.ViewInfo.Id,
+                    RumErrorEventDecoder errorEvent => errorEvent.ViewInfo.Id,
+                    RumResourceEventDecoder resourceEvent => resourceEvent.ViewInfo.Id,
+                    _ => null
+                };
+
+                if (viewId != null && viewVisitsById.TryGetValue(viewId, out var visit))
+                {
+                    switch (rumEvent)
+                    {
+                        case RumActionEventDecoder actionEvent:
+                            visit.ActionEvents.Add(actionEvent);
+                            break;
+                        case RumErrorEventDecoder errorEvent:
+                            visit.ErrorEvents.Add(errorEvent);
+                            break;
+                        case RumResourceEventDecoder resourceEvent:
+                            visit.ResourceEvents.Add(resourceEvent);
+                            break;
+                    }
+                }
+                else
+                {
+                    Debug.Log($"Could not find view for event {rumEvent} with viewId {viewId}! Skipping!");
                 }
             }
 

--- a/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
@@ -61,11 +61,7 @@ namespace Datadog.Unity.Tests.Integration.Rum
 
             Assert.AreEqual(1, firstVisit.ActionEvents.Count);
             var firstAction = firstVisit.ActionEvents[0];
-#if UNITY_WEBGL
-            Assert.AreEqual("custom", firstAction.ActionType);
-#else
             Assert.AreEqual("tap", firstAction.ActionType);
-#endif
             Assert.AreEqual("Tapped Download", firstAction.ActionName);
             Assert.AreEqual(1, firstAction.Attributes["onboarding_stage"].Value<int>());
 
@@ -90,11 +86,9 @@ namespace Datadog.Unity.Tests.Integration.Rum
             Assert.AreEqual(1, secondVisit.ErrorEvents.Count);
             var errorEvent = secondVisit.ErrorEvents[0];
 
-            // Android resources don't have ErrorType, web doesn't contain the namespace
-#if UNITY_IOS
+            // Android resources don't have ErrorType
+#if UNITY_IOS || UNITY_WEBGL
             Assert.AreEqual("System.Exception", errorEvent.ErrorType);
-#elif UNITY_WEBGL
-            Assert.AreEqual("Exception", errorEvent.ErrorType);
 #endif
 
             Assert.AreEqual("Test Exception", errorEvent.Message);
@@ -109,11 +103,7 @@ namespace Datadog.Unity.Tests.Integration.Rum
 
             Assert.AreEqual(1, secondVisit.ActionEvents.Count);
             var secondAction = secondVisit.ActionEvents[0];
-#if UNITY_WEBGL
-            Assert.AreEqual("custom", secondAction.ActionType);
-#else
             Assert.AreEqual("tap", secondAction.ActionType);
-#endif
             Assert.AreEqual("Tapped Exception", secondAction.ActionName);
 
             var finalSecondVisitView = secondVisit.ViewEvents.Last();

--- a/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
@@ -65,15 +65,15 @@ namespace Datadog.Unity.Tests.Integration.Rum
             Assert.AreEqual("Tapped Download", firstAction.ActionName);
             Assert.AreEqual(1, firstAction.Attributes["onboarding_stage"].Value<int>());
 
-#if !UNITY_WEBGL
-            Assert.AreEqual(1, firstVisit.ResourceEvents.Count);
-            var firstResource = firstVisit.ResourceEvents[0];
+            var resource1 = firstVisit.ResourceEvents.Where(r => r.Url == "http://fake/resource/1").ToList();
+            Assert.AreEqual(1, resource1.Count());
+            var firstResource = resource1.First();
             Assert.AreEqual("http://fake/resource/1", firstResource.Url);
             Assert.AreEqual("GET", firstResource.Method);
             Assert.AreEqual("image", firstResource.ResourceType);
             Assert.AreEqual(200, firstResource.StatusCode);
             Assert.AreEqual(121999, firstResource.Size);
-            Assert.GreaterOrEqual(firstResource.Duration, 50 * 1000 * 1000);
+            Assert.GreaterOrEqual(firstResource.Duration, 45 * 1000 * 1000);
 
             Assert.AreEqual(1, firstVisit.ErrorEvents.Count);
             var resourceError = firstVisit.ErrorEvents[0];
@@ -81,7 +81,7 @@ namespace Datadog.Unity.Tests.Integration.Rum
             Assert.AreEqual("POST", resourceError.ResourceMethod);
             Assert.AreEqual("System.Net.NetworkInformation.NetworkInformationException", resourceError.ErrorType);
             Assert.AreEqual("network", resourceError.Source);
-#endif
+
             var secondVisit = visits[1];
             Assert.AreEqual(1, secondVisit.ErrorEvents.Count);
             var errorEvent = secondVisit.ErrorEvents[0];
@@ -93,11 +93,7 @@ namespace Datadog.Unity.Tests.Integration.Rum
 
             Assert.AreEqual("Test Exception", errorEvent.Message);
             Assert.IsNotNull(errorEvent.Stack);
-#if UNITY_WEBGL
-            Assert.AreEqual("custom", errorEvent.Source);
-#else
             Assert.AreEqual("source", errorEvent.Source);
-#endif
             Assert.AreEqual("first_call", errorEvent.Attributes["error_attribute"].Value<string>());
             Assert.AreEqual(1, errorEvent.Attributes["onboarding_stage"].Value<int>());
 

--- a/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using Datadog.Unity.Rum;
 using Datadog.Unity.Tests.Integration.Rum.Decoders;
 using NUnit.Framework;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -19,7 +18,7 @@ namespace Datadog.Unity.Tests.Integration.Rum
     public class TrackedWebRequestIntegrationTests
     {
         [UnityTest]
-        [System.ComponentModel.Category("integration")]
+        [Category("integration")]
         public IEnumerator TrackedWebRequestScenario()
         {
             var mockServerHelper = new MockServerHelper();

--- a/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Unity.Rum;
+using Datadog.Unity.Tests.Integration.Rum.Decoders;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace Datadog.Unity.Tests.Integration.Rum
+{
+    public class TrackedWebRequestIntegrationTests
+    {
+        [UnityTest]
+        [System.ComponentModel.Category("integration")]
+        public IEnumerator TrackedWebRequestScenario()
+        {
+            var mockServerHelper = new MockServerHelper();
+            yield return mockServerHelper.Clear();
+
+            yield return new MonoBehaviourTest<TestTrackedWebRequestMonoBehavior>();
+            List<MockServerLog> serverLog = new();
+            List<MockServerLog> testRequests = new();
+            yield return mockServerHelper.PollRequests(new TimeSpan(0, 0, 30), (logs) =>
+            {
+                serverLog = logs;
+                testRequests = serverLog.Where(r => r.Endpoint.Contains("integration")).ToList();
+                var events = RumDecoderHelpers.RumEventsFromMockServer(serverLog);
+                var sessions = RumDecoderHelpers.RumSessionsFromEvents(events);
+
+                // Second view makes sure the first one has been closed
+                return sessions.Count >= 1 && sessions[0].Visits.Count >= 4;
+            });
+
+            var sessions = RumDecoderHelpers.RumSessionsFromEvents(
+                RumDecoderHelpers.RumEventsFromMockServer(serverLog));
+
+            Assert.AreEqual(1, sessions.Count);
+
+            var session = sessions.First();
+
+            // Discard visits that are automatically recorded parts of integration testing
+            var visits = session.Visits.Where(
+                visit => visit.Name != string.Empty && !visit.Name.Contains("InitTestScene")).ToArray();
+            Assert.AreEqual(2, visits.Length);
+
+            var firstVisit = visits[0];
+            var getResource = firstVisit.ResourceEvents.FirstOrDefault(r => r.Url.Contains("httpbin"));
+            Assert.IsNotNull(getResource);
+            Assert.AreEqual("https://httpbin.org/status/200", getResource.Url);
+            Assert.IsNull(getResource.TraceId);
+            Assert.IsNull(getResource.SpanId);
+
+            var testRequestEndpoint = testRequests.First();
+            var testRequest = testRequestEndpoint.Requests.First();
+            var schema = testRequest.Schemas.First();
+            var headers = schema.ParsedHeaders;
+
+            // This is mostly just checking that the headers exist. We could make this test more thorough
+            // by decoding the trace and span ids and checking the values match the resource event.
+            // For now, we'll only check the SpanId and assume unit testing covers the rest.
+            Assert.AreEqual("rum", headers["X-Datadog-Origin"]);
+            Assert.AreEqual("1", headers["X-Datadog-Sampling-Priority"]);
+            Assert.IsNotNull(headers["Traceparent"]);
+
+            var getFirstPartyResource = firstVisit.ResourceEvents.FirstOrDefault(r => r.Url.Contains("integration_get"));
+            Assert.IsNotNull(getFirstPartyResource);
+            Assert.IsNotNull(getFirstPartyResource.TraceId);
+            Assert.AreEqual(getFirstPartyResource.SpanId, headers["X-Datadog-Parent-Id"]);
+        }
+    }
+
+    public class TestTrackedWebRequestMonoBehavior : MonoBehaviour, IMonoBehaviourTest
+    {
+        public bool IsTestFinished { get; private set; }
+
+        public void Awake()
+        {
+            IsTestFinished = false;
+            DatadogSdk.Instance.SetTrackingConsent(TrackingConsent.Granted);
+
+            StartCoroutine(RunTest());
+        }
+
+        public IEnumerator RunTest()
+        {
+            var rum = DatadogSdk.Instance.Rum;
+            rum?.StartView("FirstScreen", name: "First Screen");
+
+            // Make a tracked web request, not first party
+            var getRequest = new DatadogTrackedWebRequest("https://httpbin.org/status/200");
+            yield return getRequest.SendWebRequest();
+
+            if (getRequest.result != UnityEngine.Networking.UnityWebRequest.Result.Success)
+            {
+                Debug.Log($"Web request failed: {getRequest.error}");
+            }
+
+            // Make a tracked web request, first party. This must be configured in the settings as first party --
+            // see `scripts/dev_setup.py` which will set the proper first party hosts
+            var datadogSettings = DatadogConfigurationOptions.Load();
+            var endpoint = datadogSettings.CustomEndpoint;
+            var firstPartyGetRequest = new DatadogTrackedWebRequest($"{endpoint}/integration_get");
+            yield return firstPartyGetRequest.SendWebRequest();
+
+            if (firstPartyGetRequest.result != UnityEngine.Networking.UnityWebRequest.Result.Success)
+            {
+                Debug.Log($"Web request failed: {firstPartyGetRequest.error}");
+            }
+
+            SceneManager.LoadScene("Scenes/EmptyScene");
+
+            IsTestFinished = true;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/TrackedWebRequestIntegrationTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d10b45889cc740ff9e53f7611a1f769c
+timeCreated: 1756321982

--- a/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
+++ b/packages/Datadog.Unity/Tests/Rum/DatadogTrackedWebRequestTest.cs
@@ -408,6 +408,7 @@ namespace Datadog.Unity.Rum.Tests
                 {
                     new FirstPartyHostOption("example.com", TracingHeaderType.Datadog),
                     new FirstPartyHostOption("datadoghq.com", TracingHeaderType.B3),
+                    new FirstPartyHostOption("localhost:5000", TracingHeaderType.B3),
                 }
             };
 
@@ -445,6 +446,45 @@ namespace Datadog.Unity.Rum.Tests
         {
             // Given
             var uri = new Uri("https://app.datadoghq.com/request");
+
+            // When
+            var tracingHeaders = _trackingHelper.HeaderTypesForHost(uri);
+
+            // Then
+            Assert.AreEqual(TracingHeaderType.B3, tracingHeaders);
+        }
+
+        [Test]
+        public void IsFirstPartyHostWithoutMatchingPortReturnsNone()
+        {
+            // Given
+            var uri = new Uri("https://localhost:1337/request");
+
+            // When
+            var tracingHeaders = _trackingHelper.HeaderTypesForHost(uri);
+
+            // Then
+            Assert.AreEqual(TracingHeaderType.None, tracingHeaders);
+        }
+
+        [Test]
+        public void IsFirstPartyHostOnDefaultPortReturnsHeaders()
+        {
+            // Given
+            var uri = new Uri("https://datadoghq.com:443/request");
+
+            // When
+            var tracingHeaders = _trackingHelper.HeaderTypesForHost(uri);
+
+            // Then
+            Assert.AreEqual(TracingHeaderType.B3, tracingHeaders);
+        }
+
+        [Test]
+        public void IsFirstPartyHostMatchesPortReturnsTracingTypes()
+        {
+            // Given
+            var uri = new Uri("https://localhost:5000/request");
 
             // When
             var tracingHeaders = _trackingHelper.HeaderTypesForHost(uri);

--- a/samples/Datadog Sample/Assets/WebGLTemplates/Datadog/index.html
+++ b/samples/Datadog Sample/Assets/WebGLTemplates/Datadog/index.html
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="<<<TemplateData/diagnostics.css>>>">
     <script src="<<<TemplateData/diagnostics.js>>>"></script>
 #endif
-    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script>
-    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script>
   </head>
   <body>
     <div id="unity-container" class="unity-desktop">

--- a/tools/mock_server/app.py
+++ b/tools/mock_server/app.py
@@ -16,6 +16,7 @@ import sys
 from typing import Optional
 from dataclasses import dataclass, is_dataclass, asdict
 from flask import Flask, request, Request, render_template, url_for, redirect
+from flask_cors import CORS
 import flask
 from schema_update import schemas_path_exists, update_schemas
 from schemas.schema import Schema
@@ -27,6 +28,7 @@ from templates.components.card import Card, CardTab
 from urllib.parse import urlparse
 
 app = Flask(__name__)
+CORS(app)
 
 @dataclass()
 class GenericRequest:
@@ -175,6 +177,37 @@ def generic_post(rest = ''):
     add_cors_headers(resp)
     return resp
 
+@app.route('/', methods=['GET'])
+@app.route('/<path:rest>', methods=['GET'])
+def generic_get(rest = ''):
+    """
+    GET /*
+
+    Record generic (any) GET request sent to `/**/*`
+    """
+    global endpoints
+
+    gr = GenericRequest(r=request)
+
+    response_text = ''
+    if existing := next((e for e in endpoints if e.hash() == gr.endpoint_hash()), None):
+        existing.requests.append(gr)
+        # write_to_file(endpoint=existing)
+        response_text = 'OK - request recorded to known endpoint\n'
+    else:
+        endpoints.append(
+            GenericEndpoint(
+                method=gr.method,
+                path=gr.path,
+                requests=[gr],
+                schemas=gr.schemas
+            )
+        )
+        response_text = 'OK - request recorded to new endpoint\n'
+
+    resp = flask.Response(response_text, status=202)
+    add_cors_headers(resp)
+    return resp
 
 
 @app.route('/inspect_requests/')
@@ -288,7 +321,7 @@ if __name__ == '__main__':
 
     if args.addr and args.prefer_localhost:
         raise ValueError('--addr and --prefer-localhost are mutually exclusive')
-    
+
     preferred_address = args.addr or ''
     if args.prefer_localhost:
         preferred_address = '127.0.0.1'

--- a/tools/mock_server/requirements.txt
+++ b/tools/mock_server/requirements.txt
@@ -1,2 +1,3 @@
 flask == 2.3.2
+flask-cors == 6.0.1
 jsonschema == 4.17.3

--- a/tools/scripts/common/ddconfig.py
+++ b/tools/scripts/common/ddconfig.py
@@ -9,10 +9,21 @@ import os
 from dataclasses import dataclass
 from contextlib import contextmanager
 from typing import Optional
+from yaml import load, dump, Loader, Dumper
 
 __dd_settings_asset_filename__ = 'DatadogSettings.asset'
 __dd_settings_asset_relpath__ = os.path.join('Assets', 'Resources', __dd_settings_asset_filename__)
 
+@dataclass
+class FirstPartyHost:
+    host: str
+    tracing_header_type: int
+
+    # This makes some terrible assumptions about how its being used in Yaml in an array,
+    # but this is the simplest way to write out these objects without having to perform
+    # custom parsing of Unity tags in Yaml.
+    def __str__(self) -> str:
+        return f"\n  - Host: {self.host}\n    TracingHeaderType: {self.tracing_header_type}"
 
 @dataclass
 class DatadogRuntimeConfig:
@@ -38,6 +49,14 @@ class DatadogRuntimeConfig:
     session_sample_rate: Optional[int] = None
     trace_sample_rate: Optional[int] = None
     telemetry_sample_rate: Optional[int] = None
+    first_party_hosts: Optional[list[FirstPartyHost]] = None
+
+    def apply_to(self, path: str):
+        with open(path) as fp:
+            old_text = fp.read()
+        new_text = _modify_datadog_settings_impl(old_text, self)
+        with open(path, 'w') as fp:
+            fp.write(new_text)
 
 
 @contextmanager
@@ -81,6 +100,7 @@ def _modify_datadog_settings_impl(text: str, config: DatadogRuntimeConfig) -> st
         ('SessionSampleRate', config.session_sample_rate),
         ('TraceSampleRate', config.trace_sample_rate),
         ('TelemetrySampleRate', config.telemetry_sample_rate),
+        ('FirstPartyHosts', config.first_party_hosts ),
     ]
     for key, value_or_none in to_modify:
         if value_or_none is None:
@@ -88,9 +108,23 @@ def _modify_datadog_settings_impl(text: str, config: DatadogRuntimeConfig) -> st
         value = value_or_none
         if isinstance(value, bool):
             value = int(value)
+        if isinstance(value, list):
+            if not value:
+                value = ' []'
+            else:
+                value = ''.join([str(t) for t in value])
+        else:
+            value = f' {value}'
+
         prefix = f'  {key}:'
         i = next((i for i, s in enumerate(lines) if s.startswith(prefix)), -1)
         if i < 0:
             raise ValueError(f"Invalid {__dd_settings_asset_filename__} file: no existing line begins with {prefix}")
-        lines[i] = f'{prefix} {value}'
+        # Special case -- if the next line starts an array, we want to remove lines until the array is closed, then add
+        # in our multi-line change, if we have one
+        if len(lines) > i + 1 and lines[i+1].startswith('  - '):
+            while(len(lines) > i + 1 and lines[i + 1].startswith('    ') or lines[i+1].startswith('  - ')):
+                del lines[i+1]
+        lines[i] = f'{prefix}{value}'
+
     return '\n'.join(lines) + '\n'

--- a/tools/scripts/common/ddconfig_test.py
+++ b/tools/scripts/common/ddconfig_test.py
@@ -5,7 +5,7 @@ Apache License Version 2.0. This product includes software developed at Datadog
 """
 import pytest
 
-from .ddconfig import DatadogRuntimeConfig, _modify_datadog_settings_impl
+from .ddconfig import DatadogRuntimeConfig, FirstPartyHost, _modify_datadog_settings_impl
 
 __old_settings__ = '''%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
@@ -20,14 +20,14 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31528199819cf497cbec19aabbb133a1, type: 3}
   m_Name: DatadogSettings
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   Enabled: 1
   SdkVerbosity: 0
   OutputSymbols: 1
-  ClientToken: 
+  ClientToken:
   Site: 0
-  Env: 
-  CustomEndpoint: 
+  Env:
+  CustomEndpoint:
   BatchSize: 0
   UploadFrequency: 0
   BatchProcessingLevel: 1
@@ -35,7 +35,7 @@ MonoBehaviour:
   ForwardUnityLogs: 1
   RemoteLogThreshold: 3
   RumEnabled: 1
-  RumApplicationId: 
+  RumApplicationId:
   AutomaticSceneTracking: 1
   VitalsUpdateFrequency: 2
   SessionSampleRate: 100
@@ -47,13 +47,14 @@ MonoBehaviour:
   TelemetrySampleRate: 20
 '''
 
-__config__ = DatadogRuntimeConfig(
-    custom_endpoint=None,
-    client_token='my-very-special-client-token',
-    rum_application_id='my-cool-rum-application',
-)
+def test_modify_datadog_settings_impl():
+    config = DatadogRuntimeConfig(
+        custom_endpoint=None,
+        client_token='my-very-special-client-token',
+        rum_application_id='my-cool-rum-application',
+    )
 
-__new_settings__ = '''%YAML 1.1
+    expected_settings = '''%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!114 &11400000
 MonoBehaviour:
@@ -66,14 +67,14 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31528199819cf497cbec19aabbb133a1, type: 3}
   m_Name: DatadogSettings
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   Enabled: 1
   SdkVerbosity: 0
   OutputSymbols: 1
   ClientToken: my-very-special-client-token
   Site: 0
-  Env: 
-  CustomEndpoint: 
+  Env:
+  CustomEndpoint:
   BatchSize: 0
   UploadFrequency: 0
   BatchProcessingLevel: 1
@@ -93,10 +94,114 @@ MonoBehaviour:
   TelemetrySampleRate: 20
 '''
 
-
-def test_modify_datadog_settings_impl():
-    got = _modify_datadog_settings_impl(__old_settings__, __config__)
-    assert got == __new_settings__
+    got = _modify_datadog_settings_impl(__old_settings__, config)
+    assert got == expected_settings
 
     with pytest.raises(ValueError):
-        _modify_datadog_settings_impl('not-a-valid-asset', __config__)
+        _modify_datadog_settings_impl('not-a-valid-asset', config)
+
+def test_modify_datadog_settings_impl_remove_first_party_hosts():
+    config = DatadogRuntimeConfig(
+        custom_endpoint=None,
+        client_token='my-very-special-client-token',
+        rum_application_id='my-cool-rum-application',
+        first_party_hosts=[]
+    )
+
+    expected_settings = '''%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31528199819cf497cbec19aabbb133a1, type: 3}
+  m_Name: DatadogSettings
+  m_EditorClassIdentifier:
+  Enabled: 1
+  SdkVerbosity: 0
+  OutputSymbols: 1
+  ClientToken: my-very-special-client-token
+  Site: 0
+  Env:
+  CustomEndpoint:
+  BatchSize: 0
+  UploadFrequency: 0
+  BatchProcessingLevel: 1
+  CrashReportingEnabled: 1
+  ForwardUnityLogs: 1
+  RemoteLogThreshold: 3
+  RumEnabled: 1
+  RumApplicationId: my-cool-rum-application
+  AutomaticSceneTracking: 1
+  VitalsUpdateFrequency: 2
+  SessionSampleRate: 100
+  TraceSampleRate: 100
+  TraceContextInjection: 0
+  FirstPartyHosts: []
+  TelemetrySampleRate: 20
+'''
+
+    got = _modify_datadog_settings_impl(__old_settings__, config)
+    assert got == expected_settings
+
+
+def test_modify_datadog_settings_impl_with_first_party_hosts():
+    config = DatadogRuntimeConfig(
+        custom_endpoint=None,
+        client_token='my-very-special-client-token',
+        rum_application_id='my-cool-rum-application',
+        first_party_hosts=[
+            FirstPartyHost(host='datadoghq.com', tracing_header_type=1),
+            FirstPartyHost(host='localhost', tracing_header_type=18),
+        ]
+    )
+
+    expected_settings = '''%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31528199819cf497cbec19aabbb133a1, type: 3}
+  m_Name: DatadogSettings
+  m_EditorClassIdentifier:
+  Enabled: 1
+  SdkVerbosity: 0
+  OutputSymbols: 1
+  ClientToken: my-very-special-client-token
+  Site: 0
+  Env:
+  CustomEndpoint:
+  BatchSize: 0
+  UploadFrequency: 0
+  BatchProcessingLevel: 1
+  CrashReportingEnabled: 1
+  ForwardUnityLogs: 1
+  RemoteLogThreshold: 3
+  RumEnabled: 1
+  RumApplicationId: my-cool-rum-application
+  AutomaticSceneTracking: 1
+  VitalsUpdateFrequency: 2
+  SessionSampleRate: 100
+  TraceSampleRate: 100
+  TraceContextInjection: 0
+  FirstPartyHosts:
+  - Host: datadoghq.com
+    TracingHeaderType: 1
+  - Host: localhost
+    TracingHeaderType: 18
+  TelemetrySampleRate: 20
+'''
+
+    got = _modify_datadog_settings_impl(__old_settings__, config)
+    assert got == expected_settings

--- a/tools/scripts/dev_setup.py
+++ b/tools/scripts/dev_setup.py
@@ -1,0 +1,65 @@
+"""
+Setup project settings for development, including setting properties common for
+integration test development.
+"""
+import os
+import sys
+import argparse
+from common.ddconfig import DatadogRuntimeConfig, FirstPartyHost, __dd_settings_asset_relpath__
+from common.inet_addr import get_reachable_inet_addr
+
+__repo_root__ = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+__default_test_project_root__ = os.path.join(__repo_root__, 'samples', 'Datadog Sample')
+
+def _apply_settings(for_integration_tests: bool, project_path: str):
+    mock_host = ""
+    mock_server_url = ""
+    first_party_hosts = []
+    env = "integration-test"
+
+    if for_integration_tests:
+        # We need our mock server to bind to an address that is reachable from a simulator
+        # or external device on our network
+        mock_server_port = 5000
+        mock_server_bind_addr = get_reachable_inet_addr()
+        if not mock_server_bind_addr:
+            raise RuntimeError('Failed to resolve a private IP for mock server')
+        mock_host = f'{mock_server_bind_addr}:{mock_server_port}'
+        mock_server_url = f'http://{mock_host}'
+        first_party_hosts = [
+            # 18 == TracingHeaderType.Datadog | TracingHeaderType.TraceContext
+            FirstPartyHost(host=mock_host, tracing_header_type=18)
+        ]
+
+
+    config = DatadogRuntimeConfig(
+        enabled=True,
+        sdk_verbosity=1,
+        client_token='fake-client-token',
+        env=env,
+        service_name='datadog-sample',
+        custom_endpoint=mock_server_url,
+        batch_size=1,
+        upload_frequency=1,
+        batch_processing_level=1,
+        crash_reporting_enabled=True,
+        forward_unity_logs=True,
+        remote_log_threshold=3,
+        rum_enabled=True,
+        rum_application_id='fake-rum-application-id',
+        automatic_scene_tracking=True,
+        session_sample_rate=100,
+        trace_sample_rate=100,
+        telemetry_sample_rate=100,
+        first_party_hosts=first_party_hosts
+    )
+    config_path = os.path.join(project_path, __dd_settings_asset_relpath__)
+    config.apply_to(config_path)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--for-integration-tests', '-i', action='store_true', default=False, help="Change properties specifically for development of integration tests.")
+    parser.add_argument('--project', '-p', default=__default_test_project_root__, help="Path to the root directory of the Unity project to load; defaults to 'samples/Demo Data' in this repo.")
+    args = parser.parse_args()
+
+    _apply_settings(args.for_integration_tests, args.project)

--- a/tools/scripts/integration_test.py
+++ b/tools/scripts/integration_test.py
@@ -46,14 +46,14 @@ def _integration_test_env(project_path: str, config: DatadogRuntimeConfig, mock_
                 if target != 'simulator':
                     yield
                     return
-                
+
                 # Similarly, proceed with tests if we're targeting iOS: Unity will
                 # launch Xcode and run the tests through it, and Xcode automatically
                 # launches a simulator unconditionally
                 if platform == 'ios':
                     yield
                     return
-                
+
                 # For Android builds with a target of 'simulator', preemptively launch
                 # an emulator running an appropriate AVD: this should become the
                 # default device in adb, and Unity will deploy to it automatically
@@ -62,7 +62,6 @@ def _integration_test_env(project_path: str, config: DatadogRuntimeConfig, mock_
                 # no guarantee that we'll actually use this emulator for our tests
                 with run_default_simulator(platform):
                     yield
-
 
 def integration_test(unity_version_prefix: str, project_path: str, platform: str, target: str, out_junit_path_pattern: str):
     log = init_logger()
@@ -77,12 +76,12 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
     unity_install = resolve_unity_install(unity_installs, unity_version_prefix)
     if not unity_install:
         raise RuntimeError(f'No Unity version matching {unity_version_prefix} is installed')
-    
+
     # Ensure that our output path has a 'platform' placeholder
     if r'%(platform)s' not in out_junit_path_pattern:
         root, ext = os.path.splitext(out_junit_path_pattern)
         out_junit_path_pattern = root + r'-%(platform)s' + ext
-    
+
     # Compute paths to artifact files
     junit_abspath = os.path.abspath(out_junit_path_pattern % {'platform': platform.lower()})
     artifact_dir, junit_filename = os.path.split(junit_abspath)
@@ -90,11 +89,12 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
     nunit_abspath = os.path.join(artifact_dir, 'nunit-' + junit_filename)
     log_abspath = os.path.join(artifact_dir, junit_filename_noext + '.log')
 
-    # Ensure that any stale artifacts from previous runs are cleaned up
+
     for abspath in [junit_abspath, nunit_abspath, log_abspath]:
         if os.path.isfile(abspath):
             log.info(f'Deleting old artifact: {abspath}')
             os.remove(abspath)
+
 
     # We need our mock server to bind to an address that is reachable from a simulator
     # or external device on our network
@@ -147,11 +147,11 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
             return 86
         else:
             raise RuntimeError(f'Unity exited with status code {result.exitcode}')
-        
+
         # Verify that fresh test results have been written to disk
         if not os.path.isfile(nunit_abspath):
             raise RuntimeError(f'Unity failed to write test results to {nunit_abspath}')
-        
+
         # Convert the intermediate NUnit results file to JUnit format, and parse them
         transform_nunit_to_junit(nunit_abspath, junit_abspath)
         log.info(f'JUnit results written to: {junit_abspath}')
@@ -184,7 +184,7 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Ensures that mock_server has all required schemas along with a properly initialized Python venv')
+    parser = argparse.ArgumentParser(description='Run integration tests on the provided version of Unity and on the specified platform.')
     parser.add_argument('--unity-version', '-u', default=__default_test_project_unity_version__, help='The target version of Unity to build with; may be a partial specifier (e.g. "6000", "2023.3")')
     parser.add_argument('--project', '-p', default=__default_test_project_root__, help="Path to the root directory of the Unity project to load; defaults to 'samples/Demo Data' in this repo")
     parser.add_argument('--platform', choices=['ios', 'android'], required=True, help='The platform to build an app bundle for')

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -8,3 +8,4 @@ requests==2.32.4
 types-requests==2.32.4.20250611
 junitparser==3.2.0
 pydantic==2.11.7
+pyyaml==6.0.2


### PR DESCRIPTION
### What and why?

This contains a few improvements to WebGL target support for Unity:

#### Tags on Loggers for RUM

You can now add and remove tags on specific loggers using `DdLogger.AddTag` and `DdLogger.RemoveTag`. Integration tests for web have been updated.

#### Support for "non-custom" actions

All actions in WebGL were reported as `custom`, regardless of what type you specified in `AddAction`. This has been fixed and the correct action type should be reported.

#### Support manual resource tracking

New support for calling `StartResource` and `StopResource*` now report those resources.

#### Support automatic resource tracking

The Browser SDK already reported requests made with UnityWebRequest, but didn't correctly determine first party hosts given in the settings. This has been fixed. Additionally, users using `DatadogTrackedWebRequest` would have resources double reported with the new manual resource tracking support. It has been fixed so that `DatadogTrackedWebRequest` is a passthrough on WebGL builds.

#### Technical note

We are relying on timestamps set in Attribute collections for Web, and extracting them in the JavaScript layer for two reasons. One is because the timestamp is inserted into all of the messages already, so it was a good place to capture the information. The second is because the timestamps need to be 64-bit integers, as they are Milliseconds since Epoch.  

So far as I can determine, there is no easy way to send a `long` to JavaScript (maybe through WebAssembly.BigInt?) but we can serialize it to JSON and deserialize it to a JavaScript integer just fine.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
