### PR TITLE
Feature Flags SDK (without OpenFeature)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Build/
 test_scaffolds/6000 LTS/.utmp
 unit-test*
 integration-test*
+.claire/
+.claude/

--- a/packages/Datadog.Unity/Runtime/AssemblyInfo.cs
+++ b/packages/Datadog.Unity/Runtime/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("com.datadoghq.unity.ios")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.webgl")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.Editor")]
+[assembly: InternalsVisibleTo("com.datadoghq.unity.flags")]
 
 // This is the Moq library
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/packages/Datadog.Unity/Runtime/Flags.meta
+++ b/packages/Datadog.Unity/Runtime/Flags.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2604a51a221e443b683dd5b363f5d2e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/AssemblyInfo.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("com.datadoghq.unity.tests")]

--- a/packages/Datadog.Unity/Runtime/Flags/AssemblyInfo.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e0c18d19b831496a9d62f5aa2cc7621
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -1,0 +1,217 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+using UnityEngine;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Entry point for the Datadog Flags feature in Unity.
+    ///
+    /// <code>
+    /// // Setup
+    /// DdFlags.Enable(new FlagsConfiguration());
+    /// var client = DdFlags.Instance.CreateClient();
+    /// client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), onComplete: success =>
+    /// {
+    ///     // Evaluate flags
+    ///     var showFeature = client.GetBooleanValue("show-new-feature", false);
+    /// });
+    /// </code>
+    /// </summary>
+    public class DdFlags
+    {
+        private static readonly object _enableLock = new();
+
+        private readonly FlagsConfiguration _configuration;
+        private readonly EvpTelemetrySender _telemetrySender;
+        private readonly IInternalLogger _logger;
+        private readonly Dictionary<string, FlagsClient> _clients = new();
+        private readonly object _lock = new();
+
+        /// <summary>
+        /// Gets the singleton instance of DdFlags. Null until <see cref="Enable"/> is called.
+        /// </summary>
+        public static DdFlags Instance { get; private set; }
+
+        private DdFlags(FlagsConfiguration configuration, EvpTelemetrySender telemetrySender, IInternalLogger logger)
+        {
+            _configuration = configuration;
+            _telemetrySender = telemetrySender;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Enables the Datadog Flags feature and initializes the singleton instance.
+        /// Must be called from the Unity main thread after Datadog SDK initialization.
+        /// Subsequent calls are ignored.
+        /// </summary>
+        /// <param name="configuration">Configuration options for the Flags feature.</param>
+        public static void Enable(FlagsConfiguration configuration = null)
+        {
+            lock (_enableLock)
+            {
+                if (Instance != null)
+                {
+                    DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Warn,
+                        "DdFlags.Enable() called more than once — ignoring.");
+                    return;
+                }
+
+                if (SynchronizationContext.Current == null)
+                {
+                    const string message =
+                        "DdFlags.Enable() must be called from the Unity main thread. " +
+                        "Automatic telemetry flushing will be disabled.";
+
+                    if (Application.isEditor || Debug.isDebugBuild)
+                    {
+                        throw new InvalidOperationException(message);
+                    }
+                    else
+                    {
+                        DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Error, message);
+                    }
+                }
+
+                configuration ??= new FlagsConfiguration();
+
+                var options = DatadogConfigurationOptions.Load();
+                var site = options?.Site ?? DatadogSite.Us1;
+                var exposureEndpoint = !string.IsNullOrEmpty(configuration.CustomExposureEndpoint)
+                    ? configuration.CustomExposureEndpoint
+                    : FlagsEndpoints.GetExposureEndpoint(site);
+                var evaluationEndpoint = !string.IsNullOrEmpty(configuration.CustomEvaluationEndpoint)
+                    ? configuration.CustomEvaluationEndpoint
+                    : FlagsEndpoints.GetEvaluationEndpoint(site);
+                var logger = DatadogSdk.Instance?.InternalLogger;
+
+                var sender = new EvpTelemetrySender(
+                    clientToken: options?.ClientToken ?? string.Empty,
+                    exposureEndpoint: exposureEndpoint,
+                    evaluationEndpoint: evaluationEndpoint,
+                    env: options?.Env ?? string.Empty,
+                    logger: logger);
+
+                Instance = new DdFlags(configuration, sender, logger);
+            }
+        }
+
+        /// <summary>
+        /// Shuts down the Flags feature, disposes all clients, and clears the singleton instance.
+        /// </summary>
+        public static void Shutdown()
+        {
+            DdFlags instance;
+            lock (_enableLock)
+            {
+                instance = Instance;
+                Instance = null;
+            }
+
+            instance?.ShutdownInternal();
+        }
+
+        /// <summary>
+        /// Creates a flags client for the given name.
+        /// </summary>
+        /// <param name="name">A unique name for this client. Defaults to "default".</param>
+        public FlagsClient CreateClient(string name = FlagsClient.DefaultName)
+        {
+            lock (_lock)
+            {
+                if (_clients.TryGetValue(name, out var existingClient))
+                {
+                    return existingClient;
+                }
+
+                var options = DatadogConfigurationOptions.Load();
+
+                string precomputeEndpoint;
+                if (!string.IsNullOrEmpty(_configuration.CustomFlagsEndpoint))
+                {
+                    precomputeEndpoint = _configuration.CustomFlagsEndpoint;
+                }
+                else if (options != null)
+                {
+                    precomputeEndpoint = FlagsEndpoints.GetPrecomputeEndpoint(options.Site);
+                }
+                else
+                {
+                    precomputeEndpoint = FlagsEndpoints.GetPrecomputeEndpoint(DatadogSite.Us1);
+                }
+
+                var repository = new FlagsRepository();
+                var exposureTracker = new ExposureTracker();
+
+                Action<ExposureEvent> onExposure = null;
+                EvaluationAggregator evaluationAggregator = null;
+                if (_telemetrySender != null)
+                {
+                    if (_configuration.TrackExposures)
+                    {
+                        onExposure = _telemetrySender.SendExposure;
+                    }
+
+                    if (_configuration.TrackEvaluations)
+                    {
+                        var sender = _telemetrySender;
+                        evaluationAggregator = new EvaluationAggregator(
+                            onFlush: events => sender.SendEvaluations(events),
+                            flushIntervalSeconds: _configuration.EvaluationFlushIntervalSeconds);
+                    }
+                }
+
+                var fetcher = new PrecomputeAssignmentsFetcher(
+                    endpointUrl: precomputeEndpoint,
+                    clientToken: options?.ClientToken ?? string.Empty,
+                    applicationId: options?.RumApplicationId,
+                    env: options?.Env ?? string.Empty,
+                    logger: _logger);
+
+                var client = new FlagsClient(
+                    repository: repository,
+                    exposureTracker: exposureTracker,
+                    evaluationAggregator: evaluationAggregator,
+                    fetcher: fetcher,
+                    logger: _logger,
+                    trackExposures: _configuration.TrackExposures,
+                    trackEvaluations: _configuration.TrackEvaluations,
+                    onExposure: onExposure);
+
+                _clients[name] = client;
+                return client;
+            }
+        }
+
+        internal FlagsClient GetClient(string name = FlagsClient.DefaultName)
+        {
+            lock (_lock)
+            {
+                _clients.TryGetValue(name, out var client);
+                return client;
+            }
+        }
+
+        private void ShutdownInternal()
+        {
+            List<FlagsClient> clientsToDispose;
+            lock (_lock)
+            {
+                clientsToDispose = new List<FlagsClient>(_clients.Values);
+                _clients.Clear();
+            }
+
+            foreach (var client in clientsToDispose)
+            {
+                client.Dispose();
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dcad870a29f974613945198f736c80bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Aggregates flag evaluation events and flushes them periodically or when the max count is reached.
+    /// Aggregation key dimensions: (flagKey, variantKey, allocationKey, targetingKey).
+    /// Flush triggers: timer (10s default), max aggregations (1000).
+    /// </summary>
+    internal class EvaluationAggregator : IDisposable
+    {
+        private const string ReasonDefault = "DEFAULT";
+        private const string ReasonError = "ERROR";
+
+        internal struct AggregationKey : IEquatable<AggregationKey>
+        {
+            public readonly string FlagKey;
+            public readonly string VariantKey;
+            public readonly string AllocationKey;
+            public readonly string TargetingKey;
+
+            public AggregationKey(string flagKey, string variantKey, string allocationKey, string targetingKey)
+            {
+                FlagKey = flagKey;
+                VariantKey = variantKey;
+                AllocationKey = allocationKey;
+                TargetingKey = targetingKey;
+            }
+
+            public bool Equals(AggregationKey other)
+            {
+                return FlagKey == other.FlagKey
+                    && VariantKey == other.VariantKey
+                    && AllocationKey == other.AllocationKey
+                    && TargetingKey == other.TargetingKey;
+            }
+
+            public override bool Equals(object obj)
+                => obj is AggregationKey other && Equals(other);
+
+            public override int GetHashCode()
+                => HashCode.Combine(FlagKey, VariantKey, AllocationKey, TargetingKey);
+        }
+
+        internal class AggregatedEvaluation
+        {
+            public readonly string FlagKey;
+            public readonly string VariantKey;
+            public readonly string AllocationKey;
+            public readonly string TargetingKey;
+            public readonly string TargetingRuleKey;
+            public readonly IReadOnlyDictionary<string, string> Context;
+            public readonly long FirstEvaluation;
+            public readonly bool? RuntimeDefaultUsed;
+
+            // Mutable: updated on each subsequent evaluation for the same dimensions.
+            public long LastEvaluation;
+            public int EvaluationCount;
+            public string ErrorMessage;
+
+            public AggregatedEvaluation(
+                string flagKey,
+                string variantKey,
+                string allocationKey,
+                string targetingKey,
+                string targetingRuleKey,
+                string errorMessage,
+                IReadOnlyDictionary<string, string> context,
+                long firstEvaluation,
+                bool? runtimeDefaultUsed)
+            {
+                FlagKey = flagKey;
+                VariantKey = variantKey;
+                AllocationKey = allocationKey;
+                TargetingKey = targetingKey;
+                TargetingRuleKey = targetingRuleKey;
+                ErrorMessage = errorMessage;
+                Context = context;
+                FirstEvaluation = firstEvaluation;
+                LastEvaluation = firstEvaluation;
+                EvaluationCount = 1;
+                RuntimeDefaultUsed = runtimeDefaultUsed;
+            }
+
+            public FlagEvaluationEvent ToFlagEvaluationEvent()
+            {
+            return new FlagEvaluationEvent(
+                timestamp: FirstEvaluation,
+                flag: new FlagRef(FlagKey),
+                firstEvaluation: FirstEvaluation,
+                lastEvaluation: LastEvaluation,
+                evaluationCount: EvaluationCount,
+                variant: RuntimeDefaultUsed != true && VariantKey != null ? new FlagRef(VariantKey) : null,
+                allocation: RuntimeDefaultUsed != true && AllocationKey != null ? new FlagRef(AllocationKey) : null,
+                targetingRule: TargetingRuleKey != null ? new FlagRef(TargetingRuleKey) : null,
+                targetingKey: TargetingKey,
+                runtimeDefaultUsed: RuntimeDefaultUsed,
+                error: ErrorMessage != null ? new FlagErrorDetail(ErrorMessage) : null,
+                context: Context?.Count > 0 ? new EvaluationContextPayload(Context) : null);
+            }
+        }
+
+        public const int DefaultMaxAggregations = 1_000;
+        public const float DefaultFlushIntervalSeconds = 10.0f;
+        public const float MinFlushIntervalSeconds = 1.0f;
+        public const float MaxFlushIntervalSeconds = 60.0f;
+
+        private readonly object _lock = new();
+        private readonly int _maxAggregations;
+        private readonly float _flushIntervalSeconds;
+        private readonly SynchronizationContext _mainThreadContext;
+        private Dictionary<AggregationKey, AggregatedEvaluation> _aggregations = new();
+        private Timer _flushTimer;
+        private Action<List<FlagEvaluationEvent>> _onFlush;
+        private bool _disposed;
+
+        public EvaluationAggregator(
+            Action<List<FlagEvaluationEvent>> onFlush,
+            float flushIntervalSeconds = DefaultFlushIntervalSeconds,
+            int maxAggregations = DefaultMaxAggregations)
+        {
+            _onFlush = onFlush;
+            _flushIntervalSeconds = Math.Max(MinFlushIntervalSeconds, Math.Min(MaxFlushIntervalSeconds, flushIntervalSeconds));
+            _maxAggregations = maxAggregations;
+
+            // Capture Unity's main-thread SynchronizationContext so the timer
+            // callback can dispatch back to the main thread (UnityWebRequest
+            // and SystemInfo APIs are main-thread-only).
+            _mainThreadContext = SynchronizationContext.Current;
+
+            // Only start the timer when a main-thread context is available.
+            // When null, automatic flushing is disabled and callers must invoke Flush() explicitly.
+            if (_mainThreadContext != null)
+            {
+                var intervalMs = (int)(_flushIntervalSeconds * 1000);
+                _flushTimer = new Timer(OnTimerElapsed, null, intervalMs, intervalMs);
+            }
+        }
+
+        public void RecordEvaluation(
+            string flagKey,
+            FlagAssignment assignment,
+            FlagsEvaluationContext evaluationContext,
+            string flagError)
+        {
+            // Quick non-locking check to skip expensive work if already disposed.
+            // The definitive check happens inside the lock below.
+            if (_disposed)
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            // FlagsEvaluationContext.Attributes is already an immutable ReadOnlyDictionary —
+            // no defensive copy needed.
+            var contextCopy = evaluationContext?.Attributes;
+
+            var key = new AggregationKey(
+                flagKey: flagKey,
+                variantKey: assignment?.VariationKey,
+                allocationKey: assignment?.AllocationKey,
+                targetingKey: evaluationContext?.TargetingKey);
+
+            List<FlagEvaluationEvent> eventsToFlush = null;
+
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                if (_aggregations.TryGetValue(key, out var existing))
+                {
+                    existing.EvaluationCount += 1;
+                    existing.LastEvaluation = now;
+                    existing.ErrorMessage = flagError ?? existing.ErrorMessage;
+                }
+                else
+                {
+                    var reason = assignment?.Reason;
+                    var runtimeDefaultUsed = reason == ReasonDefault || flagError != null;
+
+                    _aggregations[key] = new AggregatedEvaluation(
+                        flagKey: flagKey,
+                        variantKey: assignment?.VariationKey,
+                        allocationKey: assignment?.AllocationKey,
+                        targetingKey: evaluationContext?.TargetingKey,
+                        targetingRuleKey: null,
+                        errorMessage: flagError,
+                        context: contextCopy,
+                        firstEvaluation: now,
+                        runtimeDefaultUsed: runtimeDefaultUsed ? true : (bool?)null);
+                }
+
+                if (_aggregations.Count >= _maxAggregations)
+                {
+                    eventsToFlush = CollectAndClearEvents();
+                }
+            }
+
+            if (eventsToFlush != null)
+            {
+                _onFlush?.Invoke(eventsToFlush);
+            }
+        }
+
+        public void Flush()
+        {
+            List<FlagEvaluationEvent> events;
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                events = CollectAndClearEvents();
+            }
+
+            if (events != null)
+            {
+                _onFlush?.Invoke(events);
+            }
+        }
+
+        public void Dispose()
+        {
+            List<FlagEvaluationEvent> events;
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _flushTimer?.Dispose();
+                _flushTimer = null;
+
+                events = CollectAndClearEvents();
+            }
+
+            if (events != null)
+            {
+                _onFlush?.Invoke(events);
+            }
+        }
+
+        // Must be called within _lock.
+        private List<FlagEvaluationEvent> CollectAndClearEvents()
+        {
+            if (_aggregations.Count == 0)
+            {
+                return null;
+            }
+
+            var events = _aggregations.Values
+                .Select(a => a.ToFlagEvaluationEvent())
+                .ToList();
+
+            _aggregations.Clear();
+            return events;
+        }
+
+        private void OnTimerElapsed(object state)
+        {
+            if (_mainThreadContext == null)
+            {
+                // No main thread synchronization context is available; automatic flushing
+                // is disabled to avoid invoking Unity APIs from a timer thread. In this case,
+                // callers must invoke Flush() explicitly from the Unity main thread.
+                return;
+            }
+
+            _mainThreadContext.Post(_ => Flush(), null);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/EvaluationAggregator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8b63ce0805a346199a52f92d6a8013b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs
@@ -1,0 +1,205 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Unity.Core;
+using Newtonsoft.Json;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Sends EVP telemetry events (exposures and flag evaluations) to Datadog intake endpoints.
+    /// </summary>
+    internal class EvpTelemetrySender
+    {
+        private readonly string _clientToken;
+        private readonly string _exposureEndpoint;
+        private readonly string _evaluationEndpoint;
+        private readonly IInternalLogger _logger;
+        private readonly BatchContext _batchContext;
+
+        public EvpTelemetrySender(
+            string clientToken,
+            string exposureEndpoint,
+            string evaluationEndpoint,
+            string env,
+            IInternalLogger logger)
+        {
+            _clientToken = clientToken;
+            _exposureEndpoint = exposureEndpoint;
+            _evaluationEndpoint = evaluationEndpoint;
+            _logger = logger;
+            _batchContext = BuildBatchContext(env);
+        }
+
+        /// <summary>
+        /// Sends a single exposure event to the exposure intake endpoint.
+        /// Format: NDJSON (newline-delimited JSON), Content-Type: text/plain; charset=utf-8.
+        /// </summary>
+        public void SendExposure(ExposureEvent exposure)
+        {
+            if (exposure == null)
+            {
+                return;
+            }
+
+            var json = JsonConvert.SerializeObject(exposure) + "\n";
+            SendRequest(_exposureEndpoint, "text/plain; charset=utf-8", json, "exposure event");
+        }
+
+        /// <summary>
+        /// Sends a batch of flag evaluation events to the evaluation intake endpoint.
+        /// Format: JSON with BatchedFlagEvaluations structure, Content-Type: application/json.
+        /// </summary>
+        public void SendEvaluations(List<FlagEvaluationEvent> evaluations)
+        {
+            if (evaluations == null || evaluations.Count == 0)
+            {
+                return;
+            }
+
+            var json = JsonConvert.SerializeObject(new BatchPayload
+            {
+                Context = _batchContext,
+                FlagEvaluations = evaluations,
+            });
+            SendRequest(_evaluationEndpoint, "application/json", json, "evaluation events");
+        }
+
+        private void SendRequest(string endpoint, string contentType, string json, string eventDescription)
+        {
+            try
+            {
+                var bodyBytes = Encoding.UTF8.GetBytes(json);
+                var url = AppendDdSource(endpoint);
+                var request = new UnityWebRequest(url, "POST");
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", contentType);
+                request.SetRequestHeader("dd-api-key", _clientToken);
+                request.SetRequestHeader("dd-evp-origin", "unity");
+                request.SetRequestHeader("dd-evp-origin-version", DatadogSdk.SdkVersion);
+
+                var operation = request.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    if (request.result != UnityWebRequest.Result.Success)
+                    {
+                        _logger?.Log(Logs.DdLogLevel.Warn, $"Failed to send {eventDescription}: {request.error}");
+                    }
+                    request.Dispose();
+                };
+            }
+            catch (Exception e)
+            {
+                _logger?.TelemetryError($"Error sending {eventDescription}", e);
+            }
+        }
+
+        private static BatchContext BuildBatchContext(string env)
+        {
+            return new BatchContext
+            {
+                Device = new DeviceInfo
+                {
+                    Name = SystemInfo.deviceName,
+                    Type = GetDeviceType(),
+                    Brand = "Unity",
+                    Model = SystemInfo.deviceModel,
+                },
+                Os = new OsInfo
+                {
+                    Name = SystemInfo.operatingSystemFamily.ToString(),
+                    Version = SystemInfo.operatingSystem,
+                },
+                Service = Application.identifier ?? Application.productName,
+                Version = Application.version,
+                Env = !string.IsNullOrEmpty(env) ? env : "prod",
+            };
+        }
+
+        private static string GetDeviceType()
+        {
+            switch (SystemInfo.deviceType)
+            {
+                case DeviceType.Handheld: return "mobile";
+                case DeviceType.Console: return "console";
+                case DeviceType.Desktop: return "desktop";
+                default: return "other";
+            }
+        }
+
+        private static string AppendDdSource(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+
+            var builder = new UriBuilder(url);
+            var query = builder.Query?.TrimStart('?') ?? string.Empty;
+            if (!query.Contains("ddsource"))
+            {
+                builder.Query = query.Length > 0 ? query + "&ddsource=unity" : "ddsource=unity";
+            }
+
+            return builder.ToString();
+        }
+
+        private class BatchPayload
+        {
+            [JsonProperty("context")]
+            public BatchContext Context { get; set; }
+
+            [JsonProperty("flagEvaluations")]
+            public List<FlagEvaluationEvent> FlagEvaluations { get; set; }
+        }
+
+        private class BatchContext
+        {
+            [JsonProperty("device")]
+            public DeviceInfo Device { get; set; }
+
+            [JsonProperty("os")]
+            public OsInfo Os { get; set; }
+
+            [JsonProperty("service")]
+            public string Service { get; set; }
+
+            [JsonProperty("version")]
+            public string Version { get; set; }
+
+            [JsonProperty("env")]
+            public string Env { get; set; }
+        }
+
+        private class DeviceInfo
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("brand")]
+            public string Brand { get; set; }
+
+            [JsonProperty("model")]
+            public string Model { get; set; }
+        }
+
+        private class OsInfo
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("version")]
+            public string Version { get; set; }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/EvpTelemetrySender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42323d869fa804e01ab10c4260a1b0b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Datadog.Unity.Flags
+{
+    internal class ExposureSubject
+    {
+        [JsonProperty("id")]
+        public readonly string Id;
+
+        [JsonProperty("attributes", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly IReadOnlyDictionary<string, string> Attributes;
+
+        public ExposureSubject(string id, IReadOnlyDictionary<string, string> attributes = null)
+        {
+            Id = id;
+            Attributes = attributes;
+        }
+    }
+
+    /// <summary>
+    /// Exposure event sent to /api/v2/exposures (NDJSON, one object per line).
+    /// Serialise directly with <c>JsonConvert.SerializeObject</c>.
+    /// </summary>
+    internal class ExposureEvent
+    {
+        [JsonProperty("timestamp")]
+        public readonly long Timestamp;
+
+        [JsonProperty("flag")]
+        public readonly FlagRef Flag;
+
+        [JsonProperty("allocation")]
+        public readonly FlagRef Allocation;
+
+        [JsonProperty("variant")]
+        public readonly FlagRef Variant;
+
+        [JsonProperty("subject")]
+        public readonly ExposureSubject Subject;
+
+        public ExposureEvent(
+            long timestamp,
+            FlagRef flag,
+            FlagRef allocation,
+            FlagRef variant,
+            ExposureSubject subject)
+        {
+            Timestamp = timestamp;
+            Flag = flag;
+            Allocation = allocation;
+            Variant = variant;
+            Subject = subject;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5e515ce9e9fc46de877ec90032507d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Tracks which exposures have been sent to avoid duplicate/over-frequent exposure events.
+    /// Uses an LRU-like cache with a count limit, matching the iOS ExposureTracker pattern.
+    /// Thread-safe via lock.
+    /// </summary>
+    internal class ExposureTracker
+    {
+        internal struct ExposureKey : IEquatable<ExposureKey>
+        {
+            public readonly string TargetingKey;
+            public readonly string FlagKey;
+            public readonly string AllocationKey;
+            public readonly string VariationKey;
+
+            public ExposureKey(string targetingKey, string flagKey, string allocationKey, string variationKey)
+            {
+                TargetingKey = targetingKey;
+                FlagKey = flagKey;
+                AllocationKey = allocationKey;
+                VariationKey = variationKey;
+            }
+
+            public bool Equals(ExposureKey other)
+            {
+                return TargetingKey == other.TargetingKey
+                    && FlagKey == other.FlagKey
+                    && AllocationKey == other.AllocationKey
+                    && VariationKey == other.VariationKey;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ExposureKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+                => HashCode.Combine(TargetingKey, FlagKey, AllocationKey, VariationKey);
+        }
+
+        public const int DefaultCountLimit = 1_000;
+
+        private readonly object _lock = new();
+        private readonly int _countLimit;
+        private readonly LinkedList<ExposureKey> _order = new();
+        private readonly Dictionary<ExposureKey, LinkedListNode<ExposureKey>> _cache = new();
+
+        public ExposureTracker(int countLimit = DefaultCountLimit)
+        {
+            _countLimit = countLimit;
+        }
+
+        /// <summary>
+        /// Returns true if the exposure has already been tracked.
+        /// </summary>
+        public bool Contains(ExposureKey exposure)
+        {
+            lock (_lock)
+            {
+                return _cache.ContainsKey(exposure);
+            }
+        }
+
+        /// <summary>
+        /// Atomically checks if the exposure is already tracked, and if not, inserts it.
+        /// Returns true if the key was newly inserted (caller should send the exposure).
+        /// Returns false if the key already existed (duplicate, no action needed).
+        /// </summary>
+        public bool TrackExposure(ExposureKey exposure)
+        {
+            lock (_lock)
+            {
+                if (_cache.ContainsKey(exposure))
+                {
+                    // Move to end (most recently used)
+                    var node = _cache[exposure];
+                    _order.Remove(node);
+                    _order.AddLast(node);
+                    return false;
+                }
+
+                // Evict oldest if at capacity
+                if (_cache.Count >= _countLimit && _order.First != null)
+                {
+                    var oldest = _order.First;
+                    _order.RemoveFirst();
+                    _cache.Remove(oldest.Value);
+                }
+
+                var newNode = _order.AddLast(exposure);
+                _cache[exposure] = newNode;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of items in the cache.
+        /// </summary>
+        internal int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _cache.Count;
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40498ade7cb3745f3a8a2dbec2f3f309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+using Newtonsoft.Json.Linq;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents a precomputed flag assignment returned from the server.
+    /// </summary>
+    internal class FlagAssignment
+    {
+        public FlagAssignment(
+            string variationType,
+            JToken variationValue,
+            bool doLog,
+            string allocationKey,
+            string variationKey,
+            string reason)
+        {
+            VariationType = variationType ?? string.Empty;
+            VariationValue = variationValue;
+            DoLog = doLog;
+            AllocationKey = allocationKey ?? string.Empty;
+            VariationKey = variationKey ?? string.Empty;
+            Reason = reason ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the type of the variation value (boolean, string, integer, number, float, object).
+        /// </summary>
+        public string VariationType { get; }
+
+        /// <summary>
+        /// Gets the raw variation value token.
+        /// </summary>
+        public JToken VariationValue { get; }
+
+        /// <summary>
+        /// Gets whether to track exposure for this flag.
+        /// </summary>
+        public bool DoLog { get; }
+
+        /// <summary>
+        /// Gets the allocation identifier.
+        /// </summary>
+        public string AllocationKey { get; }
+
+        /// <summary>
+        /// Gets the variation identifier.
+        /// </summary>
+        public string VariationKey { get; }
+
+        /// <summary>
+        /// Gets the resolution reason (DEFAULT, TARGETING_MATCH, RULE_MATCH, etc.).
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
+        /// Attempts to get the variation value as the specified type.
+        /// </summary>
+        /// <param name="value">The converted value, or default on failure.</param>
+        /// <param name="flagKey">The flag key, used in the warning log on type mismatch.</param>
+        /// <param name="logger">Optional logger; receives a warning when conversion fails.</param>
+        public bool TryGetValue<T>(out T value, string flagKey = null, IInternalLogger logger = null)
+        {
+            if (VariationValue == null || VariationValue.Type == JTokenType.Null)
+            {
+                value = default;
+                return false;
+            }
+
+            try
+            {
+                value = VariationValue.ToObject<T>();
+                return true;
+            }
+            catch (Exception e)
+            {
+                logger?.Log(DdLogLevel.Warn,
+                    $"Flag '{flagKey}': could not convert value to {typeof(T).Name}: {e.Message}");
+                value = default;
+                return false;
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cbf914a8f3484643aadc47cbf6e3132
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Error codes for flag evaluation failures.
+    /// </summary>
+    public enum FlagEvaluationError
+    {
+        /// <summary>The provider is not ready to evaluate flags.</summary>
+        ProviderNotReady,
+
+        /// <summary>The flag key was not found.</summary>
+        FlagNotFound,
+
+        /// <summary>The flag type does not match the requested type.</summary>
+        TypeMismatch,
+    }
+
+    /// <summary>
+    /// Detailed result of a flag evaluation including value, variant, reason, and error information.
+    /// </summary>
+    /// <typeparam name="T">The type of the flag value.</typeparam>
+    public class FlagDetails<T>
+    {
+        internal FlagDetails(string key, T value, string variant = null, string reason = null, FlagEvaluationError? error = null)
+        {
+            Key = key;
+            Value = value;
+            Variant = variant;
+            Reason = reason;
+            Error = error;
+        }
+
+        /// <summary>Gets the flag key.</summary>
+        public string Key { get; }
+
+        /// <summary>Gets the evaluated or default value.</summary>
+        public T Value { get; }
+
+        /// <summary>Gets the variant served (null if not found).</summary>
+        public string Variant { get; }
+
+        /// <summary>Gets the evaluation reason (null if not found).</summary>
+        public string Reason { get; }
+
+        /// <summary>Gets the evaluation error (null if successful).</summary>
+        public FlagEvaluationError? Error { get; }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0095eb78949b439fb2e6387741a3d93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// A <c>{ "key": "..." }</c> reference used in evaluation and exposure event payloads.
+    /// </summary>
+    internal class FlagRef
+    {
+        [JsonProperty("key")]
+        public readonly string Key;
+
+        public FlagRef(string key)
+        {
+            Key = key;
+        }
+    }
+
+    internal class FlagErrorDetail
+    {
+        [JsonProperty("message")]
+        public readonly string Message;
+
+        public FlagErrorDetail(string message)
+        {
+            Message = message;
+        }
+    }
+
+    internal class EvaluationContextPayload
+    {
+        [JsonProperty("evaluation")]
+        public readonly IReadOnlyDictionary<string, string> Evaluation;
+
+        public EvaluationContextPayload(IReadOnlyDictionary<string, string> evaluation)
+        {
+            Evaluation = evaluation;
+        }
+    }
+
+    /// <summary>
+    /// Aggregated flag evaluation event sent to /api/v2/flagevaluation.
+    /// Serialise directly with <c>JsonConvert.SerializeObject</c>.
+    /// </summary>
+    internal class FlagEvaluationEvent
+    {
+        [JsonProperty("timestamp")]
+        public readonly long Timestamp;
+
+        [JsonProperty("flag")]
+        public readonly FlagRef Flag;
+
+        [JsonProperty("first_evaluation")]
+        public readonly long FirstEvaluation;
+
+        [JsonProperty("last_evaluation")]
+        public readonly long LastEvaluation;
+
+        [JsonProperty("evaluation_count")]
+        public readonly int EvaluationCount;
+
+        [JsonProperty("variant", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly FlagRef Variant;
+
+        [JsonProperty("allocation", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly FlagRef Allocation;
+
+        [JsonProperty("targeting_rule", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly FlagRef TargetingRule;
+
+        [JsonProperty("targeting_key", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly string TargetingKey;
+
+        [JsonProperty("runtime_default_used", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly bool? RuntimeDefaultUsed;
+
+        [JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly FlagErrorDetail Error;
+
+        [JsonProperty("context", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly EvaluationContextPayload Context;
+
+        public FlagEvaluationEvent(
+            long timestamp,
+            FlagRef flag,
+            long firstEvaluation,
+            long lastEvaluation,
+            int evaluationCount,
+            FlagRef variant = null,
+            FlagRef allocation = null,
+            FlagRef targetingRule = null,
+            string targetingKey = null,
+            bool? runtimeDefaultUsed = null,
+            FlagErrorDetail error = null,
+            EvaluationContextPayload context = null)
+        {
+            Timestamp = timestamp;
+            Flag = flag;
+            FirstEvaluation = firstEvaluation;
+            LastEvaluation = lastEvaluation;
+            EvaluationCount = evaluationCount;
+            Variant = variant;
+            Allocation = allocation;
+            TargetingRule = targetingRule;
+            TargetingKey = targetingKey;
+            RuntimeDefaultUsed = runtimeDefaultUsed;
+            Error = error;
+            Context = context;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagEvaluationEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0b7097c5c420411497719e12202b803
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -1,0 +1,331 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Client for evaluating feature flags. Use <c>DdFlags.CreateClient()</c> to create
+    /// an instance after calling <c>DdFlags.Enable()</c>.
+    /// </summary>
+    public class FlagsClient : IDisposable
+    {
+        public const string DefaultName = "default";
+
+        private readonly object _lock = new();
+        private readonly FlagsRepository _repository;
+        private readonly ExposureTracker _exposureTracker;
+        private readonly EvaluationAggregator _evaluationAggregator;
+        private readonly PrecomputeAssignmentsFetcher _fetcher;
+        private readonly Core.IInternalLogger _logger;
+        private readonly bool _trackExposures;
+        private readonly bool _trackEvaluations;
+        private readonly Action<ExposureEvent> _onExposure;
+
+        private FlagsClientState _state = FlagsClientState.NotReady;
+        private bool _disposed;
+
+        internal FlagsClient(
+            FlagsRepository repository,
+            ExposureTracker exposureTracker,
+            EvaluationAggregator evaluationAggregator,
+            PrecomputeAssignmentsFetcher fetcher,
+            Core.IInternalLogger logger,
+            bool trackExposures,
+            bool trackEvaluations,
+            Action<ExposureEvent> onExposure)
+        {
+            _repository = repository;
+            _exposureTracker = exposureTracker;
+            _evaluationAggregator = evaluationAggregator;
+            _fetcher = fetcher;
+            _logger = logger;
+            _trackExposures = trackExposures;
+            _trackEvaluations = trackEvaluations;
+            _onExposure = onExposure;
+        }
+
+        /// <summary>
+        /// Gets the current state of the client.
+        /// </summary>
+        public FlagsClientState State
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _state;
+                }
+            }
+        }
+
+        private event EventHandler<FlagsStateChange> _stateChanged;
+
+        /// <summary>
+        /// Subscribes to client state changes. The handler is invoked immediately with the
+        /// current state (where <c>Old == New</c>) so that late subscribers never miss the
+        /// initial state, and then on every subsequent transition.
+        /// </summary>
+        public event EventHandler<FlagsStateChange> StateChanged
+        {
+            add
+            {
+                FlagsClientState currentState;
+                lock (_lock)
+                {
+                    _stateChanged += value;
+                    currentState = _state;
+                }
+
+                // Replay current state to the new subscriber. Old == New signals this is a
+                // replay rather than a real transition.
+                try
+                {
+                    value?.Invoke(this, new FlagsStateChange(currentState, currentState));
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Log(Logs.DdLogLevel.Warn,
+                        $"StateChanged subscriber threw during initial replay: {ex.Message}");
+                }
+            }
+            remove
+            {
+                lock (_lock)
+                {
+                    _stateChanged -= value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the evaluation context and fetches precomputed flag assignments from the server.
+        /// </summary>
+        /// <param name="context">The evaluation context containing targeting key and attributes.</param>
+        /// <param name="onComplete">Optional callback invoked when the fetch completes (true = success).</param>
+        public void SetEvaluationContext(FlagsEvaluationContext context, Action<bool> onComplete = null)
+        {
+            if (context == null)
+            {
+                _logger?.Log(Logs.DdLogLevel.Warn, "SetEvaluationContext called with null context. Ignoring.");
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            TransitionState(FlagsClientState.Reconciling);
+
+            _fetcher.Fetch(context, flags =>
+            {
+                if (flags != null)
+                {
+                    _repository.SetFlagsAndContext(context, flags);
+                    TransitionState(FlagsClientState.Ready);
+                    onComplete?.Invoke(true);
+                }
+                else
+                {
+                    // If we have cached flags, transition to Stale; otherwise Error
+                    if (_repository.HasFlags())
+                    {
+                        TransitionState(FlagsClientState.Stale);
+                    }
+                    else
+                    {
+                        TransitionState(FlagsClientState.Error);
+                    }
+                    onComplete?.Invoke(false);
+                }
+            });
+        }
+
+        // --- Type-safe value accessors ---
+
+        public bool GetBooleanValue(string key, bool defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public string GetStringValue(string key, string defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public int GetIntegerValue(string key, int defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public double GetDoubleValue(string key, double defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        public object GetObjectValue(string key, object defaultValue)
+        {
+            return GetValue(key, defaultValue);
+        }
+
+        // --- Detailed accessors ---
+
+        public FlagDetails<bool> GetBooleanDetails(string key, bool defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<string> GetStringDetails(string key, string defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<int> GetIntegerDetails(string key, int defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        public FlagDetails<double> GetDoubleDetails(string key, double defaultValue)
+        {
+            return GetDetails(key, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets detailed evaluation result for a flag, including variant, reason, and error info.
+        /// </summary>
+        public FlagDetails<T> GetDetails<T>(string key, T defaultValue)
+        {
+            var assignment = _repository.GetFlagAssignment(key);
+
+            if (assignment == null)
+            {
+                FlagsClientState state;
+                lock (_lock)
+                {
+                    state = _state;
+                }
+
+                if (state == FlagsClientState.NotReady || state == FlagsClientState.Reconciling)
+                {
+                    TrackEvaluation(key, null, "PROVIDER_NOT_READY");
+                    return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.ProviderNotReady);
+                }
+
+                TrackEvaluation(key, null, "FLAG_NOT_FOUND");
+                return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.FlagNotFound);
+            }
+
+            if (!assignment.TryGetValue<T>(out var value, flagKey: key, logger: _logger))
+            {
+                TrackEvaluation(key, assignment, "TYPE_MISMATCH");
+                return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.TypeMismatch);
+            }
+
+            var details = new FlagDetails<T>(
+                key: key,
+                value: value,
+                variant: assignment.VariationKey,
+                reason: assignment.Reason);
+
+            TrackEvaluation(key, assignment, null);
+            return details;
+        }
+
+        /// <summary>
+        /// Flushes any pending aggregated evaluation events.
+        /// </summary>
+        public void Flush()
+        {
+            _evaluationAggregator?.Flush();
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+            }
+            _evaluationAggregator?.Dispose();
+        }
+
+        private T GetValue<T>(string key, T defaultValue)
+        {
+            return GetDetails(key, defaultValue).Value;
+        }
+
+        private void TrackEvaluation(string key, FlagAssignment assignment, string flagError)
+        {
+            var context = _repository.Context;
+
+            // Exposure tracking
+            if (_trackExposures && assignment != null && assignment.DoLog && flagError == null)
+            {
+                var exposureKey = new ExposureTracker.ExposureKey(
+                    targetingKey: context?.TargetingKey ?? string.Empty,
+                    flagKey: key,
+                    allocationKey: assignment.AllocationKey,
+                    variationKey: assignment.VariationKey);
+
+                if (_exposureTracker.TrackExposure(exposureKey))
+                {
+                    var exposureEvent = new ExposureEvent(
+                        timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        flag: new FlagRef(key),
+                        allocation: new FlagRef(assignment.AllocationKey),
+                        variant: new FlagRef(assignment.VariationKey),
+                        subject: new ExposureSubject(
+                            id: context?.TargetingKey ?? string.Empty,
+                            attributes: context?.Attributes?.Count > 0 ? context.Attributes : null));
+
+                    _onExposure?.Invoke(exposureEvent);
+                }
+            }
+
+            // Evaluation aggregation
+            if (_trackEvaluations)
+            {
+                _evaluationAggregator?.RecordEvaluation(key, assignment, context, flagError);
+            }
+        }
+
+        private void TransitionState(FlagsClientState newState)
+        {
+            EventHandler<FlagsStateChange> handler;
+            FlagsClientState oldState;
+            lock (_lock)
+            {
+                if (_state == newState)
+                {
+                    return;
+                }
+
+                oldState = _state;
+                _state = newState;
+                handler = _stateChanged;
+            }
+
+            if (handler == null)
+            {
+                return;
+            }
+
+            var args = new FlagsStateChange(oldState, newState);
+            foreach (var subscriber in handler.GetInvocationList())
+            {
+                try
+                {
+                    ((EventHandler<FlagsStateChange>)subscriber)(this, args);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Log(Logs.DdLogLevel.Warn,
+                        $"StateChanged subscriber threw: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13a10497683694e4081b5a6ada0625cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents the current state of a FlagsClient.
+    /// </summary>
+    public enum FlagsClientState
+    {
+        /// <summary>The client is not ready to evaluate flags.</summary>
+        NotReady,
+
+        /// <summary>The client has loaded flags and is ready for evaluation.</summary>
+        Ready,
+
+        /// <summary>The client is fetching new flags for a context change.</summary>
+        Reconciling,
+
+        /// <summary>The client has stale cached flags (network failed).</summary>
+        Stale,
+
+        /// <summary>An unrecoverable error occurred.</summary>
+        Error,
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44eaa173f4b7442fb9ac7a6361285b89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Immutable configuration options for the Datadog Flags feature.
+    /// All parameters are optional; defaults are used for any omitted values.
+    /// </summary>
+    public class FlagsConfiguration
+    {
+        /// <summary>
+        /// Enables exposure logging via the dedicated exposures intake endpoint.
+        /// Default: true.
+        /// </summary>
+        public readonly bool TrackExposures;
+
+        /// <summary>
+        /// Enables evaluation logging via the dedicated evaluations intake endpoint.
+        /// Default: true.
+        /// </summary>
+        public readonly bool TrackEvaluations;
+
+        /// <summary>
+        /// The interval in seconds at which aggregated evaluation data is flushed.
+        /// When used by the evaluation aggregator, this value is clamped to [1, 60]. Default: 10.
+        /// </summary>
+        public readonly float EvaluationFlushIntervalSeconds;
+
+        /// <summary>
+        /// Custom server URL for retrieving flag assignments.
+        /// If null, the SDK uses the default Datadog Flags endpoint for the configured site.
+        /// </summary>
+        public readonly string CustomFlagsEndpoint;
+
+        /// <summary>
+        /// Custom server URL for sending exposure events.
+        /// </summary>
+        public readonly string CustomExposureEndpoint;
+
+        /// <summary>
+        /// Custom server URL for sending evaluation events.
+        /// </summary>
+        public readonly string CustomEvaluationEndpoint;
+
+        public FlagsConfiguration(
+            bool trackExposures = true,
+            bool trackEvaluations = true,
+            float evaluationFlushIntervalSeconds = 10.0f,
+            string customFlagsEndpoint = null,
+            string customExposureEndpoint = null,
+            string customEvaluationEndpoint = null)
+        {
+            TrackExposures = trackExposures;
+            TrackEvaluations = trackEvaluations;
+            EvaluationFlushIntervalSeconds = evaluationFlushIntervalSeconds;
+            CustomFlagsEndpoint = customFlagsEndpoint;
+            CustomExposureEndpoint = customExposureEndpoint;
+            CustomEvaluationEndpoint = customEvaluationEndpoint;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfedb260ff8ab434cb018a50e585382d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Maps DatadogSite to the correct precompute and intake endpoints.
+    /// </summary>
+    internal static class FlagsEndpoints
+    {
+        /// <summary>
+        /// Gets the precompute assignments CDN endpoint for the given site.
+        /// </summary>
+        public static string GetPrecomputeEndpoint(DatadogSite site)
+        {
+            switch (site)
+            {
+                case DatadogSite.Us1:
+                    return "https://preview.ff-cdn.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us3:
+                    return "https://preview.ff-cdn.us3.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us5:
+                    return "https://preview.ff-cdn.us5.datadoghq.com/precompute-assignments";
+                case DatadogSite.Eu1:
+                    return "https://preview.ff-cdn.datadoghq.eu/precompute-assignments";
+                case DatadogSite.Ap1:
+                    return "https://preview.ff-cdn.ap1.datadoghq.com/precompute-assignments";
+                case DatadogSite.Ap2:
+                    return "https://preview.ff-cdn.ap2.datadoghq.com/precompute-assignments";
+                case DatadogSite.Us1Fed:
+                    return "https://preview.ff-cdn.ddog-gov.com/precompute-assignments";
+                default:
+                    return "https://preview.ff-cdn.datadoghq.com/precompute-assignments";
+            }
+        }
+
+        /// <summary>
+        /// Gets the intake endpoint base URL for the given site.
+        /// </summary>
+        public static string GetIntakeEndpoint(DatadogSite site)
+        {
+            switch (site)
+            {
+                case DatadogSite.Us1:
+                    return "https://browser-intake-datadoghq.com";
+                case DatadogSite.Us3:
+                    return "https://browser-intake-us3-datadoghq.com";
+                case DatadogSite.Us5:
+                    return "https://browser-intake-us5-datadoghq.com";
+                case DatadogSite.Eu1:
+                    return "https://browser-intake-datadoghq.eu";
+                case DatadogSite.Ap1:
+                    return "https://browser-intake-ap1-datadoghq.com";
+                case DatadogSite.Ap2:
+                    return "https://browser-intake-ap2-datadoghq.com";
+                case DatadogSite.Us1Fed:
+                    return "https://browser-intake-ddog-gov.com";
+                default:
+                    return "https://browser-intake-datadoghq.com";
+            }
+        }
+
+        /// <summary>
+        /// Gets the exposure events endpoint URL.
+        /// </summary>
+        public static string GetExposureEndpoint(DatadogSite site, string customEndpoint = null)
+        {
+            if (!string.IsNullOrEmpty(customEndpoint))
+            {
+                return customEndpoint;
+            }
+            return GetIntakeEndpoint(site) + "/api/v2/exposures";
+        }
+
+        /// <summary>
+        /// Gets the flag evaluation events endpoint URL.
+        /// </summary>
+        public static string GetEvaluationEndpoint(DatadogSite site, string customEndpoint = null)
+        {
+            if (!string.IsNullOrEmpty(customEndpoint))
+            {
+                return customEndpoint;
+            }
+            return GetIntakeEndpoint(site) + "/api/v2/flagevaluation";
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEndpoints.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72938a6be369f4fdda4bc77856521bb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Represents the evaluation context used for feature flag evaluation.
+    /// Contains the targeting key and optional attributes for targeting rules.
+    ///
+    /// Attributes are stored as strings. Nested objects are flattened with dot notation:
+    /// <c>{ "address": { "city": "NY" } }</c> becomes <c>{ "address.city": "NY" }</c>.
+    /// This matches what the precomputed assignments endpoint expects and ensures the
+    /// context is fully immutable.
+    /// </summary>
+    public class FlagsEvaluationContext
+    {
+        /// <summary>
+        /// Gets the unique identifier used for targeting and bucketing.
+        /// </summary>
+        public readonly string TargetingKey;
+
+        /// <summary>
+        /// Gets the custom attributes used for targeting rules, flattened to string values.
+        /// </summary>
+        public readonly IReadOnlyDictionary<string, string> Attributes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlagsEvaluationContext"/> class.
+        /// </summary>
+        /// <param name="targetingKey">The unique identifier for targeting/bucketing (e.g. user ID).</param>
+        /// <param name="attributes">Optional custom attributes for targeting rules. Nested objects
+        /// are flattened using dot notation; all values are converted to strings.</param>
+        public FlagsEvaluationContext(string targetingKey, Dictionary<string, object> attributes = null)
+        {
+            TargetingKey = targetingKey ?? string.Empty;
+
+            var flat = new Dictionary<string, string>();
+            if (attributes != null)
+            {
+                Flatten(attributes, prefix: null, flat);
+            }
+            Attributes = new ReadOnlyDictionary<string, string>(flat);
+        }
+
+        private static void Flatten(Dictionary<string, object> source, string prefix, Dictionary<string, string> result)
+        {
+            foreach (var kvp in source)
+            {
+                var key = prefix != null ? prefix + "." + kvp.Key : kvp.Key;
+                if (kvp.Value is Dictionary<string, object> nested)
+                {
+                    Flatten(nested, key, result);
+                }
+                else
+                {
+                    result[key] = kvp.Value?.ToString() ?? string.Empty;
+                }
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsEvaluationContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecf036c1ab68e4e6d8fa9ab18ed45fac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Thread-safe repository for storing precomputed flag assignments and evaluation context.
+    /// </summary>
+    internal class FlagsRepository
+    {
+        private readonly object _lock = new();
+        private Dictionary<string, FlagAssignment> _flags = new();
+        private FlagsEvaluationContext _context;
+
+        /// <summary>
+        /// Gets the current evaluation context.
+        /// </summary>
+        public FlagsEvaluationContext Context
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _context;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a precomputed flag by key. Returns null if not found.
+        /// </summary>
+        public FlagAssignment GetFlagAssignment(string key)
+        {
+            lock (_lock)
+            {
+                _flags.TryGetValue(key, out var flag);
+                return flag;
+            }
+        }
+
+        /// <summary>
+        /// Sets the flags and context atomically.
+        /// </summary>
+        public void SetFlagsAndContext(FlagsEvaluationContext context, Dictionary<string, FlagAssignment> flags)
+        {
+            lock (_lock)
+            {
+                _context = context;
+                _flags = flags ?? new Dictionary<string, FlagAssignment>();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if any flags are cached.
+        /// </summary>
+        public bool HasFlags()
+        {
+            lock (_lock)
+            {
+                return _flags.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Returns a snapshot of all cached flags.
+        /// </summary>
+        public Dictionary<string, FlagAssignment> GetFlagsSnapshot()
+        {
+            lock (_lock)
+            {
+                return new Dictionary<string, FlagAssignment>(_flags);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe21b4990ff2e4d17b6ac70765e751c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsStateChange.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsStateChange.cs
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Describes a FlagsClient state transition delivered via <see cref="FlagsClient.StateChanged"/>.
+    /// When <see cref="Old"/> equals <see cref="New"/> the event is a replay of the current state
+    /// emitted immediately to a new subscriber rather than a real transition.
+    /// </summary>
+    public class FlagsStateChange
+    {
+        public readonly FlagsClientState Old;
+        public readonly FlagsClientState New;
+
+        public FlagsStateChange(FlagsClientState oldState, FlagsClientState newState)
+        {
+            Old = oldState;
+            New = newState;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsStateChange.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsStateChange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f57fe85c4fc64c4bb5efe251b22191ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -1,0 +1,244 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Unity.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEngine.Networking;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Fetches precomputed flag assignments from the Datadog precompute endpoint.
+    /// </summary>
+    internal class PrecomputeAssignmentsFetcher
+    {
+        public const int FetchTimeoutSeconds = 30;
+
+        private readonly string _endpointUrl;
+        private readonly string _clientToken;
+        private readonly string _applicationId;
+        private readonly string _env;
+        private readonly IInternalLogger _logger;
+
+        public PrecomputeAssignmentsFetcher(
+            string endpointUrl,
+            string clientToken,
+            string applicationId,
+            string env,
+            IInternalLogger logger)
+        {
+            _endpointUrl = endpointUrl;
+            _clientToken = clientToken;
+            _applicationId = applicationId;
+            _env = env;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Fetches precomputed assignments for the given evaluation context.
+        /// Uses a callback since UnityWebRequest can be used from coroutines.
+        /// </summary>
+        public void Fetch(FlagsEvaluationContext context, Action<Dictionary<string, FlagAssignment>> onComplete)
+        {
+            try
+            {
+                var requestBody = BuildRequestBody(context);
+                var bodyBytes = Encoding.UTF8.GetBytes(requestBody);
+
+                var request = new UnityWebRequest(_endpointUrl, "POST");
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.timeout = FetchTimeoutSeconds;
+                request.SetRequestHeader("Content-Type", "application/vnd.api+json");
+                request.SetRequestHeader("dd-client-token", _clientToken);
+
+                if (!string.IsNullOrEmpty(_applicationId))
+                {
+                    request.SetRequestHeader("dd-application-id", _applicationId);
+                }
+
+                var operation = request.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    try
+                    {
+                        if (request.result != UnityWebRequest.Result.Success)
+                        {
+                            _logger?.Log(Logs.DdLogLevel.Warn, $"Failed to fetch flag assignments: {request.error}");
+                            onComplete?.Invoke(null);
+                            return;
+                        }
+
+                        var responseText = request.downloadHandler.text;
+                        var flags = ParseResponse(responseText);
+                        onComplete?.Invoke(flags);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger?.Log(Logs.DdLogLevel.Warn, $"Error parsing flag assignments: {e.Message}");
+                        _logger?.TelemetryError("Error parsing flag assignments", e);
+                        onComplete?.Invoke(null);
+                    }
+                    finally
+                    {
+                        request.Dispose();
+                    }
+                };
+            }
+            catch (Exception e)
+            {
+                _logger?.Log(Logs.DdLogLevel.Warn, $"Error fetching flag assignments: {e.Message}");
+                _logger?.TelemetryError("Error fetching flag assignments", e);
+                onComplete?.Invoke(null);
+            }
+        }
+
+        private string BuildRequestBody(FlagsEvaluationContext context)
+        {
+            var dto = new AssignmentsRequestDto
+            {
+                Data = new AssignmentsRequestDataDto
+                {
+                    Attributes = new AssignmentsRequestAttributesDto
+                    {
+                        Env = new AssignmentsEnvDto { Name = _env, DdEnv = _env },
+                        Subject = new AssignmentsSubjectDto
+                        {
+                            TargetingKey = context.TargetingKey,
+                            TargetingAttributes = context.Attributes.Count > 0
+                                ? context.Attributes
+                                : null,
+                        },
+                    },
+                },
+            };
+            return JsonConvert.SerializeObject(dto);
+        }
+
+        internal static Dictionary<string, FlagAssignment> ParseResponse(string json)
+        {
+            var flags = new Dictionary<string, FlagAssignment>();
+
+            if (string.IsNullOrEmpty(json))
+            {
+                return flags;
+            }
+
+            AssignmentsResponseDto response;
+            try
+            {
+                response = JsonConvert.DeserializeObject<AssignmentsResponseDto>(json);
+            }
+            catch
+            {
+                return flags;
+            }
+
+            var flagsDict = response?.Data?.Attributes?.Flags;
+            if (flagsDict == null)
+            {
+                return flags;
+            }
+
+            foreach (var kvp in flagsDict)
+            {
+                var dto = kvp.Value;
+                flags[kvp.Key] = new FlagAssignment(
+                    variationType: dto.VariationType,
+                    variationValue: dto.VariationValue,
+                    doLog: dto.DoLog,
+                    allocationKey: dto.AllocationKey,
+                    variationKey: dto.VariationKey,
+                    reason: dto.Reason);
+            }
+
+            return flags;
+        }
+
+        private class AssignmentsRequestDto
+        {
+            [JsonProperty("data")]
+            public AssignmentsRequestDataDto Data { get; set; }
+        }
+
+        private class AssignmentsRequestDataDto
+        {
+            [JsonProperty("type")]
+            public string Type { get; set; } = "precompute-assignments-request";
+
+            [JsonProperty("attributes")]
+            public AssignmentsRequestAttributesDto Attributes { get; set; }
+        }
+
+        private class AssignmentsRequestAttributesDto
+        {
+            [JsonProperty("env")]
+            public AssignmentsEnvDto Env { get; set; }
+
+            [JsonProperty("subject")]
+            public AssignmentsSubjectDto Subject { get; set; }
+        }
+
+        private class AssignmentsEnvDto
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("dd_env")]
+            public string DdEnv { get; set; }
+        }
+
+        private class AssignmentsSubjectDto
+        {
+            [JsonProperty("targeting_key")]
+            public string TargetingKey { get; set; }
+
+            [JsonProperty("targeting_attributes", NullValueHandling = NullValueHandling.Ignore)]
+            public IReadOnlyDictionary<string, string> TargetingAttributes { get; set; }
+        }
+
+        private class AssignmentsResponseDto
+        {
+            [JsonProperty("data")]
+            public AssignmentsResponseDataDto Data { get; set; }
+        }
+
+        private class AssignmentsResponseDataDto
+        {
+            [JsonProperty("attributes")]
+            public AssignmentsResponseAttributesDto Attributes { get; set; }
+        }
+
+        private class AssignmentsResponseAttributesDto
+        {
+            [JsonProperty("flags")]
+            public Dictionary<string, FlagAssignmentDto> Flags { get; set; }
+        }
+
+        private class FlagAssignmentDto
+        {
+            [JsonProperty("variationType")]
+            public string VariationType { get; set; }
+
+            [JsonProperty("variationValue")]
+            public JToken VariationValue { get; set; }
+
+            [JsonProperty("doLog")]
+            public bool DoLog { get; set; }
+
+            [JsonProperty("allocationKey")]
+            public string AllocationKey { get; set; }
+
+            [JsonProperty("variationKey")]
+            public string VariationKey { get; set; }
+
+            [JsonProperty("reason")]
+            public string Reason { get; set; }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e64b681f10cf140359d54e9d01248e62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef
+++ b/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "com.datadoghq.unity.flags",
+    "rootNamespace": "Datadog.Unity.Flags",
+    "references": [
+        "com.datadog.unity"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/com.datadoghq.unity.flags.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4c1e481dffac5430c807f0f2c9d45d69
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Worker/ThreadedWorker.cs
+++ b/packages/Datadog.Unity/Runtime/Worker/ThreadedWorker.cs
@@ -79,7 +79,7 @@ namespace Datadog.Unity.Worker
         private void ThreadWorker()
         {
 #if UNITY_ANDROID
-            AndroidJNI.AttachCurrentThread();
+            UnityEngine.AndroidJNI.AttachCurrentThread();
 #endif
 
             while (!_workQueue.IsCompleted)

--- a/packages/Datadog.Unity/Tests/Flags.meta
+++ b/packages/Datadog.Unity/Tests/Flags.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39fe35b62430b499f9b374fcbd17c485
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class EvaluationAggregatorTests
+    {
+        private List<FlagEvaluationEvent> _flushedEvents;
+        private EvaluationAggregator _aggregator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _flushedEvents = new List<FlagEvaluationEvent>();
+            _aggregator = new EvaluationAggregator(
+                onFlush: events => _flushedEvents.AddRange(events),
+                flushIntervalSeconds: 60.0f, // Large interval so only manual flush triggers
+                maxAggregations: 1000);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _aggregator?.Dispose();
+        }
+
+        [Test]
+        public void SingleEvaluationProducesOneEvent()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual("my-flag", _flushedEvents[0].Flag.Key);
+            Assert.AreEqual("variant-a", _flushedEvents[0].Variant.Key);
+            Assert.AreEqual("alloc-1", _flushedEvents[0].Allocation.Key);
+            Assert.AreEqual(1, _flushedEvents[0].EvaluationCount);
+            Assert.IsNull(_flushedEvents[0].RuntimeDefaultUsed);
+        }
+
+        [Test]
+        public void SameDimensionsAggregateIntoOneEvent()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(3, _flushedEvents[0].EvaluationCount);
+        }
+
+        [Test]
+        public void DifferentFlagsProduceSeparateEvents()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("flag-1", assignment, context, null);
+            _aggregator.RecordEvaluation("flag-2", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(2, _flushedEvents.Count);
+        }
+
+        [Test]
+        public void DefaultReasonSetsRuntimeDefaultUsed()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "DEFAULT");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(true, _flushedEvents[0].RuntimeDefaultUsed);
+            Assert.IsNull(_flushedEvents[0].Variant);
+            Assert.IsNull(_flushedEvents[0].Allocation);
+        }
+
+        [Test]
+        public void ErrorSetsRuntimeDefaultUsedAndErrorMessage()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "ERROR");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, "FLAG_NOT_FOUND");
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(true, _flushedEvents[0].RuntimeDefaultUsed);
+            Assert.AreEqual("FLAG_NOT_FOUND", _flushedEvents[0].Error.Message);
+        }
+
+        [Test]
+        public void FlushClearsAggregations()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            _flushedEvents.Clear();
+
+            // Second flush should produce no events
+            _aggregator.Flush();
+            Assert.AreEqual(0, _flushedEvents.Count);
+        }
+
+        [Test]
+        public void MaxAggregationsTriggersFlush()
+        {
+            var smallAggregator = new EvaluationAggregator(
+                onFlush: events => _flushedEvents.AddRange(events),
+                flushIntervalSeconds: 60.0f,
+                maxAggregations: 3);
+
+            var context = new FlagsEvaluationContext("user-123");
+
+            // Each different flag key creates a new aggregation
+            smallAggregator.RecordEvaluation("flag-1",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+            smallAggregator.RecordEvaluation("flag-2",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+
+            Assert.AreEqual(0, _flushedEvents.Count); // Not yet at max
+
+            smallAggregator.RecordEvaluation("flag-3",
+                new FlagAssignment("boolean", true, true, "a", "v", "TARGETING_MATCH"), context, null);
+
+            // Should have auto-flushed at 3 aggregations
+            Assert.AreEqual(3, _flushedEvents.Count);
+
+            smallAggregator.Dispose();
+        }
+
+        [Test]
+        public void DifferentContextAttributesSameKeyAggregates()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var contextA = new FlagsEvaluationContext("user-123", new Dictionary<string, object> { ["plan"] = "free" });
+            var contextB = new FlagsEvaluationContext("user-123", new Dictionary<string, object> { ["plan"] = "paid" });
+
+            _aggregator.RecordEvaluation("my-flag", assignment, contextA, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, contextB, null);
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(2, _flushedEvents[0].EvaluationCount);
+        }
+
+        [Test]
+        public void DifferentErrorMessagesSameKeyAggregates()
+        {
+            var assignment = new FlagAssignment("boolean", true, true, "alloc-1", "variant-a", "TARGETING_MATCH");
+            var context = new FlagsEvaluationContext("user-123");
+
+            _aggregator.RecordEvaluation("my-flag", assignment, context, null);
+            _aggregator.RecordEvaluation("my-flag", assignment, context, "FLAG_NOT_FOUND");
+            _aggregator.Flush();
+
+            Assert.AreEqual(1, _flushedEvents.Count);
+            Assert.AreEqual(2, _flushedEvents[0].EvaluationCount);
+        }
+
+        public class AggregationKeyTests
+        {
+            private static EvaluationAggregator.AggregationKey MakeKey(
+                string flagKey = "flag",
+                string variantKey = "variant",
+                string allocationKey = "alloc",
+                string targetingKey = "user")
+            {
+                return new EvaluationAggregator.AggregationKey(flagKey, variantKey, allocationKey, targetingKey);
+            }
+
+            [Test]
+            public void SameDimensionsAreEqual()
+            {
+                var keyA = MakeKey();
+                var keyB = MakeKey();
+
+                Assert.AreEqual(keyA, keyB);
+                Assert.AreEqual(keyA.GetHashCode(), keyB.GetHashCode());
+            }
+
+            [Test]
+            public void DifferentFlagKeyIsNotEqual()
+            {
+                Assert.AreNotEqual(MakeKey(flagKey: "a"), MakeKey(flagKey: "b"));
+            }
+
+            [Test]
+            public void DifferentVariantKeyIsNotEqual()
+            {
+                Assert.AreNotEqual(MakeKey(variantKey: "a"), MakeKey(variantKey: "b"));
+            }
+
+            [Test]
+            public void DifferentAllocationKeyIsNotEqual()
+            {
+                Assert.AreNotEqual(MakeKey(allocationKey: "a"), MakeKey(allocationKey: "b"));
+            }
+
+            [Test]
+            public void DifferentTargetingKeyIsNotEqual()
+            {
+                Assert.AreNotEqual(MakeKey(targetingKey: "user-a"), MakeKey(targetingKey: "user-b"));
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/EvaluationAggregatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dafd5dbbf7ce1467baca0410b0cc2633
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class ExposureTrackerTests
+    {
+        [Test]
+        public void NewTrackerContainsNoEntries()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+            Assert.IsFalse(tracker.Contains(key));
+        }
+
+        [Test]
+        public void TrackedExposureIsFound()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+
+            tracker.TrackExposure(key);
+
+            Assert.IsTrue(tracker.Contains(key));
+        }
+
+        [Test]
+        public void DifferentExposureIsNotFound()
+        {
+            var tracker = new ExposureTracker();
+            var key1 = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+            var key2 = new ExposureTracker.ExposureKey("user-1", "flag-2", "alloc-1", "variant-a");
+
+            tracker.TrackExposure(key1);
+
+            Assert.IsFalse(tracker.Contains(key2));
+        }
+
+        [Test]
+        public void CacheEvictsOldestWhenFull()
+        {
+            var tracker = new ExposureTracker(countLimit: 3);
+
+            var key1 = new ExposureTracker.ExposureKey("user", "flag-1", "alloc", "var");
+            var key2 = new ExposureTracker.ExposureKey("user", "flag-2", "alloc", "var");
+            var key3 = new ExposureTracker.ExposureKey("user", "flag-3", "alloc", "var");
+            var key4 = new ExposureTracker.ExposureKey("user", "flag-4", "alloc", "var");
+
+            tracker.TrackExposure(key1);
+            tracker.TrackExposure(key2);
+            tracker.TrackExposure(key3);
+
+            Assert.AreEqual(3, tracker.Count);
+            Assert.IsTrue(tracker.Contains(key1));
+
+            // Adding a 4th should evict the oldest (key1)
+            tracker.TrackExposure(key4);
+
+            Assert.AreEqual(3, tracker.Count);
+            Assert.IsFalse(tracker.Contains(key1));
+            Assert.IsTrue(tracker.Contains(key2));
+            Assert.IsTrue(tracker.Contains(key3));
+            Assert.IsTrue(tracker.Contains(key4));
+        }
+
+        [Test]
+        public void SameExposureKeyDeduplicatesAllFourDimensions()
+        {
+            var tracker = new ExposureTracker();
+
+            // Same targeting key, different flag
+            var a = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-1", "var-1");
+            var b = new ExposureTracker.ExposureKey("user-1", "flag-B", "alloc-1", "var-1");
+
+            // Same flag, different targeting key
+            var c = new ExposureTracker.ExposureKey("user-2", "flag-A", "alloc-1", "var-1");
+
+            // Same everything except allocation
+            var d = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-2", "var-1");
+
+            // Same everything except variation
+            var e = new ExposureTracker.ExposureKey("user-1", "flag-A", "alloc-1", "var-2");
+
+            tracker.TrackExposure(a);
+
+            Assert.IsTrue(tracker.Contains(a));
+            Assert.IsFalse(tracker.Contains(b));
+            Assert.IsFalse(tracker.Contains(c));
+            Assert.IsFalse(tracker.Contains(d));
+            Assert.IsFalse(tracker.Contains(e));
+        }
+
+        [Test]
+        public void DuplicateTrackDoesNotIncrementCount()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "variant-a");
+
+            tracker.TrackExposure(key);
+            tracker.TrackExposure(key);
+            tracker.TrackExposure(key);
+
+            Assert.AreEqual(1, tracker.Count);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf5d314381c534913a21c7f9d63376a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class FlagEvaluationTests
+    {
+        private FlagsRepository _repository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repository = new FlagsRepository();
+        }
+
+        [Test]
+        public void BooleanFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["show-feature"] = new FlagAssignment("boolean", true, true, "alloc-1", "treatment", "TARGETING_MATCH"),
+            };
+            var context = new FlagsEvaluationContext("user-1");
+            _repository.SetFlagsAndContext(context, flags);
+
+            var assignment = _repository.GetFlagAssignment("show-feature");
+            Assert.IsNotNull(assignment);
+            Assert.IsTrue(assignment.TryGetValue<bool>(out var value));
+            Assert.IsTrue(value);
+        }
+
+        [Test]
+        public void StringFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["theme"] = new FlagAssignment("string", "dark", true, "alloc-1", "dark-mode", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("theme");
+            Assert.IsNotNull(assignment);
+            Assert.IsTrue(assignment.TryGetValue<string>(out var value));
+            Assert.AreEqual("dark", value);
+        }
+
+        [Test]
+        public void IntegerFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["max-items"] = new FlagAssignment("integer", 42, true, "alloc-1", "high", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("max-items");
+            Assert.IsTrue(assignment.TryGetValue<int>(out var value));
+            Assert.AreEqual(42, value);
+        }
+
+        [Test]
+        public void DoubleFlagReturnsCorrectValue()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["price"] = new FlagAssignment("number", 9.99, true, "alloc-1", "discount", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("price");
+            Assert.IsTrue(assignment.TryGetValue<double>(out var value));
+            Assert.AreEqual(9.99, value, 0.001);
+        }
+
+        [Test]
+        public void MissingFlagReturnsNull()
+        {
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), new Dictionary<string, FlagAssignment>());
+
+            var assignment = _repository.GetFlagAssignment("nonexistent");
+            Assert.IsNull(assignment);
+        }
+
+        [Test]
+        public void TypeMismatchReturnsFalse()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["name"] = new FlagAssignment("string", "hello", true, "alloc-1", "greeting", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var assignment = _repository.GetFlagAssignment("name");
+            Assert.IsFalse(assignment.TryGetValue<bool>(out _));
+        }
+
+        [Test]
+        public void RepositoryContextIsSet()
+        {
+            var context = new FlagsEvaluationContext("user-42", new Dictionary<string, object>
+            {
+                { "email", "test@example.com" },
+            });
+            _repository.SetFlagsAndContext(context, new Dictionary<string, FlagAssignment>());
+
+            Assert.IsNotNull(_repository.Context);
+            Assert.AreEqual("user-42", _repository.Context.TargetingKey);
+            Assert.AreEqual("test@example.com", _repository.Context.Attributes["email"]);
+        }
+
+        [Test]
+        public void SetFlagsReplacesExistingFlags()
+        {
+            var flags1 = new Dictionary<string, FlagAssignment>
+            {
+                ["flag-a"] = new FlagAssignment("boolean", true, true, "a", "v1", "DEFAULT"),
+            };
+            var flags2 = new Dictionary<string, FlagAssignment>
+            {
+                ["flag-b"] = new FlagAssignment("string", "value", true, "b", "v2", "TARGETING_MATCH"),
+            };
+
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("u1"), flags1);
+            Assert.IsNotNull(_repository.GetFlagAssignment("flag-a"));
+            Assert.IsNull(_repository.GetFlagAssignment("flag-b"));
+
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("u1"), flags2);
+            Assert.IsNull(_repository.GetFlagAssignment("flag-a"));
+            Assert.IsNotNull(_repository.GetFlagAssignment("flag-b"));
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9f7b157a0551405a85c2361a7b3854e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/FlagsEvaluationContextTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsEvaluationContextTests.cs
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class FlagsEvaluationContextTests
+    {
+        [Test]
+        public void NullTargetingKey_DefaultsToEmptyString()
+        {
+            var ctx = new FlagsEvaluationContext(null);
+            Assert.AreEqual(string.Empty, ctx.TargetingKey);
+        }
+
+        [Test]
+        public void NoAttributes_EmptyDictionary()
+        {
+            var ctx = new FlagsEvaluationContext("user-1");
+            Assert.AreEqual(0, ctx.Attributes.Count);
+        }
+
+        [Test]
+        public void PrimitiveAttributes_StoredAsStrings()
+        {
+            var ctx = new FlagsEvaluationContext("user-1", new Dictionary<string, object>
+            {
+                { "plan", "premium" },
+                { "age", 42 },
+                { "active", true },
+            });
+
+            Assert.AreEqual("premium", ctx.Attributes["plan"]);
+            Assert.AreEqual("42", ctx.Attributes["age"]);
+            Assert.AreEqual("True", ctx.Attributes["active"]);
+        }
+
+        [Test]
+        public void NestedObject_FlattenedWithDotNotation()
+        {
+            var ctx = new FlagsEvaluationContext("user-1", new Dictionary<string, object>
+            {
+                {
+                    "address", new Dictionary<string, object>
+                    {
+                        { "city", "New York" },
+                        { "zip", "10001" },
+                    }
+                },
+            });
+
+            Assert.AreEqual("New York", ctx.Attributes["address.city"]);
+            Assert.AreEqual("10001", ctx.Attributes["address.zip"]);
+            Assert.IsFalse(ctx.Attributes.ContainsKey("address"));
+        }
+
+        [Test]
+        public void DeeplyNested_FlattenedRecursively()
+        {
+            var ctx = new FlagsEvaluationContext("user-1", new Dictionary<string, object>
+            {
+                {
+                    "a", new Dictionary<string, object>
+                    {
+                        {
+                            "b", new Dictionary<string, object>
+                            {
+                                { "c", "deep" },
+                            }
+                        },
+                    }
+                },
+            });
+
+            Assert.AreEqual("deep", ctx.Attributes["a.b.c"]);
+        }
+
+        [Test]
+        public void Attributes_AreImmutable()
+        {
+            var source = new Dictionary<string, object> { { "key", "value" } };
+            var ctx = new FlagsEvaluationContext("user-1", source);
+
+            // Mutating the source after construction should not affect the context
+            source["key"] = "mutated";
+
+            Assert.AreEqual("value", ctx.Attributes["key"]);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagsEvaluationContextTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsEvaluationContextTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98460cefc34124568bd3eacc64a8189e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class JsonSerializationTests
+    {
+        [Test]
+        public void ExposureEventSerializesCorrectly()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("show-feature"),
+                allocation: new FlagRef("alloc-123"),
+                variant: new FlagRef("variant-a"),
+                subject: new ExposureSubject(
+                    id: "user-456",
+                    attributes: new Dictionary<string, string>
+                    {
+                        { "email", "user@example.com" },
+                        { "plan", "premium" },
+                    }));
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsTrue(json.Contains("\"timestamp\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"flag\":{\"key\":\"show-feature\"}"));
+            Assert.IsTrue(json.Contains("\"allocation\":{\"key\":\"alloc-123\"}"));
+            Assert.IsTrue(json.Contains("\"variant\":{\"key\":\"variant-a\"}"));
+            Assert.IsTrue(json.Contains("\"id\":\"user-456\""));
+            Assert.IsTrue(json.Contains("\"email\":\"user@example.com\""));
+            Assert.IsTrue(json.Contains("\"plan\":\"premium\""));
+        }
+
+        [Test]
+        public void ExposureEventOmitsNullAttributes()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("show-feature"),
+                allocation: new FlagRef("alloc-123"),
+                variant: new FlagRef("variant-a"),
+                subject: new ExposureSubject(id: "user-456"));
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsFalse(json.Contains("\"attributes\""));
+        }
+
+        [Test]
+        public void FlagEvaluationEventSerializesCorrectly()
+        {
+            var evt = new FlagEvaluationEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("my-flag"),
+                firstEvaluation: 1700000000000,
+                lastEvaluation: 1700000001000,
+                evaluationCount: 5,
+                variant: new FlagRef("treatment"),
+                allocation: new FlagRef("alloc-1"),
+                targetingKey: "user-789");
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsTrue(json.Contains("\"timestamp\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"flag\":{\"key\":\"my-flag\"}"));
+            Assert.IsTrue(json.Contains("\"first_evaluation\":1700000000000"));
+            Assert.IsTrue(json.Contains("\"last_evaluation\":1700000001000"));
+            Assert.IsTrue(json.Contains("\"evaluation_count\":5"));
+            Assert.IsTrue(json.Contains("\"variant\":{\"key\":\"treatment\"}"));
+            Assert.IsTrue(json.Contains("\"allocation\":{\"key\":\"alloc-1\"}"));
+            Assert.IsTrue(json.Contains("\"targeting_key\":\"user-789\""));
+            Assert.IsFalse(json.Contains("\"runtime_default_used\""));
+        }
+
+        [Test]
+        public void RuntimeDefaultOmitsVariantAndAllocation()
+        {
+            var evt = new FlagEvaluationEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("my-flag"),
+                firstEvaluation: 1700000000000,
+                lastEvaluation: 1700000000000,
+                evaluationCount: 1,
+                targetingKey: "user-789",
+                runtimeDefaultUsed: true,
+                error: new FlagErrorDetail("FLAG_NOT_FOUND"));
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsFalse(json.Contains("\"variant\""));
+            Assert.IsFalse(json.Contains("\"allocation\""));
+            Assert.IsTrue(json.Contains("\"runtime_default_used\":true"));
+            Assert.IsTrue(json.Contains("\"error\":{\"message\":\"FLAG_NOT_FOUND\"}"));
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0401af1034b124d5ca32c78dd6ee0233
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class PrecomputeParserTests
+    {
+        [Test]
+        public void ParsesValidBooleanFlag()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(1, flags.Count);
+            Assert.IsTrue(flags.ContainsKey("enable-feature"));
+
+            var flag = flags["enable-feature"];
+            Assert.AreEqual("boolean", flag.VariationType);
+            Assert.AreEqual(true, flag.VariationValue.Value<bool>());
+            Assert.IsTrue(flag.DoLog);
+            Assert.AreEqual("alloc-abc", flag.AllocationKey);
+            Assert.AreEqual("treatment", flag.VariationKey);
+            Assert.AreEqual("TARGETING_MATCH", flag.Reason);
+        }
+
+        [Test]
+        public void ParsesMultipleFlags()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""flag-bool"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": false,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a1"",
+                                ""variationKey"": ""control"",
+                                ""reason"": ""DEFAULT""
+                            },
+                            ""flag-string"": {
+                                ""variationType"": ""string"",
+                                ""variationValue"": ""hello"",
+                                ""doLog"": false,
+                                ""allocationKey"": ""a2"",
+                                ""variationKey"": ""greeting"",
+                                ""reason"": ""RULE_MATCH""
+                            },
+                            ""flag-int"": {
+                                ""variationType"": ""integer"",
+                                ""variationValue"": 42,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a3"",
+                                ""variationKey"": ""high"",
+                                ""reason"": ""TARGETING_MATCH""
+                            },
+                            ""flag-double"": {
+                                ""variationType"": ""number"",
+                                ""variationValue"": 3.14,
+                                ""doLog"": true,
+                                ""allocationKey"": ""a4"",
+                                ""variationKey"": ""pi"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(4, flags.Count);
+
+            Assert.AreEqual(false, flags["flag-bool"].VariationValue.Value<bool>());
+            Assert.IsFalse(flags["flag-string"].DoLog);
+
+            Assert.IsTrue(flags["flag-int"].TryGetValue<int>(out var intVal));
+            Assert.AreEqual(42, intVal);
+
+            Assert.IsTrue(flags["flag-double"].TryGetValue<double>(out var dblVal));
+            Assert.AreEqual(3.14, dblVal, 0.001);
+        }
+
+        [Test]
+        public void ParsesEmptyFlagsResponse()
+        {
+            var json = @"{""data"":{""attributes"":{""flags"":{}}}}";
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+            Assert.AreEqual(0, flags.Count);
+        }
+
+        [Test]
+        public void ParsesInvalidJsonReturnsEmptyDict()
+        {
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse("not json");
+            Assert.IsNotNull(flags);
+            Assert.AreEqual(0, flags.Count);
+        }
+
+        [Test]
+        public void ParsesNullJsonReturnsEmptyDict()
+        {
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(null);
+            Assert.IsNotNull(flags);
+            Assert.AreEqual(0, flags.Count);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59f50ae9b33de4e94864e6c39c62aa07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Integration/Flags.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3f7c2e1d94b4f8ea1b2c3d4e5f60789
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bcbb7201ba440e6afa790a9063e9b66
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/EvaluationEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/EvaluationEventDecoder.cs
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Datadog.Unity.Tests.Integration.Flags
+{
+    public class BatchContext
+    {
+        public string Env { get; set; }
+        public string Service { get; set; }
+        public string Version { get; set; }
+        public JObject Device { get; set; }
+        public JObject Os { get; set; }
+    }
+
+    public class EvaluationRecord
+    {
+        public string FlagKey { get; set; }
+        public string VariantKey { get; set; }
+        public string AllocationKey { get; set; }
+        public string TargetingKey { get; set; }
+        public string ErrorMessage { get; set; }
+        public long FirstEvaluation { get; set; }
+        public long LastEvaluation { get; set; }
+        public int EvaluationCount { get; set; }
+        public bool? RuntimeDefaultUsed { get; set; }
+    }
+
+    public class BatchedEvaluations
+    {
+        public BatchContext Context { get; set; }
+        public List<EvaluationRecord> FlagEvaluations { get; set; }
+    }
+
+    public class EvaluationEventDecoder
+    {
+        public static List<BatchedEvaluations> FromMockServer(List<MockServerLog> logs)
+        {
+            var result = new List<BatchedEvaluations>();
+            foreach (var log in logs)
+            {
+                if (!log.Endpoint.Contains("/api/v2/flagevaluation"))
+                {
+                    continue;
+                }
+                foreach (var req in log.Requests)
+                {
+                    foreach (var schema in req.Schemas)
+                    {
+                        var data = schema.DecompressedData ?? schema.Data ?? string.Empty;
+                        if (string.IsNullOrWhiteSpace(data))
+                        {
+                            continue;
+                        }
+                        result.Add(ParseBatch(JObject.Parse(data)));
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static BatchedEvaluations ParseBatch(JObject root)
+        {
+            var ctx = root["context"] as JObject;
+            var context = ctx == null ? null : new BatchContext
+            {
+                Env = ctx["env"]?.Value<string>(),
+                Service = ctx["service"]?.Value<string>(),
+                Version = ctx["version"]?.Value<string>(),
+                Device = ctx["device"] as JObject,
+                Os = ctx["os"] as JObject,
+            };
+
+            var evals = new List<EvaluationRecord>();
+            if (root["flagEvaluations"] is JArray arr)
+            {
+                foreach (var item in arr)
+                {
+                    var obj = (JObject)item;
+                    evals.Add(new EvaluationRecord
+                    {
+                        FlagKey = obj["flag"]?["key"]?.Value<string>(),
+                        VariantKey = obj["variant"]?["key"]?.Value<string>(),
+                        AllocationKey = obj["allocation"]?["key"]?.Value<string>(),
+                        TargetingKey = obj["targeting_key"]?.Value<string>(),
+                        ErrorMessage = obj["error"]?["message"]?.Value<string>(),
+                        FirstEvaluation = obj["first_evaluation"]?.Value<long>() ?? 0,
+                        LastEvaluation = obj["last_evaluation"]?.Value<long>() ?? 0,
+                        EvaluationCount = obj["evaluation_count"]?.Value<int>() ?? 0,
+                        RuntimeDefaultUsed = obj["runtime_default_used"]?.Value<bool?>(),
+                    });
+                }
+            }
+
+            return new BatchedEvaluations { Context = context, FlagEvaluations = evals };
+        }
+
+        public static List<EvaluationRecord> AllRecords(List<MockServerLog> logs)
+        {
+            return FromMockServer(logs).SelectMany(b => b.FlagEvaluations).ToList();
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/EvaluationEventDecoder.cs.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/EvaluationEventDecoder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f596fe05018416e926b549e83d6dc9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Datadog.Unity.Tests.Integration.Flags
+{
+    public class ExposureEventDecoder
+    {
+        private readonly JObject _raw;
+
+        public ExposureEventDecoder(JObject raw)
+        {
+            _raw = raw;
+        }
+
+        public string FlagKey => _raw["flag"]?["key"]?.Value<string>();
+        public string AllocationKey => _raw["allocation"]?["key"]?.Value<string>();
+        public string VariantKey => _raw["variant"]?["key"]?.Value<string>();
+        public string SubjectId => _raw["subject"]?["id"]?.Value<string>();
+        public Dictionary<string, object> SubjectAttributes
+        {
+            get
+            {
+                var attrs = _raw["subject"]?["attributes"];
+                return attrs?.ToObject<Dictionary<string, object>>() ?? new Dictionary<string, object>();
+            }
+        }
+
+        public static List<ExposureEventDecoder> FromMockServer(List<MockServerLog> logs)
+        {
+            var result = new List<ExposureEventDecoder>();
+            foreach (var log in logs)
+            {
+                if (!log.Endpoint.Contains("/api/v2/exposures"))
+                {
+                    continue;
+                }
+                foreach (var req in log.Requests)
+                {
+                    foreach (var schema in req.Schemas)
+                    {
+                        var data = schema.DecompressedData ?? schema.Data ?? string.Empty;
+                        foreach (var line in data.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)))
+                        {
+                            var obj = JObject.Parse(line);
+                            result.Add(new ExposureEventDecoder(obj));
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68994a03910244cda2e1b2fed624c6a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs
@@ -1,0 +1,699 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Unity.Flags;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Datadog.Unity.Tests.Integration.Flags
+{
+    public class FlagsIntegrationTests
+    {
+        private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(30);
+
+        private MockServerHelper _mockServer;
+        private string _mockBase;
+        private string _precomputePayload;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockServer = new MockServerHelper();
+            _mockBase = DatadogConfigurationOptions.Load().CustomEndpoint;
+            _precomputePayload = Resources.Load<TextAsset>("PrecomputePayload").text;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            DdFlags.Shutdown();
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+        private FlagsConfiguration MakeConfig(
+            float flushInterval = 60f,
+            bool trackExposures = true,
+            bool trackEvaluations = true) => new FlagsConfiguration(
+                evaluationFlushIntervalSeconds: flushInterval,
+                trackExposures: trackExposures,
+                trackEvaluations: trackEvaluations,
+                customFlagsEndpoint: $"{_mockBase}/precompute-assignments",
+                customExposureEndpoint: $"{_mockBase}/api/v2/exposures",
+                customEvaluationEndpoint: $"{_mockBase}/api/v2/flagevaluation");
+
+        private IEnumerator InitFlags(
+            string targetingKey = "user-123",
+            Dictionary<string, object> attributes = null,
+            int precomputeStatus = 200,
+            string precomputeBody = null,
+            float flushInterval = 60f)
+        {
+            yield return _mockServer.Clear();
+            yield return _mockServer.ConfigureResponse(
+                "/precompute-assignments",
+                precomputeStatus,
+                precomputeBody ?? _precomputePayload);
+
+            DdFlags.Enable(MakeConfig(flushInterval));
+            var client = DdFlags.Instance.CreateClient();
+
+            var done = false;
+            var context = attributes != null
+                ? new FlagsEvaluationContext(targetingKey, attributes)
+                : new FlagsEvaluationContext(targetingKey);
+
+            client.SetEvaluationContext(context, _ => done = true);
+
+            var deadline = DateTime.Now + TimeSpan.FromSeconds(20);
+            yield return new WaitUntil(() => done || DateTime.Now > deadline);
+        }
+
+        // ─── Group 1: Precompute request shape ───────────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator PrecomputeRequest_HasCorrectHeaders()
+        {
+            yield return InitFlags();
+
+            MockServerRequest precomputeReq = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                var endpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/precompute-assignments"));
+                precomputeReq = endpoint?.Requests.FirstOrDefault();
+                return precomputeReq != null;
+            });
+
+            Assert.IsNotNull(precomputeReq, "No request recorded to /precompute-assignments");
+            var schema = precomputeReq.Schemas.FirstOrDefault();
+            Assert.IsNotNull(schema, "No schema on precompute request");
+
+            var headers = schema.ParsedHeaders;
+            Assert.AreEqual("application/vnd.api+json", headers["Content-Type"]);
+            Assert.AreEqual("fake-client-token", headers["dd-client-token"]);
+            Assert.AreEqual("fake-rum-application-id", headers["dd-application-id"]);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator PrecomputeRequest_BodyHasCorrectJsonApiShape()
+        {
+            yield return InitFlags("user-123");
+
+            MockServerRequest precomputeReq = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                var endpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/precompute-assignments"));
+                precomputeReq = endpoint?.Requests.FirstOrDefault();
+                return precomputeReq != null;
+            });
+
+            Assert.IsNotNull(precomputeReq, "No request recorded to /precompute-assignments");
+            var schema = precomputeReq.Schemas.FirstOrDefault();
+            Assert.IsNotNull(schema);
+
+            var body = JObject.Parse(schema.Data);
+            Assert.AreEqual("precompute-assignments-request", (string)body["data"]["type"]);
+            Assert.AreEqual("integration-test", (string)body["data"]["attributes"]["env"]["name"]);
+            Assert.AreEqual("user-123", (string)body["data"]["attributes"]["subject"]["targeting_key"]);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator PrecomputeRequest_IncludesContextAttributes()
+        {
+            yield return InitFlags("user-123", new Dictionary<string, object> { { "plan", "premium" } });
+
+            MockServerRequest precomputeReq = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                var endpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/precompute-assignments"));
+                precomputeReq = endpoint?.Requests.FirstOrDefault();
+                return precomputeReq != null;
+            });
+
+            var schema = precomputeReq?.Schemas.FirstOrDefault();
+            Assert.IsNotNull(schema);
+
+            var body = JObject.Parse(schema.Data);
+            Assert.AreEqual("premium", (string)body["data"]["attributes"]["subject"]["targeting_attributes"]["plan"]);
+        }
+
+        // ─── Group 2: Flags evaluable after fetch ────────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SetEvaluationContext_Success_FlagsAvailableViaClient()
+        {
+            yield return InitFlags("user-123");
+
+            var client = DdFlags.Instance.GetClient();
+            Assert.IsNotNull(client);
+            Assert.AreEqual(FlagsClientState.Ready, client.State);
+
+            Assert.IsTrue(client.GetBooleanValue("boolean-flag", false));
+            Assert.AreEqual("red", client.GetStringValue("string-flag", "x"));
+            Assert.AreEqual(42, client.GetIntegerValue("integer-flag", 0));
+            Assert.AreEqual(3.14, client.GetDoubleValue("numeric-flag", 0.0), 0.001);
+
+            var jsonDetails = client.GetDetails<object>("json-flag", null);
+            Assert.AreEqual("variation-127", jsonDetails.Variant);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SetEvaluationContext_ServerError_StateIsError()
+        {
+            yield return InitFlags(precomputeStatus: 500, precomputeBody: "{\"error\":\"server error\"}");
+
+            var client = DdFlags.Instance.GetClient();
+            Assert.IsNotNull(client);
+            Assert.AreEqual(FlagsClientState.Error, client.State);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SetEvaluationContext_ServerErrorAfterCache_StateIsStale()
+        {
+            // First fetch succeeds
+            yield return InitFlags("user-123");
+            var client = DdFlags.Instance.GetClient();
+            Assert.AreEqual(FlagsClientState.Ready, client.State);
+
+            // Reconfigure mock to return 500
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 500, "{\"error\":\"server error\"}");
+
+            var done = false;
+            DdFlags.Instance.GetClient().SetEvaluationContext(new FlagsEvaluationContext("user-456"), _ => done = true);
+            yield return new WaitUntil(() => done);
+
+            Assert.AreEqual(FlagsClientState.Stale, client.State);
+            // Old flags still evaluable
+            Assert.AreEqual("red", client.GetStringValue("string-flag", "default"));
+        }
+
+        // ─── Group 3: Exposure telemetry ─────────────────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator BooleanFlagEvaluation_SendsExposureEvent()
+        {
+            yield return InitFlags("user-123");
+
+            DdFlags.Instance.GetClient().GetBooleanValue("boolean-flag", false);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 1;
+            });
+
+            Assert.AreEqual(1, exposures.Count);
+            var exp = exposures[0];
+            Assert.AreEqual("boolean-flag", exp.FlagKey);
+            Assert.AreEqual("allocation-124", exp.AllocationKey);
+            Assert.AreEqual("variation-124", exp.VariantKey);
+            Assert.AreEqual("user-123", exp.SubjectId);
+
+            // Check headers on exposure request
+            MockServerLog expEndpoint = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                expEndpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/api/v2/exposures"));
+                return expEndpoint != null;
+            });
+
+            Assert.IsNotNull(expEndpoint);
+            var headers = expEndpoint.Requests[0].Schemas[0].ParsedHeaders;
+            Assert.AreEqual("fake-client-token", headers["dd-api-key"]);
+            Assert.AreEqual("unity", headers["dd-evp-origin"]);
+            Assert.IsTrue(headers["Content-Type"].Contains("text/plain"));
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SameFlag_EvaluatedMultipleTimes_SendsOnlyOneExposure()
+        {
+            yield return InitFlags("user-123");
+
+            var flagsClient = DdFlags.Instance.GetClient();
+            for (var i = 0; i < 5; i++)
+            {
+                flagsClient.GetBooleanValue("boolean-flag", false);
+            }
+
+            yield return new WaitForSeconds(2f);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 1;
+            });
+
+            Assert.AreEqual(1, exposures.Count, "Expected exactly one exposure for the same flag");
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator ContextChange_SendsFreshExposure()
+        {
+            // Evaluate for user-A
+            yield return InitFlags("user-A");
+            DdFlags.Instance.GetClient().GetBooleanValue("boolean-flag", false);
+
+            // Change context to user-B (requires re-fetch)
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 200, _precomputePayload);
+            var done = false;
+            DdFlags.Instance.GetClient().SetEvaluationContext(new FlagsEvaluationContext("user-B"), _ => done = true);
+            yield return new WaitUntil(() => done);
+
+            DdFlags.Instance.GetClient().GetBooleanValue("boolean-flag", false);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 2;
+            });
+
+            Assert.AreEqual(2, exposures.Count, "Expected one exposure per context");
+            var subjects = exposures.Select(e => e.SubjectId).ToList();
+            CollectionAssert.Contains(subjects, "user-A");
+            CollectionAssert.Contains(subjects, "user-B");
+        }
+
+        // ─── Group 4: Evaluation telemetry ───────────────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator FlagEvaluation_AfterExplicitFlush_SendsEvaluationBatch()
+        {
+            yield return InitFlags("user-123");
+
+            var flagsClient = DdFlags.Instance.GetClient();
+            flagsClient.GetStringValue("string-flag", "x");
+            flagsClient.GetStringValue("string-flag", "x");
+            flagsClient.GetStringValue("string-flag", "x");
+            flagsClient.Flush();
+
+            List<BatchedEvaluations> batches = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                batches = EvaluationEventDecoder.FromMockServer(logs);
+                return batches.Count >= 1;
+            });
+
+            Assert.IsNotNull(batches);
+            Assert.GreaterOrEqual(batches.Count, 1);
+
+            var ctx = batches[0].Context;
+            Assert.IsNotNull(ctx?.Env);
+            Assert.IsNotNull(ctx?.Device);
+            Assert.IsNotNull(ctx?.Os);
+
+            var records = batches.SelectMany(b => b.FlagEvaluations).ToList();
+            Assert.AreEqual(1, records.Count);
+            var rec = records[0];
+            Assert.AreEqual("string-flag", rec.FlagKey);
+            Assert.AreEqual(3, rec.EvaluationCount);
+            Assert.AreEqual("variation-123", rec.VariantKey);
+            Assert.AreEqual("user-123", rec.TargetingKey);
+            Assert.IsNull(rec.RuntimeDefaultUsed);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator MultipleFlags_ProduceSeparateEvaluationRecords()
+        {
+            yield return InitFlags("user-123");
+
+            var flagsClient = DdFlags.Instance.GetClient();
+            flagsClient.GetBooleanValue("boolean-flag", false);
+            flagsClient.GetBooleanValue("boolean-flag", false);
+            flagsClient.GetStringValue("string-flag", "x");
+            flagsClient.Flush();
+
+            var records = new List<EvaluationRecord>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                records = EvaluationEventDecoder.AllRecords(logs);
+                return records.Count >= 2;
+            });
+
+            Assert.AreEqual(2, records.Count);
+            var boolRec = records.FirstOrDefault(r => r.FlagKey == "boolean-flag");
+            var strRec = records.FirstOrDefault(r => r.FlagKey == "string-flag");
+            Assert.IsNotNull(boolRec);
+            Assert.IsNotNull(strRec);
+            Assert.AreEqual(2, boolRec.EvaluationCount);
+            Assert.AreEqual(1, strRec.EvaluationCount);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator MissingFlag_EvaluationRecord_HasRuntimeDefaultUsedTrue()
+        {
+            yield return InitFlags("user-123");
+
+            DdFlags.Instance.GetClient().GetStringValue("nonexistent-flag", "default");
+            DdFlags.Instance.GetClient().Flush();
+
+            var records = new List<EvaluationRecord>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                records = EvaluationEventDecoder.AllRecords(logs);
+                return records.Count >= 1;
+            });
+
+            Assert.AreEqual(1, records.Count);
+            var rec = records[0];
+            Assert.AreEqual("nonexistent-flag", rec.FlagKey);
+            Assert.IsTrue(rec.RuntimeDefaultUsed == true);
+            Assert.AreEqual("FLAG_NOT_FOUND", rec.ErrorMessage);
+            Assert.IsNull(rec.VariantKey);
+            Assert.IsNull(rec.AllocationKey);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator Shutdown_FlushesEvaluationsPendingOnTimer()
+        {
+            yield return InitFlags("user-123", flushInterval: 60f);
+
+            DdFlags.Instance.GetClient().GetStringValue("string-flag", "x");
+
+            // Shutdown should flush pending evaluations before destroying the aggregator
+            DdFlags.Shutdown();
+
+            var records = new List<EvaluationRecord>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                records = EvaluationEventDecoder.AllRecords(logs);
+                return records.Count >= 1;
+            });
+
+            Assert.AreEqual(1, records.Count);
+            Assert.AreEqual("string-flag", records[0].FlagKey);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator TimerFlush_SendsEvaluationBatchAfterInterval()
+        {
+            yield return InitFlags("user-123", flushInterval: 1.0f);
+
+            DdFlags.Instance.GetClient().GetStringValue("string-flag", "x");
+
+            // Wait for the timer to fire (interval = 1s, wait a bit longer)
+            yield return new WaitForSeconds(2.0f);
+
+            var records = new List<EvaluationRecord>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                records = EvaluationEventDecoder.AllRecords(logs);
+                return records.Count >= 1;
+            });
+
+            Assert.AreEqual(1, records.Count);
+            Assert.AreEqual("string-flag", records[0].FlagKey);
+        }
+
+        // ─── Group 5: Evaluation EVP headers ─────────────────────────────────────────
+
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator EvaluationBatch_HasCorrectEvpHeaders()
+        {
+            yield return InitFlags("user-123");
+
+            DdFlags.Instance.GetClient().GetStringValue("string-flag", "x");
+            DdFlags.Instance.GetClient().Flush();
+
+            MockServerLog evalEndpoint = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                evalEndpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/api/v2/flagevaluation"));
+                return evalEndpoint != null;
+            });
+
+            Assert.IsNotNull(evalEndpoint);
+            var headers = evalEndpoint.Requests[0].Schemas[0].ParsedHeaders;
+            Assert.AreEqual("fake-client-token", headers["dd-api-key"]);
+            Assert.AreEqual("unity", headers["dd-evp-origin"]);
+            Assert.AreEqual(DatadogSdk.SdkVersion, headers["dd-evp-origin-version"]);
+            Assert.IsTrue(headers["Content-Type"].Contains("application/json"));
+        }
+
+        // ─── Group 6: doLog: false suppresses exposure ────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator DoLogFalse_DoesNotSendExposure()
+        {
+            yield return InitFlags();
+
+            DdFlags.Instance.GetClient().GetBooleanValue("no-log-flag", false);
+
+            // Brief wait then a single-shot check — no exposure should arrive.
+            yield return new WaitForSeconds(2f);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(TimeSpan.FromSeconds(1), logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return true;
+            });
+
+            Assert.AreEqual(0, exposures.Count, "doLog=false flag must not send an exposure");
+        }
+
+        // ─── Group 7: Context attributes flow into exposure payload ──────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator ContextAttributes_AppearedInExposureSubject()
+        {
+            yield return InitFlags("user-123", new Dictionary<string, object>
+            {
+                { "plan", "premium" },
+                { "age", 30 },
+            });
+
+            DdFlags.Instance.GetClient().GetBooleanValue("boolean-flag", false);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 1;
+            });
+
+            Assert.AreEqual(1, exposures.Count);
+            var attrs = exposures[0].SubjectAttributes;
+            Assert.IsTrue(attrs.ContainsKey("plan"), "exposure subject should contain 'plan' attribute");
+            Assert.AreEqual("premium", attrs["plan"]?.ToString());
+            Assert.AreEqual("30", attrs["age"]?.ToString());
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator NestedContextAttributes_FlattenedInPrecomputeRequest()
+        {
+            yield return InitFlags("user-123", new Dictionary<string, object>
+            {
+                {
+                    "address", new Dictionary<string, object>
+                    {
+                        { "city", "New York" },
+                        { "zip", "10001" },
+                    }
+                },
+            });
+
+            MockServerRequest precomputeReq = null;
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                var endpoint = logs.FirstOrDefault(l => l.Endpoint.Contains("/precompute-assignments"));
+                precomputeReq = endpoint?.Requests.FirstOrDefault();
+                return precomputeReq != null;
+            });
+
+            var schema = precomputeReq?.Schemas.FirstOrDefault();
+            Assert.IsNotNull(schema);
+
+            var body = JObject.Parse(schema.Data);
+            var attrs = body["data"]?["attributes"]?["subject"]?["targeting_attributes"];
+            Assert.IsNotNull(attrs, "targeting_attributes should be present");
+            Assert.AreEqual("New York", (string)attrs["address.city"]);
+            Assert.AreEqual("10001", (string)attrs["address.zip"]);
+            Assert.IsNull(attrs["address"], "nested key should be absent after flattening");
+        }
+
+        // ─── Group 8: StateChanged event ─────────────────────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator StateChanged_FiresExpectedTransitionsOnSuccess()
+        {
+            yield return _mockServer.Clear();
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 200, _precomputePayload);
+
+            DdFlags.Enable(MakeConfig());
+            var client = DdFlags.Instance.CreateClient();
+
+            var transitions = new List<FlagsStateChange>();
+            client.StateChanged += (_, change) => transitions.Add(change);
+
+            var done = false;
+            var deadline = DateTime.Now + TimeSpan.FromSeconds(20);
+            client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), _ => done = true);
+            yield return new WaitUntil(() => done || DateTime.Now > deadline);
+
+            // Expect: initial replay (NotReady→NotReady), then NotReady→Reconciling, Reconciling→Ready
+            Assert.GreaterOrEqual(transitions.Count, 3, "Expected replay + 2 real transitions");
+
+            var replay = transitions[0];
+            Assert.AreEqual(FlagsClientState.NotReady, replay.Old);
+            Assert.AreEqual(FlagsClientState.NotReady, replay.New, "First event should be a replay (Old == New)");
+
+            var toReconciling = transitions.FirstOrDefault(t => t.New == FlagsClientState.Reconciling);
+            Assert.IsNotNull(toReconciling, "Expected NotReady→Reconciling transition");
+            Assert.AreEqual(FlagsClientState.NotReady, toReconciling.Old);
+
+            var toReady = transitions.FirstOrDefault(t => t.New == FlagsClientState.Ready);
+            Assert.IsNotNull(toReady, "Expected Reconciling→Ready transition");
+            Assert.AreEqual(FlagsClientState.Reconciling, toReady.Old);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator StateChanged_FiresErrorTransitionOnServerFailure()
+        {
+            yield return _mockServer.Clear();
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 500, "{\"error\":\"fail\"}");
+
+            DdFlags.Enable(MakeConfig());
+            var client = DdFlags.Instance.CreateClient();
+
+            var transitions = new List<FlagsStateChange>();
+            client.StateChanged += (_, change) => transitions.Add(change);
+
+            var done = false;
+            client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), _ => done = true);
+            yield return new WaitUntil(() => done);
+
+            var toError = transitions.FirstOrDefault(t => t.New == FlagsClientState.Error);
+            Assert.IsNotNull(toError, "Expected Reconciling→Error transition on server failure");
+            Assert.AreEqual(FlagsClientState.Reconciling, toError.Old);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator StateChanged_LateSubscriberReceivesCurrentStateReplay()
+        {
+            // Fully initialise first, then subscribe
+            yield return InitFlags("user-123");
+
+            var client = DdFlags.Instance.GetClient();
+            Assert.AreEqual(FlagsClientState.Ready, client.State);
+
+            FlagsStateChange replayEvent = null;
+            client.StateChanged += (_, change) => replayEvent = change;
+
+            // Replay fires synchronously in the add accessor — no yield needed
+            Assert.IsNotNull(replayEvent, "Late subscriber should receive an immediate replay");
+            Assert.AreEqual(FlagsClientState.Ready, replayEvent.Old);
+            Assert.AreEqual(FlagsClientState.Ready, replayEvent.New, "Replay should have Old == New");
+
+            yield return null;
+        }
+
+        // ─── Group 9: ProviderNotReady error before fetch ─────────────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator EvaluateBeforeFetch_ReturnsProviderNotReadyError()
+        {
+            yield return _mockServer.Clear();
+
+            DdFlags.Enable(MakeConfig());
+            var client = DdFlags.Instance.CreateClient();
+
+            // Evaluate immediately — no SetEvaluationContext has been called yet
+            var details = client.GetBooleanDetails("boolean-flag", false);
+
+            Assert.AreEqual(false, details.Value, "Should return default value");
+            Assert.AreEqual(FlagEvaluationError.ProviderNotReady, details.Error);
+
+            yield return null;
+        }
+
+        // ─── Group 10: TrackExposures / TrackEvaluations = false ─────────────────────
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator TrackExposuresFalse_DoesNotSendExposureRequest()
+        {
+            yield return _mockServer.Clear();
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 200, _precomputePayload);
+
+            DdFlags.Enable(MakeConfig(trackExposures: false));
+            var client = DdFlags.Instance.CreateClient();
+            var done = false;
+            client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), _ => done = true);
+            yield return new WaitUntil(() => done);
+
+            client.GetBooleanValue("boolean-flag", false);
+
+            yield return new WaitForSeconds(2f);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(TimeSpan.FromSeconds(1), logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return true;
+            });
+
+            Assert.AreEqual(0, exposures.Count, "TrackExposures=false should suppress all exposure requests");
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator TrackEvaluationsFalse_DoesNotSendEvaluationRequest()
+        {
+            yield return _mockServer.Clear();
+            yield return _mockServer.ConfigureResponse("/precompute-assignments", 200, _precomputePayload);
+
+            DdFlags.Enable(MakeConfig(trackEvaluations: false));
+            var client = DdFlags.Instance.CreateClient();
+            var done = false;
+            client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), _ => done = true);
+            yield return new WaitUntil(() => done);
+
+            client.GetStringValue("string-flag", "x");
+            client.Flush();
+
+            yield return new WaitForSeconds(2f);
+
+            var records = new List<EvaluationRecord>();
+            yield return _mockServer.PollRequests(TimeSpan.FromSeconds(1), logs =>
+            {
+                records = EvaluationEventDecoder.AllRecords(logs);
+                return true;
+            });
+
+            Assert.AreEqual(0, records.Count, "TrackEvaluations=false should suppress all evaluation requests");
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8165df4e10d140dbae7f31b7e2264568
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Resources.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77867691fa8642d6a38d556b502359fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "id": "test_subject",
+    "type": "precomputed-assignments",
+    "attributes": {
+      "createdAt": 1731939805123,
+      "environment": { "name": "prod" },
+      "flags": {
+        "string-flag":  { "allocationKey": "allocation-123", "variationKey": "variation-123", "variationType": "STRING",  "variationValue": "red",  "doLog": true, "reason": "TARGETING_MATCH" },
+        "boolean-flag": { "allocationKey": "allocation-124", "variationKey": "variation-124", "variationType": "BOOLEAN", "variationValue": true,   "doLog": true, "reason": "TARGETING_MATCH" },
+        "integer-flag": { "allocationKey": "allocation-125", "variationKey": "variation-125", "variationType": "NUMBER",  "variationValue": 42,     "doLog": true, "reason": "TARGETING_MATCH" },
+        "numeric-flag": { "allocationKey": "allocation-126", "variationKey": "variation-126", "variationType": "NUMBER",  "variationValue": 3.14,   "doLog": true, "reason": "TARGETING_MATCH" },
+        "json-flag":    { "allocationKey": "allocation-127", "variationKey": "variation-127", "variationType": "OBJECT",  "variationValue": { "key": "value", "prop": 123 }, "doLog": true,  "reason": "TARGETING_MATCH" },
+        "no-log-flag":  { "allocationKey": "allocation-128", "variationKey": "variation-128", "variationType": "BOOLEAN", "variationValue": true,                               "doLog": false, "reason": "TARGETING_MATCH" }
+      }
+    }
+  }
+}

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json.meta
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b38173e2666540d5a6cc7400a39fc815
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
+++ b/packages/Datadog.Unity/Tests/Integration/MockServerHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
@@ -35,6 +36,16 @@ namespace Datadog.Unity.Tests.Integration
         {
             var request = UnityWebRequest.Get($"{_endpoint}/reset");
             yield return request.SendWebRequest();
+        }
+
+        public IEnumerator ConfigureResponse(string path, int status, string body, string contentType = "application/json")
+        {
+            var payload = JsonConvert.SerializeObject(new { path, status, body, content_type = contentType });
+            var webRequest = new UnityWebRequest($"{_endpoint}/configure_response", "POST");
+            webRequest.uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(payload));
+            webRequest.downloadHandler = new DownloadHandlerBuffer();
+            webRequest.SetRequestHeader("Content-Type", "application/json");
+            yield return webRequest.SendWebRequest();
         }
 
         public IEnumerator PollRequests(TimeSpan duration, Func<List<MockServerLog>, bool> parseRequests)
@@ -129,7 +140,10 @@ namespace Datadog.Unity.Tests.Integration
         {
             get
             {
-                var headerDict = new Dictionary<string, string>();
+                // HTTP headers are case-insensitive (RFC 7230). Flask normalizes header names to
+                // title-case (e.g. "Dd-Api-Key"), so use OrdinalIgnoreCase to allow lookups
+                // with any casing (e.g. "dd-api-key").
+                var headerDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var header in Headers)
                 {
                     var colonIndex = header.IndexOf(':');

--- a/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
+++ b/packages/Datadog.Unity/Tests/com.datadoghq.unity.tests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "com.datadog.unity",
-        "com.datadoghq.unity.android"
+        "com.datadoghq.unity.android",
+        "com.datadoghq.unity.flags"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/samples/Datadog Sample/Assets/Plugins/Android/settingsTemplate.gradle
+++ b/samples/Datadog Sample/Assets/Plugins/Android/settingsTemplate.gradle
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
 // Android Resolver Repos Start
+        def unityProjectPath = $/file:///**DIR_UNITYPROJECT**/$.replace("\\", "/")
         mavenLocal()
 // Android Resolver Repos End
         flatDir {

--- a/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Datadog.Unity;
+using Datadog.Unity.Flags;
+using UnityEngine;
+
+/// <summary>
+/// Example behavior demonstrating the Datadog Flags SDK.
+/// Attach this to a GameObject in your scene to see feature flags in action.
+/// </summary>
+public class FlagsBehavior : MonoBehaviour
+{
+    public void Start()
+    {
+        DontDestroyOnLoad(gameObject);
+
+        // 1. Enable the Flags feature (after Datadog SDK is already initialized)
+        DdFlags.Enable(new FlagsConfiguration(evaluationFlushIntervalSeconds: 10.0f));
+
+        // 2. Create a flags client
+        var client = DdFlags.Instance.CreateClient();
+
+        // 3. Set the evaluation context with user/session information
+        client.SetEvaluationContext(
+            new FlagsEvaluationContext("user-12345", new Dictionary<string, object>
+            {
+                { "email", "demo@example.com" },
+                { "plan", "premium" },
+                { "country", "US" },
+            }),
+            onComplete: success =>
+            {
+                if (success)
+                {
+                    Debug.Log("[Datadog Flags] Flags loaded successfully!");
+                    EvaluateFlags(client);
+                }
+                else
+                {
+                    Debug.LogWarning("[Datadog Flags] Failed to load flags. Using defaults.");
+                    EvaluateFlags(client);
+                }
+            });
+    }
+
+    private void EvaluateFlags(FlagsClient client)
+    {
+        // Simple value accessors
+        var showNewUI = client.GetBooleanValue("show-new-ui", false);
+        Debug.Log($"[Datadog Flags] show-new-ui = {showNewUI}");
+
+        var theme = client.GetStringValue("theme-color", "blue");
+        Debug.Log($"[Datadog Flags] theme-color = {theme}");
+
+        var maxItems = client.GetIntegerValue("max-items-per-page", 25);
+        Debug.Log($"[Datadog Flags] max-items-per-page = {maxItems}");
+
+        var discountRate = client.GetDoubleValue("discount-rate", 0.0);
+        Debug.Log($"[Datadog Flags] discount-rate = {discountRate}");
+
+        // Detailed evaluation with variant/reason info
+        var details = client.GetBooleanDetails("checkout-v2-enabled", false);
+        Debug.Log($"[Datadog Flags] checkout-v2-enabled: value={details.Value}, " +
+                  $"variant={details.Variant ?? "n/a"}, reason={details.Reason ?? "n/a"}, " +
+                  $"error={details.Error?.ToString() ?? "none"}");
+    }
+
+    public void OnDestroy()
+    {
+        DdFlags.Shutdown();
+    }
+}

--- a/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs.meta
+++ b/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c280bfc9b7524db9b43346ce943cfae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/TestBehavior.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Datadog.Unity;
+using Datadog.Unity.Flags;
 using Datadog.Unity.Logs;
 using Datadog.Unity.Rum;
 using UnityEngine;
@@ -46,5 +47,26 @@ public class TestBehavior : MonoBehaviour
         });
 
         DatadogSdk.Instance.Rum.StopResource("key", RumResourceType.Native);
+
+        // Feature Flags
+        DdFlags.Enable();
+        var flagsClient = DdFlags.Instance.CreateClient();
+        flagsClient.SetEvaluationContext(
+            new FlagsEvaluationContext("user-1234", new Dictionary<string, object>
+            {
+                { "email", "test@example.com" },
+            }),
+            onComplete: success =>
+            {
+                if (success)
+                {
+                    var featureEnabled = flagsClient.GetBooleanValue("new-feature", false);
+                    logger.Info($"Feature flag 'new-feature' = {featureEnabled}");
+                }
+                else
+                {
+                    logger.Warn("Failed to fetch feature flags");
+                }
+            });
     }
 }

--- a/samples/Datadog Sample/Packages/packages-lock.json
+++ b/samples/Datadog Sample/Packages/packages-lock.json
@@ -24,11 +24,11 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.2d.animation": {
-      "version": "9.2.1",
+      "version": "9.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "8.1.1",
+        "com.unity.2d.common": "8.1.0",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.collections": "1.1.0",
         "com.unity.modules.animation": "1.0.0",
@@ -37,7 +37,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.1.10",
+      "version": "1.1.9",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -49,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.common": {
-      "version": "8.1.1",
+      "version": "8.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -71,13 +71,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.psdimporter": {
-      "version": "8.1.1",
+      "version": "8.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "8.1.1",
+        "com.unity.2d.common": "8.1.0",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.animation": "9.2.1"
+        "com.unity.2d.animation": "9.2.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -88,11 +88,11 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "9.1.1",
+      "version": "9.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "8.1.1",
+        "com.unity.2d.common": "8.1.0",
         "com.unity.mathematics": "1.1.0",
         "com.unity.modules.physics2d": "1.0.0"
       },
@@ -129,7 +129,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.24",
+      "version": "1.8.21",
       "depth": 3,
       "source": "registry",
       "dependencies": {
@@ -167,14 +167,14 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.2d.animation": "9.2.1",
+        "com.unity.2d.animation": "9.2.0",
         "com.unity.2d.pixel-perfect": "5.1.0",
-        "com.unity.2d.psdimporter": "8.1.1",
+        "com.unity.2d.psdimporter": "8.1.0",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.spriteshape": "9.1.1",
+        "com.unity.2d.spriteshape": "9.1.0",
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.2d.tilemap.extras": "3.1.3",
-        "com.unity.2d.aseprite": "1.1.10"
+        "com.unity.2d.aseprite": "1.1.9"
       }
     },
     "com.unity.ide.rider": {

--- a/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/samples/Datadog Sample/ProjectSettings/AndroidResolverDependencies.xml
@@ -17,7 +17,7 @@
     <setting name="packageDir" value="Assets/Plugins/Android" />
     <setting name="patchAndroidManifest" value="True" />
     <setting name="patchMainTemplateGradle" value="True" />
-    <setting name="projectExportEnabled" value="True" />
+    <setting name="projectExportEnabled" value="False" />
     <setting name="useFullCustomMavenRepoPathWhenExport" value="True" />
     <setting name="useFullCustomMavenRepoPathWhenNotExport" value="False" />
     <setting name="useJetifier" value="True" />

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -176,7 +176,6 @@ PlayerSettings:
   AndroidMinSdkVersion: 30
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
-  AndroidPreferredDataLocation: 1
   aotOptions: nimt-trampolines=1024
   stripEngineCode: 0
   iPhoneStrippingLevel: 0

--- a/samples/Datadog Sample/ProjectSettings/ProjectVersion.txt
+++ b/samples/Datadog Sample/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.67f2
-m_EditorVersionWithRevision: 2022.3.67f2 (6bedba8691df)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)

--- a/tools/mock_server/app.py
+++ b/tools/mock_server/app.py
@@ -30,6 +30,8 @@ from urllib.parse import urlparse
 app = Flask(__name__)
 CORS(app)
 
+configured_responses = {}  # path -> { status, body, content_type }
+
 @dataclass()
 class GenericRequest:
     method: str
@@ -145,6 +147,22 @@ def write_to_file(endpoint: GenericEndpoint):
         with open(f'fixtures/replay/{no}', 'wb') as f:
             f.write(request.get_data())
 
+@app.route('/configure_response', methods=['POST'])
+def configure_response():
+    """
+    POST /configure_response
+
+    Store a per-path response override so that subsequent POST requests to
+    that path return the configured status/body instead of the default 202.
+    """
+    global configured_responses
+    data = request.get_json()
+    configured_responses[data['path']] = data
+    resp = flask.Response('OK', status=200)
+    add_cors_headers(resp)
+    return resp
+
+
 @app.route('/', methods=['POST'])
 @app.route('/<path:rest>', methods=['POST'])
 def generic_post(rest = ''):
@@ -157,11 +175,9 @@ def generic_post(rest = ''):
 
     gr = GenericRequest(r=request)
 
-    response_text = ''
+    # Record the request regardless of whether we return a configured response
     if existing := next((e for e in endpoints if e.hash() == gr.endpoint_hash()), None):
         existing.requests.append(gr)
-        # write_to_file(endpoint=existing)
-        response_text = 'OK - request recorded to known endpoint\n'
     else:
         endpoints.append(
             GenericEndpoint(
@@ -171,9 +187,16 @@ def generic_post(rest = ''):
                 schemas=gr.schemas
             )
         )
-        response_text = 'OK - request recorded to new endpoint\n'
 
-    resp = flask.Response(response_text, status=202)
+    # Return a configured response if one was registered for this path
+    if gr.path in configured_responses:
+        cfg = configured_responses[gr.path]
+        resp = flask.Response(cfg['body'], status=cfg.get('status', 200))
+        resp.headers['Content-Type'] = cfg.get('content_type', 'application/json')
+        add_cors_headers(resp)
+        return resp
+
+    resp = flask.Response('OK - request recorded\n', status=202)
     add_cors_headers(resp)
     return resp
 
@@ -246,8 +269,9 @@ def reset():
 
     Clear currently logged requests on all endpoints
     """
-    global endpoints
+    global endpoints, configured_responses
     endpoints.clear()
+    configured_responses.clear()
     resp = flask.Response('OK', status=200)
     add_cors_headers(resp)
     return resp

--- a/tools/scripts/common/android/sdkmanager.py
+++ b/tools/scripts/common/android/sdkmanager.py
@@ -50,10 +50,10 @@ def _parse_sdkmanager_list_output(output: str) -> List[AndroidPackage]:
     # Grab each line of the table that appears beneath 'Installed packages' in the output
     section_header = 'Installed packages:'
     section_header_line_index = next((i for i, s in enumerate(lines) if s.startswith(section_header)), None)
-    if not section_header_line_index:
-        raise RuntimeError(f'Unexpected sdkmanager output: "{section_header}" did not appear')        
+    if section_header_line_index is None:
+        raise RuntimeError(f'Unexpected sdkmanager output: "{section_header}" did not appear')
     next_blank_line_index = next((i for i, s in enumerate(lines) if i > section_header_line_index and s.strip() == ''), None)
-    if not next_blank_line_index:
+    if next_blank_line_index is None:
         raise RuntimeError(f'Unexpected sdkmanager output: found no blank line after "{section_header}"')
     section_lines = lines[section_header_line_index+1:next_blank_line_index]
 

--- a/tools/scripts/integration_test.py
+++ b/tools/scripts/integration_test.py
@@ -17,7 +17,7 @@ from junitparser.junitparser import JUnitXml, TestCase
 
 from common.log import init_logger
 from common.unity import UnityHub, resolve_unity_install, UnityLicenseStatus, modified_ios_target_settings
-from common.ddconfig import DatadogRuntimeConfig, modified_datadog_settings
+from common.ddconfig import DatadogRuntimeConfig, FirstPartyHost, modified_datadog_settings
 from common.inet_addr import get_reachable_inet_addr
 from common.mockserver import prepare_mock_server_venv, run_mock_server
 from common.simulator import run_default_simulator
@@ -107,6 +107,7 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
     # Temporarily modify the project's DatadogSettings asset so that it will send data
     # to the mock server we're about to stand up, and also apply any settings that the
     # integration tests require
+    mock_host = f'{mock_server_bind_addr}:{mock_server_port}'
     config = DatadogRuntimeConfig(
         enabled=True,
         sdk_verbosity=1,
@@ -126,6 +127,8 @@ def integration_test(unity_version_prefix: str, project_path: str, platform: str
         session_sample_rate=100,
         trace_sample_rate=100,
         telemetry_sample_rate=100,
+        # 18 == TracingHeaderType.Datadog | TracingHeaderType.TraceContext
+        first_party_hosts=[FirstPartyHost(host=mock_host, tracing_header_type=18)],
     )
     with _integration_test_env(project_path, config, mock_server_bind_addr, mock_server_port, platform, target):
         # Run our Unity project's integration tests in the editor


### PR DESCRIPTION
## Summary
This PR contains the core Feature Flags SDK implementation without OpenFeature integration. All unit tests are passing across Unity 2021.3, 2022.3, and 6000.2.

## Why
We have a customer transitioning from EPPO to Datadog Flags and require a Unity SDK

## Decisions

### Separated OpenFeature Integration
**Decision:** Omit OpenFeature as a dependency and provide a direct Datadog Flags API instead.

**Rationale:**
- **Dependency complexity**: OpenFeature requires Microsoft.Extensions.Logging.Abstractions and other transitive dependencies
- **Unity compatibility**: Multiple Unity versions have different assembly resolution behaviors, leading to "Multiple precompiled assemblies" errors with OpenFeature's dependency tree
- **Target framework conflicts**: OpenFeature's NuGet packages include multiple target frameworks (net462, netstandard2.0, netstandard2.1, net6.0+) which Unity struggles to resolve correctly

**Future Work:**
- Adding the OpenFeature Provider shim code and OpenFeature dependencies in followup PR

## Changes
- Core flags client with local evaluation and direct API access
- Precomputed assignments fetching from Datadog endpoint
- Type-safe flag accessors (boolean, string, number, JSON)
- Exposure tracking and EVP telemetry
- Flag evaluation aggregation
- Thread-safety improvements in `EvaluationAggregator`
- Public API types: `FlagsClient`, `FlagsClientState`, `FlagDetails<T>`, `FlagEvaluationError`

## What's Included
- `DdFlags` - Main SDK entry point with `Enable()` (static) and `CreateClient()` (instance via `DdFlags.Instance`)
- `FlagsClient` - Client for fetching and evaluating flags; call `SetEvaluationContext()` to fetch assignments
- `EvaluationAggregator` - Aggregates flag evaluations with timer-based flushing
- `ExposureTracker` - Tracks flag exposures for RUM integration
- `EvpTelemetrySender` - Sends telemetry to Datadog EVP endpoints
- Supporting classes and comprehensive unit tests

## API Example

```csharp
// Enable the Flags feature (call once at startup, from the Unity main thread)
DdFlags.Enable(new FlagsConfiguration(evaluationFlushIntervalSeconds: 10.0f));

// Create a client
var client = DdFlags.Instance.CreateClient();

// Set evaluation context and fetch flags
client.SetEvaluationContext(
    new FlagsEvaluationContext("user-123", new Dictionary<string, object>
    {
        { "email", "user@example.com" },
        { "plan", "premium" },
    }),
    onComplete: success =>
    {
        if (success)
        {
            // Evaluate flags
            var showFeature = client.GetBooleanValue("show-new-feature", false);
            var theme = client.GetStringValue("theme-color", "blue");

            // Or get detailed evaluation results
            var details = client.GetBooleanDetails("checkout-v2-enabled", false);
            Debug.Log($"Value: {details.Value}, Variant: {details.Variant}");
        }
    });
```

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests