### PR TITLE
feat: Support `version` tag for WebGL

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+* Add application version to WebGL builds.
+* Change SDK `source` to `unity` in WebGL builds.
+
 ## 1.5.1
 
 * Fix an issue that prevented SDK functionality from working properly in WebGL builds.

--- a/packages/Datadog.Unity/Editor/DatadogDependencies.xml
+++ b/packages/Datadog.Unity/Editor/DatadogDependencies.xml
@@ -1,16 +1,16 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-rum:2.26.0">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-rum:2.26.1">
     </androidPackage>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-logs:2.26.0">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-logs:2.26.1">
     </androidPackage>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-ndk:2.26.0">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-ndk:2.26.1">
     </androidPackage>
   </androidPackages>
   <iosPods>
-    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="2.29.0" />
-    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="2.29.0" />
-    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="2.29.0" />
-    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="2.29.0" />
+    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="2.30.1" />
+    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="2.30.1" />
+    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="2.30.1" />
+    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="2.30.1" />
   </iosPods>
 </dependencies>

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLLogs.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLLogs.cs
@@ -3,11 +3,12 @@
 // Copyright 2025-Present Datadog, Inc.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Datadog.Unity.Logs;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Scripting;
 
 namespace Datadog.Unity.WebGL
 {
@@ -22,7 +23,8 @@ namespace Datadog.Unity.WebGL
                 proxy = string.IsNullOrEmpty(options.CustomEndpoint) ? null : options.CustomEndpoint,
                 site = options.Site.ToWebValue(),
                 service = options.ServiceName,
-                // TODO: Version
+                version = Application.version,
+                source = "unity",
             };
 
             var jsConfig = JsonConvert.SerializeObject(logConfig, new JsonSerializerSettings()
@@ -49,19 +51,31 @@ namespace Datadog.Unity.WebGL
             return logger;
         }
 
+        [Preserve]
         private class LoggingInitOptions
         {
+            [Preserve]
             public string clientToken;
+            [Preserve]
             public string env;
+            [Preserve]
             public string proxy;
+            [Preserve]
             public string site;
+            [Preserve]
             public string service;
+            [Preserve]
             public string version;
+            [Preserve]
+            public string source;
         }
 
+        [Preserve]
         private class LoggerConfiguration
         {
+            [Preserve]
             public string name;
+            [Preserve]
             public string service;
         }
 

--- a/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
+++ b/packages/Datadog.Unity/Runtime/WebGL/DatadogWebGLRum.cs
@@ -48,8 +48,7 @@ namespace Datadog.Unity.WebGL
                 sessionSampleRate = options.SessionSampleRate,
                 service = options.ServiceName,
                 env = options.Env,
-                // TODO: Version
-                version = "unknown",
+                version = Application.version,
                 traceSampleRate = options.TraceSampleRate,
                 trackFrustrations = true,
                 trackResources = true,
@@ -57,6 +56,7 @@ namespace Datadog.Unity.WebGL
                 proxy = string.IsNullOrEmpty(options.CustomEndpoint) ? null : options.CustomEndpoint,
                 allowedTracingUrls = allowedTracingUrls,
                 traceContextInjection = options.TraceContextInjection.ToWebValue(),
+                source = "unity",
             };
             var configurationJson = JsonConvert.SerializeObject(browserSdkConfig);
 
@@ -341,6 +341,8 @@ namespace Datadog.Unity.WebGL
             public bool trackLongTasks { get; set; }
             [Preserve]
             public List<string> enableExperimentalFeatures { get; set; } = new List<string>();
+            [Preserve]
+            public string source { get; set; }
         }
 
         [Preserve]

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
@@ -49,6 +49,19 @@ namespace Datadog.Unity.Tests.Integration.Logging
             get { return RawTags.Split(','); }
         }
 
+        public string ApplicationVersion
+        {
+            get
+            {
+#if UNITY_IOS
+                return _rawJson["version"] as string;
+#else
+                var tag = Tags.FirstOrDefault(e => e.StartsWith("version:"));
+                return tag == null ? string.Empty : tag.Split(":")[1];
+#endif
+            }
+        }
+
         public string LoggerName
         {
             get { return GetNestedProperty<string>("logger.name"); }

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -34,7 +34,6 @@ namespace Datadog.Unity.Tests.Integration.Logging
                 return logs.Count >= 5;
             });
 
-#if !UNITY_WEBGL
             foreach (var log in serverLog)
             {
                 foreach (var request in log.Requests)
@@ -42,7 +41,6 @@ namespace Datadog.Unity.Tests.Integration.Logging
                     Assert.AreEqual("unity", request.QueryParameters["ddsource"]);
                 }
             }
-#endif
 
             Assert.AreEqual(5, logs.Count);
 
@@ -130,6 +128,11 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
             Assert.AreEqual("Error Message", exceptionLog.ErrorMessage);
             Assert.NotNull(exceptionLog.ErrorStack);
+
+            foreach (var log in logs)
+            {
+                Assert.AreEqual(log.ApplicationVersion, "1.123");
+            }
         }
 
         public class TestLoggingMonoBehavior : MonoBehaviour, IMonoBehaviourTest

--- a/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumEventDecoder.cs
@@ -29,6 +29,34 @@ namespace Datadog.Unity.Tests.Integration.Rum.Decoders
             get => jsonGetProp<long>(rumEvent, "date");
         }
 
+        public Dictionary<string, string> ddtags
+        {
+            get
+            {
+                var tagMap = new Dictionary<string, string>();
+                var rawTags = rumEvent["ddtags"]?.Value<string>();
+                if (rawTags == null)
+                {
+                    return tagMap;
+                }
+
+                foreach (var tag in rawTags.Split(","))
+                {
+                    var colon = tag.IndexOf(":");
+                    if (colon == -1)
+                    {
+                        tagMap[tag] = string.Empty;
+                    }
+                    else
+                    {
+                        tagMap[tag.Substring(0, colon)] = tag.Substring(colon + 1);
+                    }
+                }
+
+                return tagMap;
+            }
+        }
+
         public JObject Attributes => rumEvent["context"] as JObject;
 
         public JObject FeatureFlags => rumEvent["feature_flags"] as JObject;

--- a/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
@@ -43,8 +43,13 @@ namespace Datadog.Unity.Tests.Integration.Rum
                 VerifyCommonTags(log);
             }
 
-            var sessions = RumDecoderHelpers.RumSessionsFromEvents(
-                RumDecoderHelpers.RumEventsFromMockServer(serverLog));
+            var rumEvents = RumDecoderHelpers.RumEventsFromMockServer(serverLog);
+            foreach (var  rumEvent in rumEvents)
+            {
+                VerifyCommonEventTags(rumEvent, "1.123");
+            }
+
+            var sessions = RumDecoderHelpers.RumSessionsFromEvents(rumEvents);
 
             Assert.AreEqual(1, sessions.Count);
 
@@ -120,12 +125,16 @@ namespace Datadog.Unity.Tests.Integration.Rum
         private void VerifyCommonTags(MockServerLog log)
         {
             // Web does not support source overrides yet
-#if !UNITY_WEBGL
             foreach (var request in log.Requests)
             {
                 Assert.AreEqual("unity", request.QueryParameters["ddsource"]);
             }
-#endif
+        }
+
+        private void VerifyCommonEventTags(RumEventDecoder rumLog, string version)
+        {
+            var tags = rumLog.ddtags;
+            Assert.AreEqual(tags["version"], version);
         }
     }
 

--- a/samples/Datadog Sample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/samples/Datadog Sample/Assets/Plugins/Android/mainTemplate.gradle
@@ -4,9 +4,9 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.datadoghq:dd-sdk-android-logs:2.26.0' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:6
-    implementation 'com.datadoghq:dd-sdk-android-ndk:2.26.0' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:8
-    implementation 'com.datadoghq:dd-sdk-android-rum:2.26.0' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:4
+    implementation 'com.datadoghq:dd-sdk-android-logs:2.26.1' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:6
+    implementation 'com.datadoghq:dd-sdk-android-ndk:2.26.1' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:8
+    implementation 'com.datadoghq:dd-sdk-android-rum:2.26.1' // Packages/com.datadoghq.unity/Editor/DatadogDependencies.xml:4
 // Android Resolver Dependencies End
 
     constraints {

--- a/samples/Datadog Sample/Packages/manifest.json
+++ b/samples/Datadog Sample/Packages/manifest.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "com.datadoghq.unity": "file:../../../packages/Datadog.Unity",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
-    "com.unity.ai.navigation": "1.1.6",
-    "com.unity.collab-proxy": "2.8.2",
+    "com.unity.ai.navigation": "1.1.7",
+    "com.unity.collab-proxy": "2.9.3",
     "com.unity.feature.2d": "2.0.1",
-    "com.unity.ide.rider": "3.0.36",
+    "com.unity.ide.rider": "3.0.37",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",

--- a/samples/Datadog Sample/Packages/packages-lock.json
+++ b/samples/Datadog Sample/Packages/packages-lock.json
@@ -37,7 +37,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.1.9",
+      "version": "1.1.10",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -120,7 +120,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ai.navigation": {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -129,7 +129,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.23",
+      "version": "1.8.24",
       "depth": 3,
       "source": "registry",
       "dependencies": {
@@ -139,7 +139,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.8.2",
+      "version": "2.9.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -174,11 +174,11 @@
         "com.unity.2d.spriteshape": "9.1.1",
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.2d.tilemap.extras": "3.1.3",
-        "com.unity.2d.aseprite": "1.1.9"
+        "com.unity.2d.aseprite": "1.1.10"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.36",
+      "version": "3.0.37",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,8 +1,8 @@
 <dependencies>
   <packages>
-    <package>com.datadoghq:dd-sdk-android-logs:2.26.0</package>
-    <package>com.datadoghq:dd-sdk-android-ndk:2.26.0</package>
-    <package>com.datadoghq:dd-sdk-android-rum:2.26.0</package>
+    <package>com.datadoghq:dd-sdk-android-logs:2.26.1</package>
+    <package>com.datadoghq:dd-sdk-android-ndk:2.26.1</package>
+    <package>com.datadoghq:dd-sdk-android-rum:2.26.1</package>
   </packages>
   <files />
   <settings>

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -77,6 +77,7 @@ PlayerSettings:
   androidMinimumWindowHeight: 300
   androidFullscreenMode: 1
   androidAutoRotationBehavior: 1
+  androidPredictiveBackSupport: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -140,7 +141,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0
+  bundleVersion: 1.123
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -162,7 +163,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Android: com.datadoghq.unity.example
+    Android: com.UnityTestRunner.UnityTestRunner
     Standalone: com.DefaultCompany.Datadog-Sample
     iPhone: com.DefaultCompany.Datadog-Sample
   buildNumber:
@@ -175,6 +176,7 @@ PlayerSettings:
   AndroidMinSdkVersion: 30
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
+  AndroidPreferredDataLocation: 1
   aotOptions: nimt-trampolines=1024
   stripEngineCode: 0
   iPhoneStrippingLevel: 0
@@ -856,7 +858,7 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  additionalIl2CppArgs: '    '
+  additionalIl2CppArgs: '     --emit-source-mapping'
   scriptingRuntimeVersion: 1
   gcIncremental: 1
   gcWBarrierValidation: 0

--- a/samples/Datadog Sample/ProjectSettings/ProjectVersion.txt
+++ b/samples/Datadog Sample/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.64f1
-m_EditorVersionWithRevision: 2022.3.64f1 (a5c5c4ade6bd)
+m_EditorVersion: 2022.3.67f2
+m_EditorVersionWithRevision: 2022.3.67f2 (6bedba8691df)

--- a/samples/Demo Data/Assets/Editor/BuildCommands.cs
+++ b/samples/Demo Data/Assets/Editor/BuildCommands.cs
@@ -92,7 +92,7 @@ public class BuildCommands
         buildPlayerOptions.locationPathName = outputLocation;
         buildPlayerOptions.scenes = Scenes;
         buildPlayerOptions.target = target;
-        buildPlayerOptions.options = BuildOptions.None;
+        buildPlayerOptions.options = BuildOptions.CleanBuildCache;
 
         BuildReport report = BuildPipeline.BuildPlayer(buildPlayerOptions);
         if (report.summary.result == BuildResult.Succeeded)

--- a/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
@@ -28,6 +28,7 @@ android {
 }
 // Android Resolver Exclusions End
 android {
+    namespace "com.datadoghq.unity.demo"
     ndkPath "**NDKPATH**"
 
     compileSdkVersion **APIVERSION**

--- a/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
@@ -18,6 +18,7 @@ dependencies {
 
 // Android Resolver Exclusions Start
 android {
+	namespace "com.unity3d.player"
   packagingOptions {
       exclude ('/lib/armeabi/*' + '*')
       exclude ('/lib/mips/*' + '*')
@@ -28,7 +29,6 @@ android {
 }
 // Android Resolver Exclusions End
 android {
-    namespace "com.datadoghq.unity.demo"
     ndkPath "**NDKPATH**"
 
     compileSdkVersion **APIVERSION**

--- a/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle.backup
+++ b/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle.backup
@@ -18,7 +18,6 @@ dependencies {
 
 // Android Resolver Exclusions Start
 android {
-	namespace "com.unity3d.player"
   packagingOptions {
       exclude ('/lib/armeabi/*' + '*')
       exclude ('/lib/mips/*' + '*')

--- a/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle.backup.meta
+++ b/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle.backup.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: adc3f0a7bf65248f696fbfb0680e3830
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
 // Android Resolver Repos Start
+        def unityProjectPath = $/file:///**DIR_UNITYPROJECT**/$.replace("\\", "/")
         mavenLocal()
 // Android Resolver Repos End
         flatDir {

--- a/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
@@ -17,7 +17,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
 // Android Resolver Repos Start
-        def unityProjectPath = $/file:///**DIR_UNITYPROJECT**/$.replace("\\", "/")
         mavenLocal()
 // Android Resolver Repos End
         flatDir {

--- a/samples/Demo Data/Assets/Resources/DatadogSettings.asset
+++ b/samples/Demo Data/Assets/Resources/DatadogSettings.asset
@@ -15,9 +15,11 @@ MonoBehaviour:
   Enabled: 1
   SdkVerbosity: 0
   OutputSymbols: 1
+  PerformNativeStackMapping: 1
   ClientToken: 
   Site: 0
   Env: 
+  ServiceName: 
   CustomEndpoint: 
   BatchSize: 0
   UploadFrequency: 0
@@ -35,4 +37,7 @@ MonoBehaviour:
   FirstPartyHosts:
   - Host: shopist.io
     TracingHeaderType: 18
+  TrackNonFatalAnrs: 2
+  TrackNonFatalAppHangs: 0
+  NonFatalAppHangThreshold: 0.25
   TelemetrySampleRate: 20

--- a/samples/Demo Data/Packages/manifest.json
+++ b/samples/Demo Data/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "com.datadoghq.unity": "file:../../../packages/Datadog.Unity",
-    "com.unity.ai.navigation": "1.1.6",
-    "com.unity.collab-proxy": "2.8.2",
+    "com.unity.ai.navigation": "1.1.7",
+    "com.unity.collab-proxy": "2.9.3",
     "com.unity.feature.2d": "2.0.1",
-    "com.unity.ide.rider": "3.0.36",
+    "com.unity.ide.rider": "3.0.37",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",

--- a/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
@@ -17,7 +17,7 @@
     <setting name="packageDir" value="Assets/Plugins/Android" />
     <setting name="patchAndroidManifest" value="True" />
     <setting name="patchMainTemplateGradle" value="True" />
-    <setting name="projectExportEnabled" value="True" />
+    <setting name="projectExportEnabled" value="False" />
     <setting name="useFullCustomMavenRepoPathWhenExport" value="True" />
     <setting name="useFullCustomMavenRepoPathWhenNotExport" value="False" />
     <setting name="useJetifier" value="True" />

--- a/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,8 +1,8 @@
 <dependencies>
   <packages>
-    <package>com.datadoghq:dd-sdk-android-logs:2.26.0</package>
-    <package>com.datadoghq:dd-sdk-android-ndk:2.26.0</package>
-    <package>com.datadoghq:dd-sdk-android-rum:2.26.0</package>
+    <package>com.datadoghq:dd-sdk-android-logs:2.26.1</package>
+    <package>com.datadoghq:dd-sdk-android-ndk:2.26.1</package>
+    <package>com.datadoghq:dd-sdk-android-rum:2.26.1</package>
   </packages>
   <files />
   <settings>
@@ -17,7 +17,7 @@
     <setting name="packageDir" value="Assets/Plugins/Android" />
     <setting name="patchAndroidManifest" value="True" />
     <setting name="patchMainTemplateGradle" value="True" />
-    <setting name="projectExportEnabled" value="False" />
+    <setting name="projectExportEnabled" value="True" />
     <setting name="useFullCustomMavenRepoPathWhenExport" value="True" />
     <setting name="useFullCustomMavenRepoPathWhenNotExport" value="False" />
     <setting name="useJetifier" value="True" />

--- a/samples/Demo Data/ProjectSettings/ProjectVersion.txt
+++ b/samples/Demo Data/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.64f1
-m_EditorVersionWithRevision: 2022.3.64f1 (a5c5c4ade6bd)
+m_EditorVersion: 2022.3.67f2
+m_EditorVersionWithRevision: 2022.3.67f2 (6bedba8691df)

--- a/tools/scripts/common/unity/install.py
+++ b/tools/scripts/common/unity/install.py
@@ -227,7 +227,7 @@ class UnityInstall:
     @classmethod
     def parse(cls, line: str) -> Optional['UnityInstall']:
         """Parses a line of output from Unity Hub's 'editors --installed' command."""
-        pattern = re.compile(r'^(\S+)\s+\(([^)]+)\), installed at (.+)$')
+        pattern = re.compile(r'^(\S+)\s+\(([^)]+)\),? installed at (.+)$')
         match = pattern.match(line)
         if match:
             path = match.group(3)


### PR DESCRIPTION
### What and why?

iOS and Android pull their version numbers from the included bundle version. WebGL needs to pull it from `Application.version` instead.

Also change `source` to `unity` in WebGL.

Update iOS and Android SDKs to add new event tag support (fixes RUM-10643)

refs: RUM-10643 RUMS-12244 RUM-11701

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
