### PR TITLE
Add Feature Flags SDK for Unity

### DIFF
--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -1,0 +1,174 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using Datadog.Unity.Core;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Entry point for the Datadog Flags feature in Unity.
+    ///
+    /// Usage:
+    /// <code>
+    /// // After Datadog SDK is initialized
+    /// DdFlags.Enable(new FlagsConfiguration());
+    ///
+    /// // Create a client
+    /// var client = DdFlags.CreateClient();
+    ///
+    /// // Set evaluation context
+    /// client.SetEvaluationContext(new FlagsEvaluationContext("user-123", new Dictionary&lt;string, object&gt;
+    /// {
+    ///     { "email", "user@example.com" },
+    ///     { "plan", "premium" }
+    /// }));
+    ///
+    /// // Evaluate flags
+    /// var showFeature = client.GetBooleanValue("show-new-feature", false);
+    /// </code>
+    /// </summary>
+    public static class DdFlags
+    {
+        private static FlagsConfiguration _configuration;
+        private static EvpTelemetrySender _telemetrySender;
+        private static readonly Dictionary<string, FlagsClient> _clients = new();
+        private static bool _enabled;
+
+        /// <summary>
+        /// Enables the Datadog Flags feature. Must be called after Datadog SDK initialization.
+        /// </summary>
+        /// <param name="configuration">Configuration options for the Flags feature.</param>
+        public static void Enable(FlagsConfiguration configuration = null)
+        {
+            if (_enabled)
+            {
+                DatadogSdk.Instance.InternalLogger?.Log(Logs.DdLogLevel.Warn, "DdFlags.Enable called multiple times. Ignoring.");
+                return;
+            }
+
+            _configuration = configuration ?? new FlagsConfiguration();
+            _enabled = true;
+
+            // Initialize the telemetry sender
+            var options = DatadogConfigurationOptions.Load();
+            if (options != null)
+            {
+                var exposureEndpoint = FlagsEndpoints.GetExposureEndpoint(options.Site, _configuration.CustomExposureEndpoint);
+                var evaluationEndpoint = FlagsEndpoints.GetEvaluationEndpoint(options.Site, _configuration.CustomEvaluationEndpoint);
+
+                _telemetrySender = new EvpTelemetrySender(
+                    clientToken: options.ClientToken,
+                    exposureEndpoint: exposureEndpoint,
+                    evaluationEndpoint: evaluationEndpoint,
+                    logger: DatadogSdk.Instance.InternalLogger);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new FlagsClient for evaluating feature flags.
+        /// </summary>
+        /// <param name="name">A unique name for this client. Defaults to "default".</param>
+        /// <returns>A FlagsClient instance.</returns>
+        public static FlagsClient CreateClient(string name = FlagsClient.DefaultName)
+        {
+            if (!_enabled)
+            {
+                DatadogSdk.Instance.InternalLogger?.Log(Logs.DdLogLevel.Warn,
+                    "DdFlags.CreateClient called before DdFlags.Enable(). Call DdFlags.Enable() first.");
+            }
+
+            if (_clients.ContainsKey(name))
+            {
+                DatadogSdk.Instance.InternalLogger?.Log(Logs.DdLogLevel.Warn,
+                    $"FlagsClient named '{name}' already exists. Returning existing client.");
+                return _clients[name];
+            }
+
+            var options = DatadogConfigurationOptions.Load();
+            var logger = DatadogSdk.Instance.InternalLogger;
+            var config = _configuration ?? new FlagsConfiguration();
+
+            // Determine precompute endpoint
+            string precomputeEndpoint;
+            if (!string.IsNullOrEmpty(config.CustomFlagsEndpoint))
+            {
+                precomputeEndpoint = config.CustomFlagsEndpoint;
+            }
+            else if (options != null)
+            {
+                precomputeEndpoint = FlagsEndpoints.GetPrecomputeEndpoint(options.Site);
+            }
+            else
+            {
+                precomputeEndpoint = FlagsEndpoints.GetPrecomputeEndpoint(DatadogSite.Us1);
+            }
+
+            var repository = new FlagsRepository();
+            var exposureTracker = new ExposureTracker();
+
+            Action<ExposureEvent> onExposure = null;
+            if (config.TrackExposures && _telemetrySender != null)
+            {
+                onExposure = _telemetrySender.SendExposure;
+            }
+
+            EvaluationAggregator evaluationAggregator = null;
+            if (config.TrackEvaluations && _telemetrySender != null)
+            {
+                var sender = _telemetrySender;
+                evaluationAggregator = new EvaluationAggregator(
+                    onFlush: events => sender.SendEvaluations(events),
+                    flushIntervalSeconds: config.EvaluationFlushIntervalSeconds);
+            }
+
+            var fetcher = new PrecomputeAssignmentsFetcher(
+                endpointUrl: precomputeEndpoint,
+                clientToken: options?.ClientToken ?? string.Empty,
+                applicationId: options?.RumApplicationId,
+                env: options?.Env ?? string.Empty,
+                logger: logger);
+
+            var client = new FlagsClient(
+                repository: repository,
+                exposureTracker: exposureTracker,
+                evaluationAggregator: evaluationAggregator,
+                fetcher: fetcher,
+                logger: logger,
+                trackExposures: config.TrackExposures,
+                trackEvaluations: config.TrackEvaluations,
+                onExposure: onExposure);
+
+            _clients[name] = client;
+            return client;
+        }
+
+        /// <summary>
+        /// Gets an existing FlagsClient by name.
+        /// </summary>
+        /// <param name="name">The name of the client. Defaults to "default".</param>
+        /// <returns>The FlagsClient, or null if not found.</returns>
+        public static FlagsClient GetClient(string name = FlagsClient.DefaultName)
+        {
+            _clients.TryGetValue(name, out var client);
+            return client;
+        }
+
+        /// <summary>
+        /// Shuts down the Flags feature and disposes all clients.
+        /// </summary>
+        public static void Shutdown()
+        {
+            foreach (var client in _clients.Values)
+            {
+                client.Dispose();
+            }
+            _clients.Clear();
+            _telemetrySender = null;
+            _configuration = null;
+            _enabled = false;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs
@@ -1,0 +1,244 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Aggregates flag evaluation events and flushes them periodically or when the max count is reached.
+    /// Matching the iOS EvaluationAggregator pattern: dimensions = (flagKey, variantKey, allocationKey,
+    /// targetingKey, errorMessage, contextHash). Flush triggers: timer (10s default), max aggregations (1000).
+    /// </summary>
+    internal class EvaluationAggregator : IDisposable
+    {
+        internal struct AggregationKey : IEquatable<AggregationKey>
+        {
+            public readonly string FlagKey;
+            public readonly string VariantKey;
+            public readonly string AllocationKey;
+            public readonly string TargetingKey;
+            public readonly string ErrorMessage;
+            public readonly int ContextHash;
+
+            public AggregationKey(
+                string flagKey,
+                string variantKey,
+                string allocationKey,
+                string targetingKey,
+                string errorMessage,
+                Dictionary<string, object> context)
+            {
+                FlagKey = flagKey;
+                VariantKey = variantKey;
+                AllocationKey = allocationKey;
+                TargetingKey = targetingKey;
+                ErrorMessage = errorMessage;
+
+                // Deterministic hash of context attributes (sorted keys)
+                unchecked
+                {
+                    var hash = 17;
+                    if (context != null)
+                    {
+                        foreach (var key in context.Keys.OrderBy(k => k, StringComparer.Ordinal))
+                        {
+                            hash = hash * 31 + key.GetHashCode();
+                            hash = hash * 31 + (context[key]?.GetHashCode() ?? 0);
+                        }
+                    }
+                    ContextHash = hash;
+                }
+            }
+
+            public bool Equals(AggregationKey other)
+            {
+                return FlagKey == other.FlagKey
+                    && VariantKey == other.VariantKey
+                    && AllocationKey == other.AllocationKey
+                    && TargetingKey == other.TargetingKey
+                    && ErrorMessage == other.ErrorMessage
+                    && ContextHash == other.ContextHash;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is AggregationKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hash = 17;
+                    hash = hash * 31 + (FlagKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (VariantKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (AllocationKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (TargetingKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (ErrorMessage?.GetHashCode() ?? 0);
+                    hash = hash * 31 + ContextHash;
+                    return hash;
+                }
+            }
+        }
+
+        internal class AggregatedEvaluation
+        {
+            public string FlagKey;
+            public string VariantKey;
+            public string AllocationKey;
+            public string TargetingKey;
+            public string TargetingRuleKey;
+            public string ErrorMessage;
+            public Dictionary<string, object> Context;
+            public long FirstEvaluation;
+            public long LastEvaluation;
+            public int EvaluationCount;
+            public bool? RuntimeDefaultUsed;
+
+            public FlagEvaluationEvent ToFlagEvaluationEvent()
+            {
+                return new FlagEvaluationEvent
+                {
+                    Timestamp = FirstEvaluation,
+                    FlagKey = FlagKey,
+                    FirstEvaluation = FirstEvaluation,
+                    LastEvaluation = LastEvaluation,
+                    EvaluationCount = EvaluationCount,
+                    VariantKey = RuntimeDefaultUsed == true ? null : VariantKey,
+                    AllocationKey = RuntimeDefaultUsed == true ? null : AllocationKey,
+                    TargetingRuleKey = TargetingRuleKey,
+                    TargetingKey = TargetingKey,
+                    RuntimeDefaultUsed = RuntimeDefaultUsed,
+                    ErrorMessage = ErrorMessage,
+                    EvaluationAttributes = Context?.Count > 0 ? Context : null,
+                };
+            }
+        }
+
+        public const int DefaultMaxAggregations = 1_000;
+        public const float DefaultFlushIntervalSeconds = 10.0f;
+        public const float MinFlushIntervalSeconds = 1.0f;
+        public const float MaxFlushIntervalSeconds = 60.0f;
+
+        private readonly object _lock = new();
+        private readonly int _maxAggregations;
+        private readonly float _flushIntervalSeconds;
+        private Dictionary<AggregationKey, AggregatedEvaluation> _aggregations = new();
+        private Timer _flushTimer;
+        private Action<List<FlagEvaluationEvent>> _onFlush;
+        private bool _disposed;
+
+        public EvaluationAggregator(
+            Action<List<FlagEvaluationEvent>> onFlush,
+            float flushIntervalSeconds = DefaultFlushIntervalSeconds,
+            int maxAggregations = DefaultMaxAggregations)
+        {
+            _onFlush = onFlush;
+            _flushIntervalSeconds = Math.Max(MinFlushIntervalSeconds, Math.Min(MaxFlushIntervalSeconds, flushIntervalSeconds));
+            _maxAggregations = maxAggregations;
+
+            var intervalMs = (int)(_flushIntervalSeconds * 1000);
+            _flushTimer = new Timer(OnTimerElapsed, null, intervalMs, intervalMs);
+        }
+
+        public void RecordEvaluation(
+            string flagKey,
+            FlagAssignment assignment,
+            FlagsEvaluationContext evaluationContext,
+            string flagError)
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            var key = new AggregationKey(
+                flagKey: flagKey,
+                variantKey: assignment?.VariationKey,
+                allocationKey: assignment?.AllocationKey,
+                targetingKey: evaluationContext?.TargetingKey,
+                errorMessage: flagError,
+                context: evaluationContext?.Attributes);
+
+            lock (_lock)
+            {
+                if (_aggregations.TryGetValue(key, out var existing))
+                {
+                    existing.EvaluationCount += 1;
+                    existing.LastEvaluation = now;
+                }
+                else
+                {
+                    var reason = assignment?.Reason;
+                    var runtimeDefaultUsed = reason == "DEFAULT" || flagError != null;
+
+                    _aggregations[key] = new AggregatedEvaluation
+                    {
+                        FlagKey = flagKey,
+                        VariantKey = assignment?.VariationKey,
+                        AllocationKey = assignment?.AllocationKey,
+                        TargetingKey = evaluationContext?.TargetingKey,
+                        TargetingRuleKey = null,
+                        ErrorMessage = flagError,
+                        Context = evaluationContext?.Attributes,
+                        FirstEvaluation = now,
+                        LastEvaluation = now,
+                        EvaluationCount = 1,
+                        RuntimeDefaultUsed = runtimeDefaultUsed ? true : (bool?)null,
+                    };
+                }
+
+                if (_aggregations.Count >= _maxAggregations)
+                {
+                    FlushInternal();
+                }
+            }
+        }
+
+        public void Flush()
+        {
+            lock (_lock)
+            {
+                FlushInternal();
+            }
+        }
+
+        private void FlushInternal()
+        {
+            if (_aggregations.Count == 0)
+            {
+                return;
+            }
+
+            var events = _aggregations.Values
+                .Select(a => a.ToFlagEvaluationEvent())
+                .ToList();
+
+            _aggregations.Clear();
+
+            _onFlush?.Invoke(events);
+        }
+
+        private void OnTimerElapsed(object state)
+        {
+            Flush();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _flushTimer?.Dispose();
+            _flushTimer = null;
+
+            // Final flush
+            Flush();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Unity.Core;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Sends EVP telemetry events (exposures and flag evaluations) to Datadog intake endpoints.
+    /// </summary>
+    internal class EvpTelemetrySender
+    {
+        private readonly string _clientToken;
+        private readonly string _exposureEndpoint;
+        private readonly string _evaluationEndpoint;
+        private readonly IInternalLogger _logger;
+
+        public EvpTelemetrySender(
+            string clientToken,
+            string exposureEndpoint,
+            string evaluationEndpoint,
+            IInternalLogger logger)
+        {
+            _clientToken = clientToken;
+            _exposureEndpoint = exposureEndpoint;
+            _evaluationEndpoint = evaluationEndpoint;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Sends a single exposure event to the exposure intake endpoint.
+        /// Format: NDJSON (newline-delimited JSON), Content-Type: text/plain; charset=utf-8.
+        /// </summary>
+        public void SendExposure(ExposureEvent exposure)
+        {
+            if (exposure == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var json = exposure.ToJson();
+                var bodyBytes = Encoding.UTF8.GetBytes(json);
+
+                var url = AppendDdSource(_exposureEndpoint);
+                var request = new UnityWebRequest(url, "POST");
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "text/plain; charset=utf-8");
+                request.SetRequestHeader("dd-api-key", _clientToken);
+                request.SetRequestHeader("dd-evp-origin", "unity");
+                request.SetRequestHeader("dd-evp-origin-version", DatadogSdk.SdkVersion);
+
+                var operation = request.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    if (request.result != UnityWebRequest.Result.Success)
+                    {
+                        _logger?.Log(Logs.DdLogLevel.Debug, $"Failed to send exposure event: {request.error}");
+                    }
+                    request.Dispose();
+                };
+            }
+            catch (Exception e)
+            {
+                _logger?.TelemetryError("Error sending exposure event", e);
+            }
+        }
+
+        /// <summary>
+        /// Sends a batch of flag evaluation events to the evaluation intake endpoint.
+        /// Format: JSON with BatchedFlagEvaluations structure, Content-Type: application/json.
+        /// </summary>
+        public void SendEvaluations(List<FlagEvaluationEvent> evaluations)
+        {
+            if (evaluations == null || evaluations.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                var json = BuildBatchedEvaluationsJson(evaluations);
+                var bodyBytes = Encoding.UTF8.GetBytes(json);
+
+                var url = AppendDdSource(_evaluationEndpoint);
+                var request = new UnityWebRequest(url, "POST");
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+                request.SetRequestHeader("dd-api-key", _clientToken);
+                request.SetRequestHeader("dd-evp-origin", "unity");
+                request.SetRequestHeader("dd-evp-origin-version", DatadogSdk.SdkVersion);
+
+                var operation = request.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    if (request.result != UnityWebRequest.Result.Success)
+                    {
+                        _logger?.Log(Logs.DdLogLevel.Debug, $"Failed to send evaluation events: {request.error}");
+                    }
+                    request.Dispose();
+                };
+            }
+            catch (Exception e)
+            {
+                _logger?.TelemetryError("Error sending evaluation events", e);
+            }
+        }
+
+        private string BuildBatchedEvaluationsJson(List<FlagEvaluationEvent> evaluations)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"context\":");
+            sb.Append(BuildBatchContextJson());
+            sb.Append(",\"flagEvaluations\":[");
+
+            for (var i = 0; i < evaluations.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+                sb.Append(evaluations[i].ToJson());
+            }
+
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private string BuildBatchContextJson()
+        {
+            var sb = new StringBuilder();
+            sb.Append('{');
+            sb.AppendFormat("\"device\":{{\"name\":{0},\"type\":{1},\"brand\":{2},\"model\":{3}}}",
+                JsonHelper.Escape(SystemInfo.deviceName),
+                JsonHelper.Escape(GetDeviceType()),
+                JsonHelper.Escape("Unity"),
+                JsonHelper.Escape(SystemInfo.deviceModel));
+            sb.AppendFormat(",\"os\":{{\"name\":{0},\"version\":{1}}}",
+                JsonHelper.Escape(SystemInfo.operatingSystemFamily.ToString()),
+                JsonHelper.Escape(SystemInfo.operatingSystem));
+            sb.AppendFormat(",\"service\":{0}", JsonHelper.Escape(Application.identifier ?? Application.productName));
+            sb.AppendFormat(",\"version\":{0}", JsonHelper.Escape(Application.version));
+            sb.AppendFormat(",\"env\":{0}", JsonHelper.Escape("prod"));
+            sb.Append('}');
+            return sb.ToString();
+        }
+
+        private static string GetDeviceType()
+        {
+            switch (SystemInfo.deviceType)
+            {
+                case DeviceType.Handheld: return "mobile";
+                case DeviceType.Console: return "console";
+                case DeviceType.Desktop: return "desktop";
+                default: return "other";
+            }
+        }
+
+        private static string AppendDdSource(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+            var separator = url.Contains("?") ? "&" : "?";
+            return url + separator + "ddsource=unity";
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents an exposure event sent to the /api/v2/exposures endpoint.
+    /// </summary>
+    internal class ExposureEvent
+    {
+        public ExposureEvent(long timestamp, string flagKey, string allocationKey, string variationKey, string subjectId, Dictionary<string, object> subjectAttributes)
+        {
+            Timestamp = timestamp;
+            FlagKey = flagKey;
+            AllocationKey = allocationKey;
+            VariationKey = variationKey;
+            SubjectId = subjectId;
+            SubjectAttributes = subjectAttributes ?? new Dictionary<string, object>();
+        }
+
+        public long Timestamp { get; }
+        public string FlagKey { get; }
+        public string AllocationKey { get; }
+        public string VariationKey { get; }
+        public string SubjectId { get; }
+        public Dictionary<string, object> SubjectAttributes { get; }
+
+        public string ToJson()
+        {
+            var sb = new StringBuilder();
+            sb.Append('{');
+            sb.AppendFormat("\"timestamp\":{0}", Timestamp);
+            sb.AppendFormat(",\"flag\":{{\"key\":{0}}}", JsonHelper.Escape(FlagKey));
+            sb.AppendFormat(",\"allocation\":{{\"key\":{0}}}", JsonHelper.Escape(AllocationKey));
+            sb.AppendFormat(",\"variant\":{{\"key\":{0}}}", JsonHelper.Escape(VariationKey));
+            sb.Append(",\"subject\":{");
+            sb.AppendFormat("\"id\":{0}", JsonHelper.Escape(SubjectId));
+            sb.Append(",\"attributes\":");
+            sb.Append(JsonHelper.DictionaryToJson(SubjectAttributes));
+            sb.Append('}');
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Tracks which exposures have been sent to avoid duplicate/over-frequent exposure events.
+    /// Uses an LRU-like cache with a count limit, matching the iOS ExposureTracker pattern.
+    /// Thread-safe via lock.
+    /// </summary>
+    internal class ExposureTracker
+    {
+        internal struct ExposureKey : IEquatable<ExposureKey>
+        {
+            public readonly string TargetingKey;
+            public readonly string FlagKey;
+            public readonly string AllocationKey;
+            public readonly string VariationKey;
+
+            public ExposureKey(string targetingKey, string flagKey, string allocationKey, string variationKey)
+            {
+                TargetingKey = targetingKey;
+                FlagKey = flagKey;
+                AllocationKey = allocationKey;
+                VariationKey = variationKey;
+            }
+
+            public bool Equals(ExposureKey other)
+            {
+                return TargetingKey == other.TargetingKey
+                    && FlagKey == other.FlagKey
+                    && AllocationKey == other.AllocationKey
+                    && VariationKey == other.VariationKey;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ExposureKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hash = 17;
+                    hash = hash * 31 + (TargetingKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (FlagKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (AllocationKey?.GetHashCode() ?? 0);
+                    hash = hash * 31 + (VariationKey?.GetHashCode() ?? 0);
+                    return hash;
+                }
+            }
+        }
+
+        public const int DefaultCountLimit = 1_000;
+
+        private readonly object _lock = new();
+        private readonly int _countLimit;
+        private readonly LinkedList<ExposureKey> _order = new();
+        private readonly Dictionary<ExposureKey, LinkedListNode<ExposureKey>> _cache = new();
+
+        public ExposureTracker(int countLimit = DefaultCountLimit)
+        {
+            _countLimit = countLimit;
+        }
+
+        /// <summary>
+        /// Returns true if the exposure has already been tracked.
+        /// </summary>
+        public bool Contains(ExposureKey exposure)
+        {
+            lock (_lock)
+            {
+                return _cache.ContainsKey(exposure);
+            }
+        }
+
+        /// <summary>
+        /// Inserts the exposure into the cache. If the cache is full, the oldest entry is evicted.
+        /// </summary>
+        public void Insert(ExposureKey exposure)
+        {
+            lock (_lock)
+            {
+                if (_cache.ContainsKey(exposure))
+                {
+                    // Move to end (most recently used)
+                    var node = _cache[exposure];
+                    _order.Remove(node);
+                    _order.AddLast(node);
+                    return;
+                }
+
+                // Evict oldest if at capacity
+                while (_cache.Count >= _countLimit && _order.First != null)
+                {
+                    var oldest = _order.First;
+                    _order.RemoveFirst();
+                    _cache.Remove(oldest.Value);
+                }
+
+                var newNode = _order.AddLast(exposure);
+                _cache[exposure] = newNode;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of items in the cache.
+        /// </summary>
+        internal int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _cache.Count;
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents a precomputed flag assignment returned from the server.
+    /// </summary>
+    internal class FlagAssignment
+    {
+        public FlagAssignment(
+            string variationType,
+            object variationValue,
+            bool doLog,
+            string allocationKey,
+            string variationKey,
+            string reason)
+        {
+            VariationType = variationType ?? string.Empty;
+            VariationValue = variationValue;
+            DoLog = doLog;
+            AllocationKey = allocationKey ?? string.Empty;
+            VariationKey = variationKey ?? string.Empty;
+            Reason = reason ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the type of the variation value (boolean, string, integer, number, float, object).
+        /// </summary>
+        public string VariationType { get; }
+
+        /// <summary>
+        /// Gets the parsed variation value.
+        /// </summary>
+        public object VariationValue { get; }
+
+        /// <summary>
+        /// Gets whether to track exposure for this flag.
+        /// </summary>
+        public bool DoLog { get; }
+
+        /// <summary>
+        /// Gets the allocation identifier.
+        /// </summary>
+        public string AllocationKey { get; }
+
+        /// <summary>
+        /// Gets the variation identifier.
+        /// </summary>
+        public string VariationKey { get; }
+
+        /// <summary>
+        /// Gets the resolution reason (DEFAULT, TARGETING_MATCH, RULE_MATCH, etc.).
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
+        /// Attempts to get the variation value as the specified type.
+        /// </summary>
+        public bool TryGetValue<T>(out T value)
+        {
+            try
+            {
+                if (VariationValue is T typedValue)
+                {
+                    value = typedValue;
+                    return true;
+                }
+
+                // Handle numeric conversions
+                if (typeof(T) == typeof(int) && VariationValue is long longVal)
+                {
+                    value = (T)(object)(int)longVal;
+                    return true;
+                }
+
+                if (typeof(T) == typeof(double) && VariationValue is long longVal2)
+                {
+                    value = (T)(object)(double)longVal2;
+                    return true;
+                }
+
+                if (typeof(T) == typeof(double) && VariationValue is int intVal)
+                {
+                    value = (T)(object)(double)intVal;
+                    return true;
+                }
+
+                if (typeof(T) == typeof(int) && VariationValue is double doubleVal)
+                {
+                    value = (T)(object)(int)doubleVal;
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Error codes for flag evaluation failures.
+    /// </summary>
+    public enum FlagEvaluationError
+    {
+        /// <summary>The provider is not ready to evaluate flags.</summary>
+        ProviderNotReady,
+
+        /// <summary>The flag key was not found.</summary>
+        FlagNotFound,
+
+        /// <summary>The flag type does not match the requested type.</summary>
+        TypeMismatch,
+    }
+
+    /// <summary>
+    /// Reason codes explaining why a particular flag value was resolved.
+    /// </summary>
+    public enum ResolutionReason
+    {
+        /// <summary>No targeting rules matched; the fallthrough/default allocation was used.</summary>
+        Static,
+
+        /// <summary>The resolved value is the default value provided in code.</summary>
+        Default,
+
+        /// <summary>The resolved value matched targeting rules.</summary>
+        TargetingMatch,
+
+        /// <summary>The resolved value matched a specific evaluation rule.</summary>
+        RuleMatch,
+
+        /// <summary>A prerequisite flag evaluation failed.</summary>
+        PrerequisiteFailed,
+
+        /// <summary>An error occurred during flag evaluation.</summary>
+        Error,
+    }
+
+    /// <summary>
+    /// Detailed result of a flag evaluation including value, variant, reason, and error information.
+    /// </summary>
+    /// <typeparam name="T">The type of the flag value.</typeparam>
+    public class FlagDetails<T>
+    {
+        internal FlagDetails(string key, T value, string variant = null, string reason = null, FlagEvaluationError? error = null)
+        {
+            Key = key;
+            Value = value;
+            Variant = variant;
+            Reason = reason;
+            Error = error;
+        }
+
+        /// <summary>Gets the flag key.</summary>
+        public string Key { get; }
+
+        /// <summary>Gets the evaluated or default value.</summary>
+        public T Value { get; }
+
+        /// <summary>Gets the variant served (null if not found).</summary>
+        public string Variant { get; }
+
+        /// <summary>Gets the evaluation reason (null if not found).</summary>
+        public string Reason { get; }
+
+        /// <summary>Gets the evaluation error (null if successful).</summary>
+        public FlagEvaluationError? Error { get; }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents an aggregated flag evaluation event sent to /api/v2/flagevaluation.
+    /// </summary>
+    internal class FlagEvaluationEvent
+    {
+        public long Timestamp { get; set; }
+        public string FlagKey { get; set; }
+        public long FirstEvaluation { get; set; }
+        public long LastEvaluation { get; set; }
+        public int EvaluationCount { get; set; }
+        public string VariantKey { get; set; }
+        public string AllocationKey { get; set; }
+        public string TargetingRuleKey { get; set; }
+        public string TargetingKey { get; set; }
+        public bool? RuntimeDefaultUsed { get; set; }
+        public string ErrorMessage { get; set; }
+        public Dictionary<string, object> EvaluationAttributes { get; set; }
+
+        public string ToJson()
+        {
+            var sb = new StringBuilder();
+            sb.Append('{');
+            sb.AppendFormat("\"timestamp\":{0}", Timestamp);
+            sb.AppendFormat(",\"flag\":{{\"key\":{0}}}", JsonHelper.Escape(FlagKey));
+            sb.AppendFormat(",\"first_evaluation\":{0}", FirstEvaluation);
+            sb.AppendFormat(",\"last_evaluation\":{0}", LastEvaluation);
+            sb.AppendFormat(",\"evaluation_count\":{0}", EvaluationCount);
+
+            if (RuntimeDefaultUsed != true && VariantKey != null)
+            {
+                sb.AppendFormat(",\"variant\":{{\"key\":{0}}}", JsonHelper.Escape(VariantKey));
+            }
+
+            if (RuntimeDefaultUsed != true && AllocationKey != null)
+            {
+                sb.AppendFormat(",\"allocation\":{{\"key\":{0}}}", JsonHelper.Escape(AllocationKey));
+            }
+
+            if (TargetingRuleKey != null)
+            {
+                sb.AppendFormat(",\"targeting_rule\":{{\"key\":{0}}}", JsonHelper.Escape(TargetingRuleKey));
+            }
+
+            if (TargetingKey != null)
+            {
+                sb.AppendFormat(",\"targeting_key\":{0}", JsonHelper.Escape(TargetingKey));
+            }
+
+            if (RuntimeDefaultUsed.HasValue)
+            {
+                sb.AppendFormat(",\"runtime_default_used\":{0}", RuntimeDefaultUsed.Value ? "true" : "false");
+            }
+
+            if (ErrorMessage != null)
+            {
+                sb.AppendFormat(",\"error\":{{\"message\":{0}}}", JsonHelper.Escape(ErrorMessage));
+            }
+
+            if (EvaluationAttributes != null && EvaluationAttributes.Count > 0)
+            {
+                sb.Append(",\"context\":{\"evaluation\":");
+                sb.Append(JsonHelper.DictionaryToJson(EvaluationAttributes));
+                sb.Append('}');
+            }
+
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -1,0 +1,248 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// A client for evaluating feature flags in your Unity application.
+    /// Provides type-safe access to flag values with automatic exposure tracking
+    /// and evaluation aggregation.
+    /// </summary>
+    public class FlagsClient : IDisposable
+    {
+        public const string DefaultName = "default";
+
+        private readonly FlagsRepository _repository;
+        private readonly ExposureTracker _exposureTracker;
+        private readonly EvaluationAggregator _evaluationAggregator;
+        private readonly PrecomputeAssignmentsFetcher _fetcher;
+        private readonly Core.IInternalLogger _logger;
+        private readonly bool _trackExposures;
+        private readonly bool _trackEvaluations;
+        private readonly Action<ExposureEvent> _onExposure;
+
+        private FlagsClientState _state = FlagsClientState.NotReady;
+        private bool _disposed;
+
+        internal FlagsClient(
+            FlagsRepository repository,
+            ExposureTracker exposureTracker,
+            EvaluationAggregator evaluationAggregator,
+            PrecomputeAssignmentsFetcher fetcher,
+            Core.IInternalLogger logger,
+            bool trackExposures,
+            bool trackEvaluations,
+            Action<ExposureEvent> onExposure)
+        {
+            _repository = repository;
+            _exposureTracker = exposureTracker;
+            _evaluationAggregator = evaluationAggregator;
+            _fetcher = fetcher;
+            _logger = logger;
+            _trackExposures = trackExposures;
+            _trackEvaluations = trackEvaluations;
+            _onExposure = onExposure;
+        }
+
+        /// <summary>
+        /// Gets the current state of the client.
+        /// </summary>
+        public FlagsClientState State => _state;
+
+        /// <summary>
+        /// Event raised when the client state changes.
+        /// </summary>
+        public event Action<FlagsClientState> StateChanged;
+
+        /// <summary>
+        /// Sets the evaluation context and fetches precomputed flag assignments from the server.
+        /// </summary>
+        /// <param name="context">The evaluation context containing targeting key and attributes.</param>
+        /// <param name="onComplete">Optional callback invoked when the fetch completes (true = success).</param>
+        public void SetEvaluationContext(FlagsEvaluationContext context, Action<bool> onComplete = null)
+        {
+            if (context == null)
+            {
+                _logger?.Log(Logs.DdLogLevel.Warn, "SetEvaluationContext called with null context. Ignoring.");
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            TransitionState(FlagsClientState.Reconciling);
+
+            _fetcher.Fetch(context, flags =>
+            {
+                if (flags != null)
+                {
+                    _repository.SetFlagsAndContext(context, flags);
+                    TransitionState(FlagsClientState.Ready);
+                    onComplete?.Invoke(true);
+                }
+                else
+                {
+                    // If we have cached flags, transition to Stale; otherwise Error
+                    if (_repository.HasFlags())
+                    {
+                        TransitionState(FlagsClientState.Stale);
+                    }
+                    else
+                    {
+                        TransitionState(FlagsClientState.Error);
+                    }
+                    onComplete?.Invoke(false);
+                }
+            });
+        }
+
+        // --- Type-safe value accessors ---
+
+        public bool GetBooleanValue(string key, bool defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public string GetStringValue(string key, string defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public int GetIntegerValue(string key, int defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public double GetDoubleValue(string key, double defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public object GetObjectValue(string key, object defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        // --- Detailed accessors ---
+
+        public FlagDetails<bool> GetBooleanDetails(string key, bool defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<string> GetStringDetails(string key, string defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<int> GetIntegerDetails(string key, int defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<double> GetDoubleDetails(string key, double defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets detailed evaluation result for a flag, including variant, reason, and error info.
+        /// </summary>
+        public FlagDetails<T> GetDetails<T>(string key, T defaultValue)
+        {
+            var assignment = _repository.GetFlagAssignment(key);
+
+            if (assignment == null)
+            {
+                TrackEvaluation(key, null, "FLAG_NOT_FOUND");
+                return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.FlagNotFound);
+            }
+
+            if (!assignment.TryGetValue<T>(out var value))
+            {
+                TrackEvaluation(key, assignment, "TYPE_MISMATCH");
+                return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.TypeMismatch);
+            }
+
+            var details = new FlagDetails<T>(
+                key: key,
+                value: value,
+                variant: assignment.VariationKey,
+                reason: assignment.Reason);
+
+            TrackEvaluation(key, assignment, null);
+            return details;
+        }
+
+        /// <summary>
+        /// Flushes any pending aggregated evaluation events.
+        /// </summary>
+        public void Flush()
+        {
+            _evaluationAggregator?.Flush();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            _evaluationAggregator?.Dispose();
+        }
+
+        private T GetValue<T>(string key, T defaultValue)
+        {
+            return GetDetails(key, defaultValue).Value;
+        }
+
+        private void TrackEvaluation(string key, FlagAssignment assignment, string flagError)
+        {
+            var context = _repository.Context;
+
+            // Exposure tracking
+            if (_trackExposures && assignment != null && assignment.DoLog && flagError == null)
+            {
+                var exposureKey = new ExposureTracker.ExposureKey(
+                    targetingKey: context?.TargetingKey ?? string.Empty,
+                    flagKey: key,
+                    allocationKey: assignment.AllocationKey,
+                    variationKey: assignment.VariationKey);
+
+                if (!_exposureTracker.Contains(exposureKey))
+                {
+                    _exposureTracker.Insert(exposureKey);
+
+                    var exposureEvent = new ExposureEvent(
+                        timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        flagKey: key,
+                        allocationKey: assignment.AllocationKey,
+                        variationKey: assignment.VariationKey,
+                        subjectId: context?.TargetingKey ?? string.Empty,
+                        subjectAttributes: context?.Attributes);
+
+                    _onExposure?.Invoke(exposureEvent);
+                }
+            }
+
+            // Evaluation aggregation
+            if (_trackEvaluations)
+            {
+                _evaluationAggregator?.RecordEvaluation(key, assignment, context, flagError);
+            }
+        }
+
+        private void TransitionState(FlagsClientState newState)
+        {
+            if (_state == newState)
+            {
+                return;
+            }
+            _state = newState;
+            StateChanged?.Invoke(newState);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents the current state of a FlagsClient.
+    /// </summary>
+    public enum FlagsClientState
+    {
+        /// <summary>The client is not ready to evaluate flags.</summary>
+        NotReady,
+
+        /// <summary>The client has loaded flags and is ready for evaluation.</summary>
+        Ready,
+
+        /// <summary>The client is fetching new flags for a context change.</summary>
+        Reconciling,
+
+        /// <summary>The client has stale cached flags (network failed).</summary>
+        Stale,
+
+        /// <summary>An unrecoverable error occurred.</summary>
+        Error,
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Configuration options for the Datadog Flags feature.
+    /// </summary>
+    public class FlagsConfiguration
+    {
+        /// <summary>
+        /// Enables exposure logging via the dedicated exposures intake endpoint.
+        /// Default: true.
+        /// </summary>
+        public bool TrackExposures { get; set; } = true;
+
+        /// <summary>
+        /// Enables evaluation logging via the dedicated evaluations intake endpoint.
+        /// Default: true.
+        /// </summary>
+        public bool TrackEvaluations { get; set; } = true;
+
+        /// <summary>
+        /// The interval in seconds at which aggregated evaluation data is flushed.
+        /// Clamped to [1, 60]. Default: 10.
+        /// </summary>
+        public float EvaluationFlushIntervalSeconds { get; set; } = 10.0f;
+
+        /// <summary>
+        /// Custom server URL for retrieving flag assignments.
+        /// If null, the SDK uses the default Datadog Flags endpoint for the configured site.
+        /// </summary>
+        public string CustomFlagsEndpoint { get; set; }
+
+        /// <summary>
+        /// Custom server URL for sending exposure events.
+        /// </summary>
+        public string CustomExposureEndpoint { get; set; }
+
+        /// <summary>
+        /// Custom server URL for sending evaluation events.
+        /// </summary>
+        public string CustomEvaluationEndpoint { get; set; }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Maps DatadogSite to the correct precompute and intake endpoints.
+    /// </summary>
+    internal static class FlagsEndpoints
+    {
+        /// <summary>
+        /// Gets the precompute assignments CDN endpoint for the given site.
+        /// </summary>
+        public static string GetPrecomputeEndpoint(DatadogSite site)
+        {
+            switch (site)
+            {
+                case DatadogSite.Us1:
+                    return "https://preview.ff-cdn.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us3:
+                    return "https://preview.ff-cdn.us3.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us5:
+                    return "https://preview.ff-cdn.us5.datadoghq.com/precompute-assignments";
+                case DatadogSite.Eu1:
+                    return "https://preview.ff-cdn.datadoghq.eu/precompute-assignments";
+                case DatadogSite.Ap1:
+                    return "https://preview.ff-cdn.ap1.datadoghq.com/precompute-assignments";
+                case DatadogSite.Ap2:
+                    return "https://preview.ff-cdn.ap2.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us1Fed:
+                    return "https://preview.ff-cdn.ddog-gov.com/precompute-assignments";
+                default:
+                    return "https://preview.ff-cdn.datadoghq.com/precompute-assignments";
+            }
+        }
+
+        /// <summary>
+        /// Gets the intake endpoint base URL for the given site.
+        /// </summary>
+        public static string GetIntakeEndpoint(DatadogSite site)
+        {
+            switch (site)
+            {
+                case DatadogSite.Us1:
+                    return "https://browser-intake-datadoghq.com";
+                case DatadogSite.Us3:
+                    return "https://browser-intake-us3-datadoghq.com";
+                case DatadogSite.Us5:
+                    return "https://browser-intake-us5-datadoghq.com";
+                case DatadogSite.Eu1:
+                    return "https://browser-intake-datadoghq.eu";
+                case DatadogSite.Ap1:
+                    return "https://browser-intake-ap1-datadoghq.com";
+                case DatadogSite.Ap2:
+                    return "https://browser-intake-ap2-datadoghq.com";
+                case DatadogSite.Us1Fed:
+                    return "https://browser-intake-ddog-gov.com";
+                default:
+                    return "https://browser-intake-datadoghq.com";
+            }
+        }
+
+        /// <summary>
+        /// Gets the exposure events endpoint URL.
+        /// </summary>
+        public static string GetExposureEndpoint(DatadogSite site, string customEndpoint = null)
+        {
+            if (!string.IsNullOrEmpty(customEndpoint))
+            {
+                return customEndpoint;
+            }
+            return GetIntakeEndpoint(site) + "/api/v2/exposures";
+        }
+
+        /// <summary>
+        /// Gets the flag evaluation events endpoint URL.
+        /// </summary>
+        public static string GetEvaluationEndpoint(DatadogSite site, string customEndpoint = null)
+        {
+            if (!string.IsNullOrEmpty(customEndpoint))
+            {
+                return customEndpoint;
+            }
+            return GetIntakeEndpoint(site) + "/api/v2/flagevaluation";
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents the evaluation context used for feature flag evaluation.
+    /// Contains the targeting key and optional attributes for targeting rules.
+    /// </summary>
+    public class FlagsEvaluationContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlagsEvaluationContext"/> class.
+        /// </summary>
+        /// <param name="targetingKey">The unique identifier for targeting/bucketing (e.g. user ID).</param>
+        /// <param name="attributes">Optional custom attributes for targeting rules.</param>
+        public FlagsEvaluationContext(string targetingKey, Dictionary<string, object> attributes = null)
+        {
+            TargetingKey = targetingKey ?? string.Empty;
+            Attributes = attributes ?? new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Gets the unique identifier used for targeting and bucketing.
+        /// </summary>
+        public string TargetingKey { get; }
+
+        /// <summary>
+        /// Gets the custom attributes used for targeting rules.
+        /// </summary>
+        public Dictionary<string, object> Attributes { get; }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Thread-safe repository for storing precomputed flag assignments and evaluation context.
+    /// </summary>
+    internal class FlagsRepository
+    {
+        private readonly object _lock = new();
+        private Dictionary<string, FlagAssignment> _flags = new();
+        private FlagsEvaluationContext _context;
+
+        /// <summary>
+        /// Gets the current evaluation context.
+        /// </summary>
+        public FlagsEvaluationContext Context
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _context;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a precomputed flag by key. Returns null if not found.
+        /// </summary>
+        public FlagAssignment GetFlagAssignment(string key)
+        {
+            lock (_lock)
+            {
+                _flags.TryGetValue(key, out var flag);
+                return flag;
+            }
+        }
+
+        /// <summary>
+        /// Sets the flags and context atomically.
+        /// </summary>
+        public void SetFlagsAndContext(FlagsEvaluationContext context, Dictionary<string, FlagAssignment> flags)
+        {
+            lock (_lock)
+            {
+                _context = context;
+                _flags = flags ?? new Dictionary<string, FlagAssignment>();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if any flags are cached.
+        /// </summary>
+        public bool HasFlags()
+        {
+            lock (_lock)
+            {
+                return _flags.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Returns a snapshot of all cached flags.
+        /// </summary>
+        public Dictionary<string, FlagAssignment> GetFlagsSnapshot()
+        {
+            lock (_lock)
+            {
+                return new Dictionary<string, FlagAssignment>(_flags);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/JsonHelper.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/JsonHelper.cs
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Lightweight JSON serialization helper to avoid external dependencies.
+    /// </summary>
+    internal static class JsonHelper
+    {
+        public static string Escape(string value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            var sb = new StringBuilder(value.Length + 2);
+            sb.Append('"');
+            foreach (var c in value)
+            {
+                switch (c)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            sb.AppendFormat("\\u{0:x4}", (int)c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        public static string ValueToJson(object value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            if (value is bool boolVal)
+            {
+                return boolVal ? "true" : "false";
+            }
+
+            if (value is int intVal)
+            {
+                return intVal.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is long longVal)
+            {
+                return longVal.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is double doubleVal)
+            {
+                return doubleVal.ToString("G", CultureInfo.InvariantCulture);
+            }
+
+            if (value is float floatVal)
+            {
+                return floatVal.ToString("G", CultureInfo.InvariantCulture);
+            }
+
+            if (value is string strVal)
+            {
+                return Escape(strVal);
+            }
+
+            if (value is IDictionary dict)
+            {
+                var sb = new StringBuilder();
+                sb.Append('{');
+                var first = true;
+                foreach (DictionaryEntry entry in dict)
+                {
+                    if (!first)
+                    {
+                        sb.Append(',');
+                    }
+                    sb.Append(Escape(entry.Key.ToString()));
+                    sb.Append(':');
+                    sb.Append(ValueToJson(entry.Value));
+                    first = false;
+                }
+                sb.Append('}');
+                return sb.ToString();
+            }
+
+            if (value is IList list)
+            {
+                var sb = new StringBuilder();
+                sb.Append('[');
+                for (var i = 0; i < list.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        sb.Append(',');
+                    }
+                    sb.Append(ValueToJson(list[i]));
+                }
+                sb.Append(']');
+                return sb.ToString();
+            }
+
+            return Escape(value.ToString());
+        }
+
+        public static string DictionaryToJson(Dictionary<string, object> dict)
+        {
+            if (dict == null || dict.Count == 0)
+            {
+                return "{}";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append('{');
+            var first = true;
+            foreach (var kvp in dict)
+            {
+                if (!first)
+                {
+                    sb.Append(',');
+                }
+                sb.Append(Escape(kvp.Key));
+                sb.Append(':');
+                sb.Append(ValueToJson(kvp.Value));
+                first = false;
+            }
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/MiniJson.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/MiniJson.cs
@@ -1,0 +1,288 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+// MiniJSON - Minimal JSON parser for Unity (no external dependencies).
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Datadog.Unity.Flags
+{
+    internal static class MiniJson
+    {
+        public static object Deserialize(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+            {
+                return null;
+            }
+
+            return new Parser(json).ParseValue();
+        }
+
+        private class Parser
+        {
+            private readonly string _json;
+            private int _pos;
+
+            public Parser(string json)
+            {
+                _json = json;
+                _pos = 0;
+            }
+
+            public object ParseValue()
+            {
+                SkipWhitespace();
+                if (_pos >= _json.Length)
+                {
+                    return null;
+                }
+
+                var c = _json[_pos];
+                switch (c)
+                {
+                    case '{': return ParseObject();
+                    case '[': return ParseArray();
+                    case '"': return ParseString();
+                    case 't':
+                    case 'f': return ParseBool();
+                    case 'n': return ParseNull();
+                    default:
+                        if (c == '-' || (c >= '0' && c <= '9'))
+                        {
+                            return ParseNumber();
+                        }
+                        return null;
+                }
+            }
+
+            private Dictionary<string, object> ParseObject()
+            {
+                var dict = new Dictionary<string, object>();
+                _pos++; // skip '{'
+                SkipWhitespace();
+
+                while (_pos < _json.Length && _json[_pos] != '}')
+                {
+                    SkipWhitespace();
+                    var key = ParseString();
+                    SkipWhitespace();
+                    if (_pos < _json.Length && _json[_pos] == ':')
+                    {
+                        _pos++;
+                    }
+                    var value = ParseValue();
+                    dict[key] = value;
+                    SkipWhitespace();
+                    if (_pos < _json.Length && _json[_pos] == ',')
+                    {
+                        _pos++;
+                    }
+                }
+
+                if (_pos < _json.Length)
+                {
+                    _pos++; // skip '}'
+                }
+
+                return dict;
+            }
+
+            private List<object> ParseArray()
+            {
+                var list = new List<object>();
+                _pos++; // skip '['
+                SkipWhitespace();
+
+                while (_pos < _json.Length && _json[_pos] != ']')
+                {
+                    list.Add(ParseValue());
+                    SkipWhitespace();
+                    if (_pos < _json.Length && _json[_pos] == ',')
+                    {
+                        _pos++;
+                    }
+                    SkipWhitespace();
+                }
+
+                if (_pos < _json.Length)
+                {
+                    _pos++; // skip ']'
+                }
+
+                return list;
+            }
+
+            private string ParseString()
+            {
+                if (_pos >= _json.Length || _json[_pos] != '"')
+                {
+                    return string.Empty;
+                }
+
+                _pos++; // skip '"'
+                var sb = new StringBuilder();
+
+                while (_pos < _json.Length)
+                {
+                    var c = _json[_pos];
+                    if (c == '"')
+                    {
+                        _pos++;
+                        return sb.ToString();
+                    }
+
+                    if (c == '\\')
+                    {
+                        _pos++;
+                        if (_pos >= _json.Length)
+                        {
+                            break;
+                        }
+
+                        c = _json[_pos];
+                        switch (c)
+                        {
+                            case '"': sb.Append('"'); break;
+                            case '\\': sb.Append('\\'); break;
+                            case '/': sb.Append('/'); break;
+                            case 'n': sb.Append('\n'); break;
+                            case 'r': sb.Append('\r'); break;
+                            case 't': sb.Append('\t'); break;
+                            case 'b': sb.Append('\b'); break;
+                            case 'f': sb.Append('\f'); break;
+                            case 'u':
+                                if (_pos + 4 < _json.Length)
+                                {
+                                    var hex = _json.Substring(_pos + 1, 4);
+                                    if (int.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code))
+                                    {
+                                        sb.Append((char)code);
+                                    }
+                                    _pos += 4;
+                                }
+                                break;
+                            default: sb.Append(c); break;
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    _pos++;
+                }
+
+                return sb.ToString();
+            }
+
+            private object ParseNumber()
+            {
+                var start = _pos;
+                var isFloat = false;
+
+                if (_pos < _json.Length && _json[_pos] == '-')
+                {
+                    _pos++;
+                }
+
+                while (_pos < _json.Length && _json[_pos] >= '0' && _json[_pos] <= '9')
+                {
+                    _pos++;
+                }
+
+                if (_pos < _json.Length && _json[_pos] == '.')
+                {
+                    isFloat = true;
+                    _pos++;
+                    while (_pos < _json.Length && _json[_pos] >= '0' && _json[_pos] <= '9')
+                    {
+                        _pos++;
+                    }
+                }
+
+                if (_pos < _json.Length && (_json[_pos] == 'e' || _json[_pos] == 'E'))
+                {
+                    isFloat = true;
+                    _pos++;
+                    if (_pos < _json.Length && (_json[_pos] == '+' || _json[_pos] == '-'))
+                    {
+                        _pos++;
+                    }
+                    while (_pos < _json.Length && _json[_pos] >= '0' && _json[_pos] <= '9')
+                    {
+                        _pos++;
+                    }
+                }
+
+                var numStr = _json.Substring(start, _pos - start);
+
+                if (isFloat)
+                {
+                    if (double.TryParse(numStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
+                    {
+                        return d;
+                    }
+                }
+                else
+                {
+                    if (long.TryParse(numStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var l))
+                    {
+                        // Return int if it fits
+                        if (l >= int.MinValue && l <= int.MaxValue)
+                        {
+                            return (long)l;
+                        }
+                        return l;
+                    }
+                }
+
+                return 0;
+            }
+
+            private bool ParseBool()
+            {
+                if (_pos + 4 <= _json.Length && _json.Substring(_pos, 4) == "true")
+                {
+                    _pos += 4;
+                    return true;
+                }
+
+                if (_pos + 5 <= _json.Length && _json.Substring(_pos, 5) == "false")
+                {
+                    _pos += 5;
+                    return false;
+                }
+
+                return false;
+            }
+
+            private object ParseNull()
+            {
+                if (_pos + 4 <= _json.Length && _json.Substring(_pos, 4) == "null")
+                {
+                    _pos += 4;
+                }
+
+                return null;
+            }
+
+            private void SkipWhitespace()
+            {
+                while (_pos < _json.Length)
+                {
+                    var c = _json[_pos];
+                    if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
+                    {
+                        break;
+                    }
+                    _pos++;
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -1,0 +1,258 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Unity.Core;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Fetches precomputed flag assignments from the Datadog precompute endpoint.
+    /// </summary>
+    internal class PrecomputeAssignmentsFetcher
+    {
+        private readonly string _endpointUrl;
+        private readonly string _clientToken;
+        private readonly string _applicationId;
+        private readonly string _env;
+        private readonly IInternalLogger _logger;
+
+        public PrecomputeAssignmentsFetcher(
+            string endpointUrl,
+            string clientToken,
+            string applicationId,
+            string env,
+            IInternalLogger logger)
+        {
+            _endpointUrl = endpointUrl;
+            _clientToken = clientToken;
+            _applicationId = applicationId;
+            _env = env;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Fetches precomputed assignments for the given evaluation context.
+        /// Uses a callback since UnityWebRequest can be used from coroutines.
+        /// </summary>
+        public void Fetch(FlagsEvaluationContext context, Action<Dictionary<string, FlagAssignment>> onComplete)
+        {
+            try
+            {
+                var requestBody = BuildRequestBody(context);
+                var bodyBytes = Encoding.UTF8.GetBytes(requestBody);
+
+                var request = new UnityWebRequest(_endpointUrl, "POST");
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/vnd.api+json");
+                request.SetRequestHeader("Accept-Encoding", "gzip, deflate, br");
+                request.SetRequestHeader("dd-client-token", _clientToken);
+
+                if (!string.IsNullOrEmpty(_applicationId))
+                {
+                    request.SetRequestHeader("dd-application-id", _applicationId);
+                }
+
+                var operation = request.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    try
+                    {
+                        if (request.result != UnityWebRequest.Result.Success)
+                        {
+                            _logger.Log(Logs.DdLogLevel.Warn, $"Failed to fetch flag assignments: {request.error}");
+                            onComplete?.Invoke(null);
+                            return;
+                        }
+
+                        var responseText = request.downloadHandler.text;
+                        var flags = ParseResponse(responseText);
+                        onComplete?.Invoke(flags);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Log(Logs.DdLogLevel.Warn, $"Error parsing flag assignments: {e.Message}");
+                        _logger.TelemetryError("Error parsing flag assignments", e);
+                        onComplete?.Invoke(null);
+                    }
+                    finally
+                    {
+                        request.Dispose();
+                    }
+                };
+            }
+            catch (Exception e)
+            {
+                _logger.Log(Logs.DdLogLevel.Warn, $"Error fetching flag assignments: {e.Message}");
+                _logger.TelemetryError("Error fetching flag assignments", e);
+                onComplete?.Invoke(null);
+            }
+        }
+
+        private string BuildRequestBody(FlagsEvaluationContext context)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"data\":{\"type\":\"precompute-assignments-request\",\"attributes\":{");
+            sb.AppendFormat("\"env\":{{\"name\":{0},\"dd_env\":{0}}}", JsonHelper.Escape(_env));
+            sb.Append(",\"subject\":{");
+            sb.AppendFormat("\"targeting_key\":{0}", JsonHelper.Escape(context.TargetingKey));
+
+            if (context.Attributes.Count > 0)
+            {
+                sb.Append(",\"targeting_attributes\":");
+                sb.Append(JsonHelper.DictionaryToJson(context.Attributes));
+            }
+
+            sb.Append("}}}}");
+            return sb.ToString();
+        }
+
+        internal static Dictionary<string, FlagAssignment> ParseResponse(string json)
+        {
+            var flags = new Dictionary<string, FlagAssignment>();
+
+            // Parse the JSON response: {"data":{"attributes":{"flags":{...}}}}
+            // Using Unity's JsonUtility is limited for dynamic keys, so we use a minimal parser
+            var parsed = MiniJson.Deserialize(json) as Dictionary<string, object>;
+            if (parsed == null)
+            {
+                return flags;
+            }
+
+            if (!parsed.TryGetValue("data", out var dataObj) || !(dataObj is Dictionary<string, object> data))
+            {
+                return flags;
+            }
+
+            if (!data.TryGetValue("attributes", out var attrObj) || !(attrObj is Dictionary<string, object> attributes))
+            {
+                return flags;
+            }
+
+            if (!attributes.TryGetValue("flags", out var flagsObj) || !(flagsObj is Dictionary<string, object> flagsDict))
+            {
+                return flags;
+            }
+
+            foreach (var kvp in flagsDict)
+            {
+                if (!(kvp.Value is Dictionary<string, object> flagData))
+                {
+                    continue;
+                }
+
+                var variationType = GetStringField(flagData, "variationType");
+                var variationValueRaw = flagData.ContainsKey("variationValue") ? flagData["variationValue"] : null;
+                var doLog = GetBoolField(flagData, "doLog");
+                var allocationKey = GetStringField(flagData, "allocationKey");
+                var variationKey = GetStringField(flagData, "variationKey");
+                var reason = GetStringField(flagData, "reason");
+
+                var variationValue = ParseVariationValue(variationType, variationValueRaw);
+
+                flags[kvp.Key] = new FlagAssignment(
+                    variationType: variationType,
+                    variationValue: variationValue,
+                    doLog: doLog,
+                    allocationKey: allocationKey,
+                    variationKey: variationKey,
+                    reason: reason);
+            }
+
+            return flags;
+        }
+
+        private static object ParseVariationValue(string variationType, object rawValue)
+        {
+            if (rawValue == null)
+            {
+                return null;
+            }
+
+            switch (variationType?.ToLowerInvariant())
+            {
+                case "boolean":
+                    if (rawValue is bool boolVal)
+                    {
+                        return boolVal;
+                    }
+                    if (rawValue is string boolStr)
+                    {
+                        return string.Equals(boolStr, "true", StringComparison.OrdinalIgnoreCase);
+                    }
+                    return false;
+
+                case "string":
+                    return rawValue.ToString();
+
+                case "integer":
+                    if (rawValue is long longVal)
+                    {
+                        return (int)longVal;
+                    }
+                    if (rawValue is double dblAsInt)
+                    {
+                        return (int)dblAsInt;
+                    }
+                    if (rawValue is string intStr && int.TryParse(intStr, out var parsed))
+                    {
+                        return parsed;
+                    }
+                    return 0;
+
+                case "number":
+                case "float":
+                    if (rawValue is double dblVal)
+                    {
+                        return dblVal;
+                    }
+                    if (rawValue is long longAsDbl)
+                    {
+                        return (double)longAsDbl;
+                    }
+                    if (rawValue is string dblStr && double.TryParse(dblStr, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var parsedDbl))
+                    {
+                        return parsedDbl;
+                    }
+                    return 0.0;
+
+                case "object":
+                    return rawValue; // Return as-is (Dictionary<string, object> from MiniJson)
+
+                default:
+                    return rawValue;
+            }
+        }
+
+        private static string GetStringField(Dictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var value) && value != null)
+            {
+                return value.ToString();
+            }
+            return null;
+        }
+
+        private static bool GetBoolField(Dictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var value))
+            {
+                if (value is bool b)
+                {
+                    return b;
+                }
+                if (value is string s)
+                {
+                    return string.Equals(s, "true", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef
+++ b/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "com.datadoghq.unity.flags",
+    "rootNamespace": "Datadog.Unity.Flags",
+    "references": [
+        "com.datadog.unity"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class EvaluationAggregatorTests
+    {
+        private List<FlagEvaluationEvent> _flushedEvents;
+        private EvaluationAggregator _aggregator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _flushedEvents = new List<FlagEvaluationEvent>();
+            _aggregator = new EvaluationAggregator(
+                onFlush: events => _flushedEvents.AddRange(events),
+                flushIntervalSeconds: 60.0f, // Large interval so only manual flush triggers
+                maxAggregations: 1000);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _aggregator?.Dispose();
+        }
+
+        [Test]
+        public void SingleEvaluationProducesOneEvent()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual("my-flag", _flushedEvents[0].FlagKey);
+            Assert.AreEqual("variant-a", _flushedEvents[0].VariantKey);
+            Assert.AreEqual("alloc-1", _flushedEvents[0].AllocationKey);
+            Assert.AreEqual(1, _flushedEvents[0].EvaluationCount);
+            Assert.IsNull(_flushedEvents[0].RuntimeDefaultUsed);
+        }
+
+        [Test]
+        public void SameDimensionsAggregateIntoOneEvent()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(3, _flushedEvents[0].EvaluationCount);
+        }
+
+        [Test]
+        public void DifferentFlagsProduceSeparateEvents()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("flag-1", assignment, context, null);
+            _aggregator.RecordEvaluation("flag-2", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(2, _flushedEvents.Count);
+        }
+
+        [Test]
+        public void DefaultReasonSetsRuntimeDefaultUsed()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "DEFAULT");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(true, _flushedEvents[0].RuntimeDefaultUsed);
+            Assert.IsNull(_flushedEvents[0].VariantKey); // Null when runtime default
+            Assert.IsNull(_flushedEvents[0].AllocationKey);
+        }
+
+        [Test]
+        public void ErrorSetsRuntimeDefaultUsedAndErrorMessage()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "ERROR");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, "FLAG_NOT_FOUND");
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(true, _flushedEvents[0].RuntimeDefaultUsed);
+            Assert.AreEqual("FLAG_NOT_FOUND", _flushedEvents[0].ErrorMessage);
+        }
+
+        [Test]
+        public void FlushClearsAggregations()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            _flushedEvents.Clear();
+
+            // Second flush should produce no events
+            _aggregator.Flush();
+            Assert.AreEqual(0, _flushedEvents.Count);
+        }
+
+        [Test]
+        public void MaxAggregationsTriggersFlush()
+        {
+            var smallAggregator = new EvaluationAggregator(
+                onFlush: events => _flushedEvents.AddRange(events),
+                flushIntervalSeconds: 60.0f,
+                maxAggregations: 3);
+
+            var context = new FlagsEvaluationContext("user-123");
+
+            // Each different flag key creates a new aggregation
+            smallAggregator.RecordEvaluation("flag-1",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+            smallAggregator.RecordEvaluation("flag-2",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+
+            Assert.AreEqual(0, _flushedEvents.Count); // Not yet at max
+
+            smallAggregator.RecordEvaluation("flag-3",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+
+            // Should have auto-flushed at 3 aggregations
+            Assert.AreEqual(3, _flushedEvents.Count);
+
+            smallAggregator.Dispose();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class ExposureTrackerTests
+    {
+        [Test]
+        public void NewTrackerContainsNoEntries()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+            Assert.IsFalse(tracker.Contains(key));
+        }
+
+        [Test]
+        public void InsertedExposureIsFound()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+
+            tracker.Insert(key);
+
+            Assert.IsTrue(tracker.Contains(key));
+        }
+
+        [Test]
+        public void DifferentExposureIsNotFound()
+        {
+            var tracker = new ExposureTracker();
+            var key1 = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+            var key2 = new ExposureTracker.ExposureKey("user-1", "flag-2", "alloc-1", "variant-a");
+
+            tracker.Insert(key1);
+
+            Assert.IsFalse(tracker.Contains(key2));
+        }
+
+        [Test]
+        public void CacheEvictsOldestWhenFull()
+        {
+            var tracker = new ExposureTracker(countLimit: 3);
+
+            var key1 = new ExposureTracker.ExposureKey("user", "flag-1", "alloc", "var");
+            var key2 = new ExposureTracker.ExposureKey("user", "flag-2", "alloc", "var");
+            var key3 = new ExposureTracker.ExposureKey("user", "flag-3", "alloc", "var");
+            var key4 = new ExposureTracker.ExposureKey("user", "flag-4", "alloc", "var");
+
+            tracker.Insert(key1);
+            tracker.Insert(key2);
+            tracker.Insert(key3);
+
+            Assert.AreEqual(3, tracker.Count);
+            Assert.IsTrue(tracker.Contains(key1));
+
+            // Adding a 4th should evict the oldest (key1)
+            tracker.Insert(key4);
+
+            Assert.AreEqual(3, tracker.Count);
+            Assert.IsFalse(tracker.Contains(key1));
+            Assert.IsTrue(tracker.Contains(key2));
+            Assert.IsTrue(tracker.Contains(key3));
+            Assert.IsTrue(tracker.Contains(key4));
+        }
+
+        [Test]
+        public void SameExposureKeyDeduplicatesAllFourDimensions()
+        {
+            var tracker = new ExposureTracker();
+
+            // Same targeting key, different flag
+            var a = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-1", "var-1");
+            var b = new ExposureTracker.ExposureKey("user-1", "flag-B", "alloc-1", "var-1");
+
+            // Same flag, different targeting key
+            var c = new ExposureTracker.ExposureKey("user-2", "flag-A", "alloc-1", "var-1");
+
+            // Same everything except allocation
+            var d = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-2", "var-1");
+
+            // Same everything except variation
+            var e = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-1", "var-2");
+
+            tracker.Insert(a);
+
+            Assert.IsTrue(tracker.Contains(a));
+            Assert.IsFalse(tracker.Contains(b));
+            Assert.IsFalse(tracker.Contains(c));
+            Assert.IsFalse(tracker.Contains(d));
+            Assert.IsFalse(tracker.Contains(e));
+        }
+
+        [Test]
+        public void DuplicateInsertDoesNotIncrementCount()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+
+            tracker.Insert(key);
+            tracker.Insert(key);
+            tracker.Insert(key);
+
+            Assert.AreEqual(1, tracker.Count);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class FlagEvaluationTests
+    {
+        private FlagsRepository _repository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repository = new FlagsRepository();
+        }
+
+        [Test]
+        public void BooleanFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["show-feature"] = new FlagAssignment("boolean", true, true, "alloc-1", "treatment", "TARGETING_MATCH"),
+            };
+            var context = new FlagsEvaluationContext("user-1");
+            _repository.SetFlagsAndContext(context, flags);
+
+            var assignment = _repository.GetFlagAssignment("show-feature");
+            Assert.IsNotNull(assignment);
+            Assert.IsTrue(assignment.TryGetValue<bool>(out var value));
+            Assert.IsTrue(value);
+        }
+
+        [Test]
+        public void StringFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["theme"] = new FlagAssignment("string", "dark", true, "alloc-1", "dark-mode", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("theme");
+            Assert.IsNotNull(assignment);
+            Assert.IsTrue(assignment.TryGetValue<string>(out var value));
+            Assert.AreEqual("dark", value);
+        }
+
+        [Test]
+        public void IntegerFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["max-items"] = new FlagAssignment("integer", 42, true, "alloc-1", "high", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("max-items");
+            Assert.IsTrue(assignment.TryGetValue<int>(out var value));
+            Assert.AreEqual(42, value);
+        }
+
+        [Test]
+        public void DoubleFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["price"] = new FlagAssignment("number", 9.99, true, "alloc-1", "discount", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("price");
+            Assert.IsTrue(assignment.TryGetValue<double>(out var value));
+            Assert.AreEqual(9.99, value, 0.001);
+        }
+
+        [Test]
+        public void MissingFlagReturnsNull()
+        {
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), new Dictionary<string, FlagAssignment>());
+
+            var assignment = _repository.GetFlagAssignment("nonexistent");
+            Assert.IsNull(assignment);
+        }
+
+        [Test]
+        public void TypeMismatchReturnsFalse()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["name"] = new FlagAssignment("string", "hello", true, "alloc-1", "greeting", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("name");
+            Assert.IsFalse(assignment.TryGetValue<bool>(out _));
+        }
+
+        [Test]
+        public void RepositoryContextIsSet()
+        {
+            var context = new FlagsEvaluationContext("user-42", new Dictionary<string, object>
+            {
+                { "email", "test@example.com" },
+            });
+            _repository.SetFlagsAndContext(context, new Dictionary<string, FlagAssignment>());
+
+            Assert.IsNotNull(_repository.Context);
+            Assert.AreEqual("user-42", _repository.Context.TargetingKey);
+            Assert.AreEqual("test@example.com", _repository.Context.Attributes["email"]);
+        }
+
+        [Test]
+        public void SetFlagsReplacesExistingFlags()
+        {
+            var flags1 = new Dictionary<string, FlagAssignment>
+            {
+                ["flag-a"] = new FlagAssignment("boolean", true, true, "a", "v1", "DEFAULT"),
+            };
+            var flags2 = new Dictionary<string, FlagAssignment>
+            {
+                ["flag-b"] = new FlagAssignment("string", "value", true, "b", "v2", "TARGETING_MATCH"),
+            };
+
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("u1"), flags1);
+            Assert.IsNotNull(_repository.GetFlagAssignment("flag-a"));
+            Assert.IsNull(_repository.GetFlagAssignment("flag-b"));
+
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("u1"), flags2);
+            Assert.IsNull(_repository.GetFlagAssignment("flag-a"));
+            Assert.IsNotNull(_repository.GetFlagAssignment("flag-b"));
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class JsonSerializationTests
+    {
+        [Test]
+        public void ExposureEventSerializesCorrectly()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flagKey: "show-feature",
+                allocationKey: "alloc-123",
+                variationKey: "variant-a",
+                subjectId: "user-456",
+                subjectAttributes: new Dictionary<string, object>
+                {
+                    { "email", "user@example.com" },
+                    { "plan", "premium" },
+                });
+
+            var json = evt.ToJson();
+
+            Assert.IsTrue(json.Contains("\"timestamp\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"flag\":{\"key\":\"show-feature\"}"));
+            Assert.IsTrue(json.Contains("\"allocation\":{\"key\":\"alloc-123\"}"));
+            Assert.IsTrue(json.Contains("\"variant\":{\"key\":\"variant-a\"}"));
+            Assert.IsTrue(json.Contains("\"id\":\"user-456\""));
+            Assert.IsTrue(json.Contains("\"email\":\"user@example.com\""));
+            Assert.IsTrue(json.Contains("\"plan\":\"premium\""));
+        }
+
+        [Test]
+        public void FlagEvaluationEventSerializesCorrectly()
+        {
+            var evt = new FlagEvaluationEvent
+            {
+                Timestamp = 1700000000000,
+                FlagKey = "my-flag",
+                FirstEvaluation = 1700000000000,
+                LastEvaluation = 1700000001000,
+                EvaluationCount = 5,
+                VariantKey = "treatment",
+                AllocationKey = "alloc-1",
+                TargetingKey = "user-789",
+                RuntimeDefaultUsed = null,
+            };
+
+            var json = evt.ToJson();
+
+            Assert.IsTrue(json.Contains("\"timestamp\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"flag\":{\"key\":\"my-flag\"}"));
+            Assert.IsTrue(json.Contains("\"first_evaluation\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"last_evaluation\":1700000001000"));
+            Assert.IsTrue(json.Contains("\"evaluation_count\":5"));
+            Assert.IsTrue(json.Contains("\"variant\":{\"key\":\"treatment\"}"));
+            Assert.IsTrue(json.Contains("\"allocation\":{\"key\":\"alloc-1\"}"));
+            Assert.IsTrue(json.Contains("\"targeting_key\":\"user-789\""));
+            Assert.IsFalse(json.Contains("\"runtime_default_used\""));
+        }
+
+        [Test]
+        public void RuntimeDefaultOmitsVariantAndAllocation()
+        {
+            var evt = new FlagEvaluationEvent
+            {
+                Timestamp = 1700000000000,
+                FlagKey = "my-flag",
+                FirstEvaluation = 1700000000000,
+                LastEvaluation = 1700000000000,
+                EvaluationCount = 1,
+                VariantKey = "treatment",
+                AllocationKey = "alloc-1",
+                TargetingKey = "user-789",
+                RuntimeDefaultUsed = true,
+                ErrorMessage = "FLAG_NOT_FOUND",
+            };
+
+            var json = evt.ToJson();
+
+            Assert.IsFalse(json.Contains("\"variant\""));
+            Assert.IsFalse(json.Contains("\"allocation\""));
+            Assert.IsTrue(json.Contains("\"runtime_default_used\":true"));
+            Assert.IsTrue(json.Contains("\"error\":{\"message\":\"FLAG_NOT_FOUND\"}"));
+        }
+
+        [Test]
+        public void JsonEscapesSpecialCharacters()
+        {
+            var escaped = JsonHelper.Escape("hello \"world\"\nnewline");
+            Assert.AreEqual("\"hello \\\"world\\\"\\nnewline\"", escaped);
+        }
+
+        [Test]
+        public void JsonEscapesNullToLiteral()
+        {
+            var escaped = JsonHelper.Escape(null);
+            Assert.AreEqual("null", escaped);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class PrecomputeParserTests
+    {
+        [Test]
+        public void ParsesValidBooleanFlag()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(1, flags.Count);
+            Assert.IsTrue(flags.ContainsKey("enable-feature"));
+
+            var flag = flags["enable-feature"];
+            Assert.AreEqual("boolean", flag.VariationType);
+            Assert.AreEqual(true, flag.VariationValue);
+            Assert.IsTrue(flag.DoLog);
+            Assert.AreEqual("alloc-abc", flag.AllocationKey);
+            Assert.AreEqual("treatment", flag.VariationKey);
+            Assert.AreEqual("TARGETING_MATCH", flag.Reason);
+        }
+
+        [Test]
+        public void ParsesMultipleFlags()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""flag-bool"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": false,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a1"",
+                                ""variationKey"": ""control"",
+                                ""reason"": ""DEFAULT""
+                            },
+                            ""flag-string"": {
+                                ""variationType"": ""string"",
+                                ""variationValue"": ""hello"",
+                                ""doLog"": false,
+                                ""allocationKey"": ""a2"",
+                                ""variationKey"": ""greeting"",
+                                ""reason"": ""RULE_MATCH""
+                            },
+                            ""flag-int"": {
+                                ""variationType"": ""integer"",
+                                ""variationValue"": 42,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a3"",
+                                ""variationKey"": ""high"",
+                                ""reason"": ""TARGETING_MATCH""
+                            },
+                            ""flag-double"": {
+                                ""variationType"": ""number"",
+                                ""variationValue"": 3.14,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a4"",
+                                ""variationKey"": ""pi"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(4, flags.Count);
+
+            Assert.AreEqual(false, flags["flag-bool"].VariationValue);
+            Assert.IsFalse(flags["flag-string"].DoLog);
+
+            Assert.IsTrue(flags["flag-int"].TryGetValue<int>(out var intVal));
+            Assert.AreEqual(42, intVal);
+
+            Assert.IsTrue(flags["flag-double"].TryGetValue<double>(out var dblVal));
+            Assert.AreEqual(3.14, dblVal, 0.001);
+        }
+
+        [Test]
+        public void ParsesEmptyFlagsResponse()
+        {
+            var json = @"{""data"":{""attributes"":{""flags"":{}}}}";
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+            Assert.AreEqual(0, flags.Count);
+        }
+
+        [Test]
+        public void ParsesInvalidJsonReturnsEmptyDict()
+        {
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse("not json");
+            Assert.IsNotNull(flags);
+            Assert.AreEqual(0, flags.Count);
+        }
+
+        [Test]
+        public void ParsesNullJsonReturnsEmptyDict()
+        {
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(null);
+            Assert.IsNotNull(flags);
+            Assert.AreEqual(0, flags.Count);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
+++ b/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "com.datadog.unity",
-        "com.datadoghq.unity.android"
+        "com.datadoghq.unity.android",
+        "com.datadoghq.unity.flags"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Datadog.Unity;
+using Datadog.Unity.Flags;
+using UnityEngine;
+
+/// <summary>
+/// Example behavior demonstrating the Datadog Flags SDK.
+/// Attach this to a GameObject in your scene to see feature flags in action.
+/// </summary>
+public class FlagsBehavior : MonoBehaviour
+{
+    public void Start()
+    {
+        // 1. Enable the Flags feature (after Datadog SDK is already initialized)
+        DdFlags.Enable(new FlagsConfiguration
+        {
+            TrackExposures = true,
+            TrackEvaluations = true,
+            EvaluationFlushIntervalSeconds = 10.0f,
+        });
+
+        // 2. Create a flags client
+        var client = DdFlags.CreateClient();
+
+        // 3. Set the evaluation context with user/session information
+        client.SetEvaluationContext(
+            new FlagsEvaluationContext("user-12345", new Dictionary<string, object>
+            {
+                { "email", "demo@example.com" },
+                { "plan", "premium" },
+                { "country", "US" },
+            }),
+            onComplete: success =>
+            {
+                if (success)
+                {
+                    Debug.Log("[Datadog Flags] Flags loaded successfully!");
+                    EvaluateFlags(client);
+                }
+                else
+                {
+                    Debug.LogWarning("[Datadog Flags] Failed to load flags. Using defaults.");
+                    EvaluateFlags(client);
+                }
+            });
+    }
+
+    private void EvaluateFlags(FlagsClient client)
+    {
+        // Simple value accessors
+        var showNewUI = client.GetBooleanValue("show-new-ui", false);
+        Debug.Log($"[Datadog Flags] show-new-ui = {showNewUI}");
+
+        var theme = client.GetStringValue("theme-color", "blue");
+        Debug.Log($"[Datadog Flags] theme-color = {theme}");
+
+        var maxItems = client.GetIntegerValue("max-items-per-page", 25);
+        Debug.Log($"[Datadog Flags] max-items-per-page = {maxItems}");
+
+        var discountRate = client.GetDoubleValue("discount-rate", 0.0);
+        Debug.Log($"[Datadog Flags] discount-rate = {discountRate}");
+
+        // Detailed evaluation with variant/reason info
+        var details = client.GetBooleanDetails("checkout-v2-enabled", false);
+        Debug.Log($"[Datadog Flags] checkout-v2-enabled: value={details.Value}, " +
+                  $"variant={details.Variant ?? "n/a"}, reason={details.Reason ?? "n/a"}, " +
+                  $"error={details.Error?.ToString() ?? "none"}");
+    }
+
+    public void OnDestroy()
+    {
+        DdFlags.Shutdown();
+    }
+}

--- a/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Datadog.Unity;
+using Datadog.Unity.Flags;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using UnityEngine;
@@ -46,5 +47,16 @@ public class TestBehavior : MonoBehaviour
         });
 
         DatadogSdk.Instance.Rum.StopResource("key", RumResourceType.Native);
+
+        // Feature Flags
+        DdFlags.Enable();
+        var flagsClient = DdFlags.CreateClient();
+        flagsClient.SetEvaluationContext(
+            new FlagsEvaluationContext("user-1234", new Dictionary<string, object>
+            {
+                { "email", "test@example.com" },
+            }));
+        var featureEnabled = flagsClient.GetBooleanValue("new-feature", false);
+        logger.Info($"Feature flag 'new-feature' = {featureEnabled}");
     }
 }


### PR DESCRIPTION
## Motivation

Add a Feature Flags SDK to the Unity package, enabling Unity applications to evaluate feature flags via Datadog's precompute endpoint with exposure tracking and evaluation telemetry — matching the behavior of the Android and iOS SDKs.

## Changes

- **17 runtime source files** in `packages/Datadog.Unity/Runtime/Flags/`:
  - `DdFlags` static entry point (`Enable()`, `CreateClient()`, `Shutdown()`)
  - `FlagsClient` with type-safe accessors (`GetBooleanValue`, `GetStringValue`, `GetIntegerValue`, `GetDoubleValue`, `GetObjectValue`, `GetDetails<T>`)
  - `PrecomputeAssignmentsFetcher` — POST to `/precompute-assignments` with JSON:API request body
  - `FlagsRepository` — thread-safe in-memory flag cache
  - `ExposureTracker` — LRU dedup cache (1000 count limit) keyed on `(targetingKey, flagKey, allocationKey, variationKey)`
  - `EvaluationAggregator` — 6-dimension aggregation with 10s periodic flush and 1000-max trigger
  - `EvpTelemetrySender` — sends exposures (NDJSON to `/api/v2/exposures`) and evaluations (batched JSON to `/api/v2/flagevaluation`)
  - `FlagsEndpoints` — site-to-endpoint mapping for all Datadog sites
  - `MiniJson` / `JsonHelper` — lightweight JSON parser/serializer (no external deps)
  - Models: `FlagAssignment`, `FlagDetails<T>`, `FlagsEvaluationContext`, `FlagsClientState`, `FlagsConfiguration`, `ExposureEvent`, `FlagEvaluationEvent`
  - Assembly definition: `com.datadoghq.unity.flags.asmdef`
- **5 test files** in `packages/Datadog.Unity/Tests/Flags/` (31 tests total covering exposure dedup, aggregation flush, flag evaluation, JSON parsing, serialization)
- **Sample app** additions: `FlagsBehavior.cs` MonoBehaviour + inline flags usage in `TestBehavior.cs`
- Updated test asmdef to reference the flags assembly

## Decisions

- **No external JSON dependency**: Used a lightweight built-in `MiniJson` parser to avoid adding Newtonsoft or other deps to the flags assembly
- **Thread safety via `lock`**: Matches the existing Unity SDK pattern (`ThreadSafeObjectPool`, etc.) rather than using `ConcurrentDictionary`
- **In-memory only**: No disk persistence for cached flags (iOS/Android persist to data store). Can be added later via `PlayerPrefs` or file-based storage
- **Fire-and-forget telemetry**: Exposure and evaluation HTTP sends don't retry on failure. Retry with backoff can be added as a follow-up
- **Exposure cache uses LRU with LinkedList**: C# doesn't have `NSCache`, so implemented equivalent LRU with `Dictionary` + `LinkedList` matching the same 1000-count eviction behavior