### PR TITLE
chore: Update CHANGELOG in preparation for 1.6.4 release

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Fixed a missing `using` statement that could cause Android builds to fail.
+
 ## 1.6.3
 
 * Data passed to `AddUserExtraInfo()` is now properly included in Android builds.


### PR DESCRIPTION
(Release script expects `CHANGELOG.md` to be up to date with all unreleased changes in `develop` prior to starting the release.)