### PR TITLE
chore: Commit latest Unity-generated changes to Demo Data sample project

### DIFF
--- a/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/mainTemplate.gradle
@@ -18,6 +18,7 @@ dependencies {
 
 // Android Resolver Exclusions Start
 android {
+	namespace "com.unity3d.player"
   packagingOptions {
       exclude ('/lib/armeabi/*' + '*')
       exclude ('/lib/mips/*' + '*')

--- a/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
+++ b/samples/Demo Data/Assets/Plugins/Android/settingsTemplate.gradle
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
 // Android Resolver Repos Start
+        def unityProjectPath = $/file:///**DIR_UNITYPROJECT**/$.replace("\\", "/")
         mavenLocal()
 // Android Resolver Repos End
         flatDir {

--- a/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Demo Data/ProjectSettings/AndroidResolverDependencies.xml
@@ -17,7 +17,7 @@
     <setting name="packageDir" value="Assets/Plugins/Android" />
     <setting name="patchAndroidManifest" value="True" />
     <setting name="patchMainTemplateGradle" value="True" />
-    <setting name="projectExportEnabled" value="True" />
+    <setting name="projectExportEnabled" value="False" />
     <setting name="useFullCustomMavenRepoPathWhenExport" value="True" />
     <setting name="useFullCustomMavenRepoPathWhenNotExport" value="False" />
     <setting name="useJetifier" value="True" />

--- a/samples/Demo Data/ProjectSettings/ProjectSettings.asset
+++ b/samples/Demo Data/ProjectSettings/ProjectSettings.asset
@@ -243,7 +243,7 @@ PlayerSettings:
   iOSRenderExtraFrameOnPause: 0
   iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
-  iOSManualSigningProvisioningProfileID: 808da561-5a13-45ac-b6f9-e360c86e648a
+  iOSManualSigningProvisioningProfileID: f49debf4-3b3d-4e29-af0d-c7ae382137cf
   tvOSManualSigningProvisioningProfileID: 
   VisionOSManualSigningProvisioningProfileID: 
   iOSManualSigningProvisioningProfileType: 1

--- a/samples/Demo Data/exportOptions.plist
+++ b/samples/Demo Data/exportOptions.plist
@@ -11,8 +11,6 @@
 			<key>com.datadoghq.unity.demo</key>
 			<string>Unity Demo App</string>
 		</dict>
-		<key>signingCertificate</key>
-		<string>Apple Development: Alex Forsythe (3P27M3SHZL)</string>
 		<key>teamID</key>
 		<string>JKFCB4CN7C</string>
 	</dict>

--- a/samples/Demo Data/exportOptions.plist
+++ b/samples/Demo Data/exportOptions.plist
@@ -12,7 +12,7 @@
 			<string>Unity Demo App</string>
 		</dict>
 		<key>signingCertificate</key>
-		<string>Apple Development: Jeff Ward (TL2P8NFDM4)</string>
+		<string>Apple Development: Alex Forsythe (3P27M3SHZL)</string>
 		<key>teamID</key>
 		<string>JKFCB4CN7C</string>
 	</dict>


### PR DESCRIPTION
Opening the Unity Editor auto-inserts a `namespace` line into `mainTemplate.gradle`; automated builds for Android will typically fail unless this line is present.

The other settings don't matter for the sample project.

This PR ensures that the git-versioned copy of the project files matches the state that Unity 2022.3.67f2 would like the project to be in.

This PR also updates the explicit Profile ID reference in the iOS signing settings for `Demo Data`- the old profile was expired; we've now generated a new one that's good thru March 13, 2027.