### PR TITLE
fix: Disable the use of JankStats in Android builds

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Use of the JankStats API is now fully disabled in Android builds, to guard against crashes triggered by a bug in certain versions of `androidx.metrics`.
+
 ## 1.6.1
 
 * Fix a bug where setting "Vitals Update Frequency" to `None` would not take effect as intended on Android builds.

--- a/packages/Datadog.Unity/Editor/DatadogDependencies.xml
+++ b/packages/Datadog.Unity/Editor/DatadogDependencies.xml
@@ -1,10 +1,10 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-rum:2.26.1">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-rum:2.26.3">
     </androidPackage>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-logs:2.26.1">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-logs:2.26.3">
     </androidPackage>
-    <androidPackage spec="com.datadoghq:dd-sdk-android-ndk:2.26.1">
+    <androidPackage spec="com.datadoghq:dd-sdk-android-ndk:2.26.3">
     </androidPackage>
   </androidPackages>
   <iosPods>

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -148,14 +148,19 @@ namespace Datadog.Unity.Android
                 using var internalBuilderCompanion = internalBuilder.GetStatic<AndroidJavaObject>("Companion");
                 internalBuilderCompanion.Call<AndroidJavaObject>("setTelemetryConfigurationEventMapper", rumConfigBuilder, new TelemetryCallback());
 
-                // Uncomment to always send Configuraiton telemetry
-                // var rumAdditionalConfig = new Dictionary<string, object>()
-                // {
-                //     { "_dd.telemetry.configuration_sample_rate", 100.0f },
-                // };
-                // internalBuilderCompanion.Call<AndroidJavaObject>("setAdditionalConfiguration",
-                //     rumConfigBuilder,
-                //     DatadogAndroidHelpers.DictionaryToJavaMap(rumAdditionalConfig));
+                var rumAdditionalConfig = new Dictionary<string, object>()
+                {
+                    // JankStats does not work for Unity apps, and disabling it entirely
+                    // safeguards against known crash issues with androidx.metrics
+                    { "_dd.rum.disable_jank_stats", true }
+                };
+
+                // Uncomment to always send Configuration telemetry
+                // rumAdditionalConfig["_dd.telemetry.configuration_sample_rate"] = 100.0f;
+
+                internalBuilderCompanion.Call<AndroidJavaObject>("setAdditionalConfiguration",
+                    rumConfigBuilder,
+                    DatadogAndroidHelpers.DictionaryToJavaMap(rumAdditionalConfig));
 
                 using var rumConfig = rumConfigBuilder.Call<AndroidJavaObject>("build");
                 using var rumClass = new AndroidJavaClass("com.datadog.android.rum.Rum");

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -148,19 +148,18 @@ namespace Datadog.Unity.Android
                 using var internalBuilderCompanion = internalBuilder.GetStatic<AndroidJavaObject>("Companion");
                 internalBuilderCompanion.Call<AndroidJavaObject>("setTelemetryConfigurationEventMapper", rumConfigBuilder, new TelemetryCallback());
 
-                var rumAdditionalConfig = new Dictionary<string, object>()
-                {
-                    // JankStats does not work for Unity apps, and disabling it entirely
-                    // safeguards against known crash issues with androidx.metrics
-                    { "_dd.rum.disable_jank_stats", true }
-                };
+                // JankStats does not work for Unity apps, and disabling it entirely safeguards against
+                // known crash issues with androidx.metrics
+                internalBuilderCompanion.Call<AndroidJavaObject>("setDisableJankStats", rumConfigBuilder, true);
 
                 // Uncomment to always send Configuration telemetry
-                // rumAdditionalConfig["_dd.telemetry.configuration_sample_rate"] = 100.0f;
-
-                internalBuilderCompanion.Call<AndroidJavaObject>("setAdditionalConfiguration",
-                    rumConfigBuilder,
-                    DatadogAndroidHelpers.DictionaryToJavaMap(rumAdditionalConfig));
+                // var rumAdditionalConfig = new Dictionary<string, object>()
+                // {
+                //     { "_dd.telemetry.configuration_sample_rate", 100.0f }
+                // };
+                // internalBuilderCompanion.Call<AndroidJavaObject>("setAdditionalConfiguration",
+                //     rumConfigBuilder,
+                //     DatadogAndroidHelpers.DictionaryToJavaMap(rumAdditionalConfig));
 
                 using var rumConfig = rumConfigBuilder.Call<AndroidJavaObject>("build");
                 using var rumClass = new AndroidJavaClass("com.datadog.android.rum.Rum");


### PR DESCRIPTION
refs: RUM-12764

This PR updates Android RUM initialization logic such that we always call `setDisableJankStats(true)` when configuring `dd-sdk-android`.

This change depends on [an accompanying dd-sdk-android fix](https://github.com/DataDog/dd-sdk-android/pull/3000), which will need to be released in v2. We'll need to bump the Unity SDK's dd-sdk-android dependency once that release is available.