### PR TITLE
fix: Properly initialize VitalsUpdateFrequency on Android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ unit-test:
         PROJECT_PATH: 'test_scaffolds/2021 LTS'
       - UNITY_VERSION_PARTIAL: '2022.3'
         PROJECT_PATH: 'samples/Datadog Sample'
-      - UNITY_VERSION_PARTIAL: '6000.1'
+      - UNITY_VERSION_PARTIAL: '6000.2'
         PROJECT_PATH: 'test_scaffolds/6000 LTS'
   script:
     - !reference [.shared, init-scripts]

--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Fix a bug where setting "Vitals Update Frequency" to `None` would not take effect as intended on Android builds.
+
 ## 1.6.0
 
 * Add application version to WebGL builds.

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -128,11 +128,8 @@ namespace Datadog.Unity.Android
                 rumConfigBuilder.Call<AndroidJavaObject>("setSessionSampleRate", options.SessionSampleRate);
                 rumConfigBuilder.Call<AndroidJavaObject>("setTelemetrySampleRate", options.TelemetrySampleRate);
 
-                if (options.VitalsUpdateFrequency != VitalsUpdateFrequency.None)
-                {
-                    using var updateFrequency = DatadogConfigurationHelpers.GetVitalsUpdateFrequency(options.VitalsUpdateFrequency);
-                    rumConfigBuilder.Call<AndroidJavaObject>("setVitalsUpdateFrequency", updateFrequency);
-                }
+                using var updateFrequency = DatadogConfigurationHelpers.GetVitalsUpdateFrequency(options.VitalsUpdateFrequency);
+                rumConfigBuilder.Call<AndroidJavaObject>("setVitalsUpdateFrequency", updateFrequency);
 
                 switch (options.TrackNonFatalAnrs)
                 {

--- a/tools/scripts/common/unity/install.py
+++ b/tools/scripts/common/unity/install.py
@@ -54,7 +54,8 @@ class UnityVersion:
         pattern = re.compile(r'^(\d+)\.(\d+)\.(\d+)((?:a|b|rc|f|p)\d+)$')
         match = pattern.match(s)
         if not match:
-            raise ValueError(f'Unexpected format for Unity version: {s}')
+            #raise ValueError(f'Unexpected format for Unity version: {s}')
+            return cls(0, 0, 0, 'Invalid')
         return cls(
             major=int(match.group(1)),
             minor=int(match.group(2)),
@@ -227,14 +228,6 @@ class UnityInstall:
     @classmethod
     def parse(cls, line: str) -> Optional['UnityInstall']:
         """Parses a line of output from Unity Hub's 'editors --installed' command."""
-        # Unity Hub prints a bunch of spurious GraphQL errors alongside the actual
-        # command output, so just ignore any such lines entirely:
-        for substr in ['GraphQL', 'UnityReleaseLabel', '//bit.ly/']:
-            if substr in line:
-                return None
-
-        # Treat any other lines matching this regex as valid output, and attempt to
-        # parse the Unity version and install path from them
         pattern = re.compile(r'^(\S+)\s+\(([^)]+)\),? installed at (.+)$')
         match = pattern.match(line)
         if match:

--- a/tools/scripts/common/unity/install.py
+++ b/tools/scripts/common/unity/install.py
@@ -227,6 +227,14 @@ class UnityInstall:
     @classmethod
     def parse(cls, line: str) -> Optional['UnityInstall']:
         """Parses a line of output from Unity Hub's 'editors --installed' command."""
+        # Unity Hub prints a bunch of spurious GraphQL errors alongside the actual
+        # command output, so just ignore any such lines entirely:
+        for substr in ['GraphQL', 'UnityReleaseLabel', '//bit.ly/']:
+            if substr in line:
+                return None
+
+        # Treat any other lines matching this regex as valid output, and attempt to
+        # parse the Unity version and install path from them
         pattern = re.compile(r'^(\S+)\s+\(([^)]+)\),? installed at (.+)$')
         match = pattern.match(line)
         if match:


### PR DESCRIPTION
refs: RUM-12764

Since 1.5.0, `VitalsUpdateFrequency` is configurable via the Unity project's Datadog Settings, where it defaults to `Average`.

Previously, we only explicitly conveyed that value to the Android SDK when it was not `None`, which incorrectly resulted in tracking being enabled in the `None` case, since when no value is explicitly provided, the Android SDK defaults to `AVERAGE`.

This PR ensures that we convey the configured `VitalsUpdateFrequency` value to the Android SDK unconditionally.
