### PR TITLE
Log error instead of throw when Env not configured; return noop client with NotReady state

### DIFF
--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -15,12 +15,10 @@ namespace Datadog.Unity.Flags
     /// Entry point for the Datadog Flags feature in Unity.
     ///
     /// <code>
-    /// // Setup
     /// DdFlags.Enable(new FlagsConfiguration());
     /// var client = DdFlags.Instance.CreateClient();
     /// client.SetEvaluationContext(new FlagsEvaluationContext("user-123"), onComplete: success =>
     /// {
-    ///     // Evaluate flags
     ///     var showFeature = client.GetBooleanValue("show-new-feature", false);
     /// });
     /// </code>
@@ -29,101 +27,106 @@ namespace Datadog.Unity.Flags
     {
         private static readonly object _enableLock = new();
 
-        private readonly FlagsConfiguration _configuration;
-        private readonly EvpTelemetrySender _telemetrySender;
-        private readonly IInternalLogger _logger;
-        private readonly Dictionary<string, FlagsClient> _clients = new();
+        /// <summary>
+        /// The singleton. Always non-null. Call <see cref="Enable"/> to configure it.
+        /// Before <see cref="Enable"/> succeeds, <see cref="CreateClient"/> returns a
+        /// <see cref="NoopFlagsClient"/> with reason <c>"DISABLED"</c>.
+        /// </summary>
+        public static readonly DdFlags Instance = new();
+
+        private FlagsConfiguration _configuration;
+        private EvpTelemetrySender _telemetrySender;
+        private IInternalLogger _logger;
+        private volatile bool _isEnabled;
+        private readonly Dictionary<string, IFlagsClient> _clients = new();
         private readonly object _lock = new();
 
-        /// <summary>
-        /// Gets the singleton instance of DdFlags. Null until <see cref="Enable"/> is called.
-        /// </summary>
-        public static DdFlags Instance { get; private set; }
-
-        private DdFlags(FlagsConfiguration configuration, EvpTelemetrySender telemetrySender, IInternalLogger logger)
-        {
-            _configuration = configuration;
-            _telemetrySender = telemetrySender;
-            _logger = logger;
-        }
+        private DdFlags() { }
 
         /// <summary>
-        /// Enables the Datadog Flags feature and initializes the singleton instance.
-        /// Must be called from the Unity main thread after Datadog SDK initialization.
-        /// Subsequent calls are ignored.
+        /// Enables the Datadog Flags feature. Must be called from the Unity main thread
+        /// after Datadog SDK initialization. Subsequent calls are ignored.
         /// </summary>
-        /// <param name="configuration">Configuration options for the Flags feature.</param>
         public static void Enable(FlagsConfiguration configuration = null)
         {
+            if (Instance._isEnabled)
+            {
+                DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Warn,
+                    "DdFlags.Enable() called more than once — ignoring.");
+                return;
+            }
+
             lock (_enableLock)
             {
-                if (Instance != null)
+                // Re-check inside the lock in case two threads raced.
+                if (Instance._isEnabled)
                 {
-                    DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Warn,
-                        "DdFlags.Enable() called more than once — ignoring.");
                     return;
                 }
 
+                var logger = DatadogSdk.Instance?.InternalLogger;
+
                 if (SynchronizationContext.Current == null)
                 {
-                    const string message =
+                    ThrowOrLog(logger,
                         "DdFlags.Enable() must be called from the Unity main thread. " +
-                        "Automatic telemetry flushing will be disabled.";
-
-                    if (Application.isEditor || Debug.isDebugBuild)
-                    {
-                        throw new InvalidOperationException(message);
-                    }
-                    else
-                    {
-                        DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Error, message);
-                    }
+                        "Automatic telemetry flushing will be disabled.");
+                    // Non-fatal: continue in degraded mode without automatic flushing.
                 }
 
                 configuration ??= new FlagsConfiguration();
 
                 var options = DatadogConfigurationOptions.Load();
-                var site = options?.Site ?? DatadogSite.Us1;
-                var exposureEndpoint = !string.IsNullOrEmpty(configuration.CustomExposureEndpoint)
-                    ? configuration.CustomExposureEndpoint
-                    : FlagsEndpoints.GetExposureEndpoint(site);
-                var evaluationEndpoint = !string.IsNullOrEmpty(configuration.CustomEvaluationEndpoint)
-                    ? configuration.CustomEvaluationEndpoint
-                    : FlagsEndpoints.GetEvaluationEndpoint(site);
-                var logger = DatadogSdk.Instance?.InternalLogger;
 
-                var sender = new EvpTelemetrySender(
-                    clientToken: options?.ClientToken ?? string.Empty,
-                    exposureEndpoint: exposureEndpoint,
-                    evaluationEndpoint: evaluationEndpoint,
-                    env: options?.Env ?? string.Empty,
-                    logger: logger);
+                if (string.IsNullOrEmpty(options?.Env))
+                {
+                    ThrowOrLog(logger,
+                        "DdFlags.Enable() requires the Datadog 'Env' setting to be configured. " +
+                        "Set Env in your DatadogSettings asset. " +
+                        "Flag evaluations will return default values.");
+                    return;
+                }
 
-                Instance = new DdFlags(configuration, sender, logger);
+                if (string.IsNullOrEmpty(options?.ClientToken))
+                {
+                    ThrowOrLog(logger,
+                        "DdFlags.Enable() requires the Datadog 'ClientToken' setting to be configured. " +
+                        "Set ClientToken in your DatadogSettings asset. " +
+                        "Flag evaluations will return default values.");
+                    return;
+                }
+
+                Instance.Configure(configuration, logger);
             }
         }
 
         /// <summary>
-        /// Shuts down the Flags feature, disposes all clients, and clears the singleton instance.
+        /// Shuts down the Flags feature, disposes all clients, and resets to pre-Enable state.
         /// </summary>
         public static void Shutdown()
         {
-            DdFlags instance;
             lock (_enableLock)
             {
-                instance = Instance;
-                Instance = null;
+                Instance._isEnabled = false;
+                Instance._configuration = null;
+                Instance._telemetrySender = null;
+                Instance._logger = null;
             }
 
-            instance?.ShutdownInternal();
+            Instance.ShutdownInternal();
         }
 
         /// <summary>
-        /// Creates a flags client for the given name.
+        /// Creates a flags client for the given name. Returns a <see cref="NoopFlagsClient"/>
+        /// if the SDK has not been enabled yet.
         /// </summary>
-        /// <param name="name">A unique name for this client. Defaults to "default".</param>
-        public FlagsClient CreateClient(string name = FlagsClient.DefaultName)
+        public IFlagsClient CreateClient(string name = FlagsClient.DefaultName)
         {
+            if (!_isEnabled)
+            {
+                return new NoopFlagsClient("DISABLED", DatadogSdk.Instance?.InternalLogger);
+            }
+
             lock (_lock)
             {
                 if (_clients.TryGetValue(name, out var existingClient))
@@ -147,25 +150,20 @@ namespace Datadog.Unity.Flags
                     precomputeEndpoint = FlagsEndpoints.GetPrecomputeEndpoint(DatadogSite.Us1);
                 }
 
-                var repository = new FlagsRepository();
-                var exposureTracker = new ExposureTracker();
+                var sender = GetOrCreateSender(options);
 
                 Action<ExposureEvent> onExposure = null;
                 EvaluationAggregator evaluationAggregator = null;
-                if (_telemetrySender != null)
+                if (_configuration.TrackExposures)
                 {
-                    if (_configuration.TrackExposures)
-                    {
-                        onExposure = _telemetrySender.SendExposure;
-                    }
+                    onExposure = sender.SendExposure;
+                }
 
-                    if (_configuration.TrackEvaluations)
-                    {
-                        var sender = _telemetrySender;
-                        evaluationAggregator = new EvaluationAggregator(
-                            onFlush: events => sender.SendEvaluations(events),
-                            flushIntervalSeconds: _configuration.EvaluationFlushIntervalSeconds);
-                    }
+                if (_configuration.TrackEvaluations)
+                {
+                    evaluationAggregator = new EvaluationAggregator(
+                        onFlush: events => sender.SendEvaluations(events),
+                        flushIntervalSeconds: _configuration.EvaluationFlushIntervalSeconds);
                 }
 
                 var fetcher = new PrecomputeAssignmentsFetcher(
@@ -176,8 +174,8 @@ namespace Datadog.Unity.Flags
                     logger: _logger);
 
                 var client = new FlagsClient(
-                    repository: repository,
-                    exposureTracker: exposureTracker,
+                    repository: new FlagsRepository(),
+                    exposureTracker: new ExposureTracker(),
                     evaluationAggregator: evaluationAggregator,
                     fetcher: fetcher,
                     logger: _logger,
@@ -190,7 +188,7 @@ namespace Datadog.Unity.Flags
             }
         }
 
-        internal FlagsClient GetClient(string name = FlagsClient.DefaultName)
+        internal IFlagsClient GetClient(string name = FlagsClient.DefaultName)
         {
             lock (_lock)
             {
@@ -199,12 +197,57 @@ namespace Datadog.Unity.Flags
             }
         }
 
+        // Sets configuration and marks the instance as enabled.
+        private void Configure(FlagsConfiguration configuration, IInternalLogger logger)
+        {
+            _configuration = configuration;
+            _logger = logger;
+            _isEnabled = true;
+        }
+
+        // Lazily creates the shared telemetry sender; reuses it on subsequent calls.
+        private EvpTelemetrySender GetOrCreateSender(DatadogConfigurationOptions options)
+        {
+            if (_telemetrySender != null)
+            {
+                return _telemetrySender;
+            }
+
+            var site = options?.Site ?? DatadogSite.Us1;
+            var exposureEndpoint = !string.IsNullOrEmpty(_configuration.CustomExposureEndpoint)
+                ? _configuration.CustomExposureEndpoint
+                : FlagsEndpoints.GetExposureEndpoint(site);
+            var evaluationEndpoint = !string.IsNullOrEmpty(_configuration.CustomEvaluationEndpoint)
+                ? _configuration.CustomEvaluationEndpoint
+                : FlagsEndpoints.GetEvaluationEndpoint(site);
+
+            _telemetrySender = new EvpTelemetrySender(
+                clientToken: options?.ClientToken ?? string.Empty,
+                exposureEndpoint: exposureEndpoint,
+                evaluationEndpoint: evaluationEndpoint,
+                env: options?.Env ?? string.Empty,
+                logger: _logger);
+
+            return _telemetrySender;
+        }
+
+        // Throws in editor/debug builds; logs at error level in production.
+        private static void ThrowOrLog(IInternalLogger logger, string message)
+        {
+            if (Application.isEditor || Debug.isDebugBuild)
+            {
+                throw new InvalidOperationException(message);
+            }
+
+            logger?.Log(DdLogLevel.Error, message);
+        }
+
         private void ShutdownInternal()
         {
-            List<FlagsClient> clientsToDispose;
+            List<IFlagsClient> clientsToDispose;
             lock (_lock)
             {
-                clientsToDispose = new List<FlagsClient>(_clients.Values);
+                clientsToDispose = new List<IFlagsClient>(_clients.Values);
                 _clients.Clear();
             }
 

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -30,7 +30,7 @@ namespace Datadog.Unity.Flags
         /// <summary>
         /// The singleton. Always non-null. Call <see cref="Enable"/> to configure it.
         /// Before <see cref="Enable"/> succeeds, <see cref="CreateClient"/> returns a
-        /// <see cref="NoopFlagsClient"/> with reason <c>"DISABLED"</c>.
+        /// <see cref="NoopFlagsClient"/> with reason <c>"DEFAULT"</c>.
         /// </summary>
         public static readonly DdFlags Instance = new();
 
@@ -49,18 +49,12 @@ namespace Datadog.Unity.Flags
         /// </summary>
         public static void Enable(FlagsConfiguration configuration = null)
         {
-            if (Instance._isEnabled)
-            {
-                DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Warn,
-                    "DdFlags.Enable() called more than once — ignoring.");
-                return;
-            }
-
             lock (_enableLock)
             {
-                // Re-check inside the lock in case two threads raced.
                 if (Instance._isEnabled)
                 {
+                    DatadogSdk.Instance?.InternalLogger?.Log(DdLogLevel.Warn,
+                        "DdFlags.Enable() called more than once — ignoring.");
                     return;
                 }
 
@@ -68,7 +62,7 @@ namespace Datadog.Unity.Flags
 
                 if (SynchronizationContext.Current == null)
                 {
-                    ThrowOrLog(logger,
+                    ReportMisconfiguration(logger,
                         "DdFlags.Enable() must be called from the Unity main thread. " +
                         "Automatic telemetry flushing will be disabled.");
                     // Non-fatal: continue in degraded mode without automatic flushing.
@@ -80,7 +74,7 @@ namespace Datadog.Unity.Flags
 
                 if (string.IsNullOrEmpty(options?.Env))
                 {
-                    ThrowOrLog(logger,
+                    ReportMisconfiguration(logger,
                         "DdFlags.Enable() requires the Datadog 'Env' setting to be configured. " +
                         "Set Env in your DatadogSettings asset. " +
                         "Flag evaluations will return default values.");
@@ -89,7 +83,7 @@ namespace Datadog.Unity.Flags
 
                 if (string.IsNullOrEmpty(options?.ClientToken))
                 {
-                    ThrowOrLog(logger,
+                    ReportMisconfiguration(logger,
                         "DdFlags.Enable() requires the Datadog 'ClientToken' setting to be configured. " +
                         "Set ClientToken in your DatadogSettings asset. " +
                         "Flag evaluations will return default values.");
@@ -107,10 +101,11 @@ namespace Datadog.Unity.Flags
         {
             lock (_enableLock)
             {
+                // Only flip _isEnabled — do not null out _configuration/_telemetrySender/_logger.
+                // Nulling those fields under a different lock than CreateClient() uses (_lock)
+                // creates a race where a concurrent CreateClient() could observe _isEnabled == true
+                // and then hit NullReferenceException on _configuration.
                 Instance._isEnabled = false;
-                Instance._configuration = null;
-                Instance._telemetrySender = null;
-                Instance._logger = null;
             }
 
             Instance.ShutdownInternal();
@@ -124,7 +119,7 @@ namespace Datadog.Unity.Flags
         {
             if (!_isEnabled)
             {
-                return new NoopFlagsClient("DISABLED", DatadogSdk.Instance?.InternalLogger);
+                return new NoopFlagsClient("DEFAULT", DatadogSdk.Instance?.InternalLogger);
             }
 
             lock (_lock)
@@ -231,8 +226,9 @@ namespace Datadog.Unity.Flags
             return _telemetrySender;
         }
 
-        // Throws in editor/debug builds; logs at error level in production.
-        private static void ThrowOrLog(IInternalLogger logger, string message)
+        // Reports a misconfiguration: throws in editor/debug builds so developers catch it
+        // immediately; logs at error level in production so the app never crashes.
+        private static void ReportMisconfiguration(IInternalLogger logger, string message)
         {
             if (Application.isEditor || Debug.isDebugBuild)
             {

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -117,12 +117,6 @@ namespace Datadog.Unity.Flags
                 return;
             }
 
-            if (_fetcher == null)
-            {
-                onComplete?.Invoke(false);
-                return;
-            }
-
             TransitionState(FlagsClientState.Reconciling);
 
             _fetcher.Fetch(context, flags =>

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -11,7 +11,7 @@ namespace Datadog.Unity.Flags
     /// Client for evaluating feature flags. Use <c>DdFlags.CreateClient()</c> to create
     /// an instance after calling <c>DdFlags.Enable()</c>.
     /// </summary>
-    public class FlagsClient : IDisposable
+    public class FlagsClient : IFlagsClient
     {
         public const string DefaultName = "default";
 
@@ -25,7 +25,7 @@ namespace Datadog.Unity.Flags
         private readonly bool _trackEvaluations;
         private readonly Action<ExposureEvent> _onExposure;
 
-        private FlagsClientState _state = FlagsClientState.NotReady;
+        private FlagsClientState _state;
         private bool _disposed;
 
         internal FlagsClient(
@@ -36,7 +36,8 @@ namespace Datadog.Unity.Flags
             Core.IInternalLogger logger,
             bool trackExposures,
             bool trackEvaluations,
-            Action<ExposureEvent> onExposure)
+            Action<ExposureEvent> onExposure,
+            FlagsClientState initialState = FlagsClientState.NotReady)
         {
             _repository = repository;
             _exposureTracker = exposureTracker;
@@ -46,6 +47,7 @@ namespace Datadog.Unity.Flags
             _trackExposures = trackExposures;
             _trackEvaluations = trackEvaluations;
             _onExposure = onExposure;
+            _state = initialState;
         }
 
         /// <summary>
@@ -111,6 +113,12 @@ namespace Datadog.Unity.Flags
             if (context == null)
             {
                 _logger?.Log(Logs.DdLogLevel.Warn, "SetEvaluationContext called with null context. Ignoring.");
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            if (_fetcher == null)
+            {
                 onComplete?.Invoke(false);
                 return;
             }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
@@ -25,5 +25,8 @@ namespace Datadog.Unity.Flags
 
         /// <summary>An unrecoverable error occurred.</summary>
         Error,
+
+        /// <summary>The client is disabled (e.g. SDK not yet enabled, or ENV not configured). All evaluations return defaults.</summary>
+        Disabled,
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClientState.cs
@@ -25,8 +25,5 @@ namespace Datadog.Unity.Flags
 
         /// <summary>An unrecoverable error occurred.</summary>
         Error,
-
-        /// <summary>The client is disabled (e.g. SDK not yet enabled, or ENV not configured). All evaluations return defaults.</summary>
-        Disabled,
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsClient.cs
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Interface for evaluating feature flags. Use <c>DdFlags.Instance.CreateClient()</c> to obtain an instance.
+    /// </summary>
+    public interface IFlagsClient : IDisposable
+    {
+        /// <summary>Gets the current state of the client.</summary>
+        FlagsClientState State { get; }
+
+        /// <summary>
+        /// Subscribes to client state changes. The handler is invoked immediately with the
+        /// current state (where <c>Old == New</c>) and on every subsequent transition.
+        /// </summary>
+        event EventHandler<FlagsStateChange> StateChanged;
+
+        /// <summary>Sets the evaluation context and fetches precomputed flag assignments.</summary>
+        void SetEvaluationContext(FlagsEvaluationContext context, Action<bool> onComplete = null);
+
+        bool GetBooleanValue(string key, bool defaultValue);
+        string GetStringValue(string key, string defaultValue);
+        int GetIntegerValue(string key, int defaultValue);
+        double GetDoubleValue(string key, double defaultValue);
+        object GetObjectValue(string key, object defaultValue);
+
+        FlagDetails<bool> GetBooleanDetails(string key, bool defaultValue);
+        FlagDetails<string> GetStringDetails(string key, string defaultValue);
+        FlagDetails<int> GetIntegerDetails(string key, int defaultValue);
+        FlagDetails<double> GetDoubleDetails(string key, double defaultValue);
+        FlagDetails<T> GetDetails<T>(string key, T defaultValue);
+
+        /// <summary>Flushes any pending aggregated evaluation events.</summary>
+        void Flush();
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsClient.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1c4e8f2b6d03597e4a2c91f7b5d6e38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs
@@ -25,11 +25,17 @@ namespace Datadog.Unity.Flags
             _logger = logger;
         }
 
-        public FlagsClientState State => FlagsClientState.Disabled;
+        public FlagsClientState State => FlagsClientState.NotReady;
 
         public event EventHandler<FlagsStateChange> StateChanged
         {
-            add { }
+            add
+            {
+                // Replay current (NotReady) state immediately, matching IFlagsClient contract.
+                // No further transitions will ever fire on a noop client.
+                if (value == null) return;
+                value(this, new FlagsStateChange(FlagsClientState.NotReady, FlagsClientState.NotReady));
+            }
             remove { }
         }
 
@@ -52,7 +58,7 @@ namespace Datadog.Unity.Flags
         public FlagDetails<T> GetDetails<T>(string key, T defaultValue)
         {
             _logger?.Log(DdLogLevel.Debug,
-                $"[DdFlags] Returning default value for '{key}' — {_reason}");
+                $"[DdFlags] '{key}' — returning developer default ({_reason}: client not configured)");
             return new FlagDetails<T>(key, defaultValue, reason: _reason);
         }
 

--- a/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// A no-op implementation of <see cref="IFlagsClient"/> that returns the caller-supplied
+    /// default value for every evaluation. Used when the Flags SDK is not operational —
+    /// either because <see cref="DdFlags.Enable"/> has not been called, or because the
+    /// required <c>Env</c> setting was not configured in a production build.
+    /// </summary>
+    internal class NoopFlagsClient : IFlagsClient
+    {
+        private readonly string _reason;
+        private readonly IInternalLogger _logger;
+
+        internal NoopFlagsClient(string reason, IInternalLogger logger = null)
+        {
+            _reason = reason;
+            _logger = logger;
+        }
+
+        public FlagsClientState State => FlagsClientState.Disabled;
+
+        public event EventHandler<FlagsStateChange> StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void SetEvaluationContext(FlagsEvaluationContext context, Action<bool> onComplete = null)
+        {
+            onComplete?.Invoke(false);
+        }
+
+        public bool GetBooleanValue(string key, bool defaultValue) => GetDetails(key, defaultValue).Value;
+        public string GetStringValue(string key, string defaultValue) => GetDetails(key, defaultValue).Value;
+        public int GetIntegerValue(string key, int defaultValue) => GetDetails(key, defaultValue).Value;
+        public double GetDoubleValue(string key, double defaultValue) => GetDetails(key, defaultValue).Value;
+        public object GetObjectValue(string key, object defaultValue) => GetDetails(key, defaultValue).Value;
+
+        public FlagDetails<bool> GetBooleanDetails(string key, bool defaultValue) => GetDetails(key, defaultValue);
+        public FlagDetails<string> GetStringDetails(string key, string defaultValue) => GetDetails(key, defaultValue);
+        public FlagDetails<int> GetIntegerDetails(string key, int defaultValue) => GetDetails(key, defaultValue);
+        public FlagDetails<double> GetDoubleDetails(string key, double defaultValue) => GetDetails(key, defaultValue);
+
+        public FlagDetails<T> GetDetails<T>(string key, T defaultValue)
+        {
+            _logger?.Log(DdLogLevel.Debug,
+                $"[DdFlags] Returning default value for '{key}' — {_reason}");
+            return new FlagDetails<T>(key, defaultValue, reason: _reason);
+        }
+
+        public void Flush() { }
+
+        public void Dispose() { }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/NoopFlagsClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3a5b8d2e1c4709a6b3d2e8f4c7a1b56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -69,11 +69,9 @@ namespace Datadog.Unity.Flags
                     {
                         if (request.result != UnityWebRequest.Result.Success)
                         {
-                            var body = request.downloadHandler?.text;
-                            var message = string.IsNullOrEmpty(body)
-                                ? $"Failed to fetch flag assignments: {request.error}"
-                                : $"Failed to fetch flag assignments: {request.error} \u2014 {body}";
-                            _logger?.Log(Logs.DdLogLevel.Warn, message);
+                            var errorDetail = ExtractServerError(request.downloadHandler?.text, request.responseCode);
+                            _logger?.Log(Logs.DdLogLevel.Warn,
+                                $"Failed to fetch flag assignments (HTTP {request.responseCode}): {errorDetail}");
                             onComplete?.Invoke(null);
                             return;
                         }
@@ -122,6 +120,51 @@ namespace Datadog.Unity.Flags
                 },
             };
             return JsonConvert.SerializeObject(dto);
+        }
+
+        /// <summary>
+        /// Extracts a human-readable error message from a server response body.
+        /// Handles the two response shapes returned by the edge-assignments server:
+        ///   - JSON:API:  {"errors":[{"title":"...","detail":"..."}]}
+        ///   - Flat:      {"error":"..."} (Fastly-level panics / 405 handler)
+        /// Falls through to a generic message if the body is absent or unparseable.
+        /// </summary>
+        internal static string ExtractServerError(string body, long httpCode)
+        {
+            if (!string.IsNullOrEmpty(body))
+            {
+                try
+                {
+                    var obj = JObject.Parse(body);
+
+                    // JSON:API format: {"errors":[{"title":"...","detail":"..."}]}
+                    var errors = obj["errors"] as JArray;
+                    if (errors != null && errors.Count > 0)
+                    {
+                        var first = errors[0];
+                        var title = first["title"]?.Value<string>();
+                        var detail = first["detail"]?.Value<string>();
+
+                        if (!string.IsNullOrEmpty(title) && !string.IsNullOrEmpty(detail))
+                            return $"{title}: {detail}";
+                        if (!string.IsNullOrEmpty(title))
+                            return title;
+                        if (!string.IsNullOrEmpty(detail))
+                            return detail;
+                    }
+
+                    // Flat format: {"error":"..."} (Fastly catch-all / 405 handler)
+                    var error = obj["error"]?.Value<string>();
+                    if (!string.IsNullOrEmpty(error))
+                        return error;
+                }
+                catch
+                {
+                    // Body is not valid JSON — fall through.
+                }
+            }
+
+            return $"unreadable error response (HTTP {httpCode})";
         }
 
         internal static Dictionary<string, FlagAssignment> ParseResponse(string json)

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -69,7 +69,11 @@ namespace Datadog.Unity.Flags
                     {
                         if (request.result != UnityWebRequest.Result.Success)
                         {
-                            _logger?.Log(Logs.DdLogLevel.Warn, $"Failed to fetch flag assignments: {request.error}");
+                            var body = request.downloadHandler?.text;
+                            var message = string.IsNullOrEmpty(body)
+                                ? $"Failed to fetch flag assignments: {request.error}"
+                                : $"Failed to fetch flag assignments: {request.error} \u2014 {body}";
+                            _logger?.Log(Logs.DdLogLevel.Warn, message);
                             onComplete?.Invoke(null);
                             return;
                         }

--- a/packages/Datadog.Unity/Tests/Flags/DdFlagsTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/DdFlagsTests.cs
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class DdFlagsTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            DdFlags.Shutdown();
+        }
+
+        [Test]
+        public void Enable_ThrowsWhenEnvNotConfigured()
+        {
+            // DatadogSettings.asset has Env left blank (the default for new projects).
+            // DdFlags.Enable() must throw rather than silently sending a request that
+            // the edge layer rejects with 400 ("dd_env cannot be empty").
+            Assert.Throws<InvalidOperationException>(() => DdFlags.Enable());
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/DdFlagsTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/DdFlagsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b3a92f1c4e8d5072a1cd3b7e60f94285
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Unity.Flags.Tests
         public void SetUp()
         {
             _logger = Substitute.For<IInternalLogger>();
-            _client = new NoopFlagsClient("DISABLED", _logger);
+            _client = new NoopFlagsClient("DEFAULT", _logger);
         }
 
         [TearDown]
@@ -30,9 +30,9 @@ namespace Datadog.Unity.Flags.Tests
         }
 
         [Test]
-        public void State_IsAlwaysDisabled()
+        public void State_IsNotReady()
         {
-            Assert.AreEqual(FlagsClientState.Disabled, _client.State);
+            Assert.AreEqual(FlagsClientState.NotReady, _client.State);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Datadog.Unity.Flags.Tests
             var details = _client.GetBooleanDetails("flag", false);
 
             Assert.AreEqual(false, details.Value);
-            Assert.AreEqual("DISABLED", details.Reason);
+            Assert.AreEqual("DEFAULT", details.Reason);
             Assert.IsNull(details.Error);
         }
 
@@ -88,7 +88,7 @@ namespace Datadog.Unity.Flags.Tests
 
             _logger.Received(1).Log(
                 DdLogLevel.Debug,
-                Arg.Is<string>(s => s.Contains("my-flag") && s.Contains("DISABLED")));
+                Arg.Is<string>(s => s.Contains("my-flag") && s.Contains("DEFAULT")));
         }
 
         [Test]
@@ -108,14 +108,28 @@ namespace Datadog.Unity.Flags.Tests
         }
 
         [Test]
-        public void StateChanged_NeverFires()
+        public void StateChanged_FiresImmediateReplay_WithNotReadyState()
         {
-            var fired = false;
-            _client.StateChanged += (_, _) => fired = true;
+            FlagsStateChange received = default;
+            _client.StateChanged += (_, change) => received = change;
+
+            Assert.AreEqual(FlagsClientState.NotReady, received.Old,
+                "Replay should fire synchronously with Old == NotReady");
+            Assert.AreEqual(FlagsClientState.NotReady, received.New,
+                "Replay should fire synchronously with New == NotReady (Old == New signals replay)");
+        }
+
+        [Test]
+        public void StateChanged_DoesNotFireOnContextChange()
+        {
+            var fireCount = 0;
+            _client.StateChanged += (_, _) => fireCount++;
+            // Reset counter after the subscription replay
+            fireCount = 0;
 
             _client.SetEvaluationContext(new FlagsEvaluationContext("user-1"));
 
-            Assert.IsFalse(fired);
+            Assert.AreEqual(0, fireCount, "No transitions should fire after initial subscription replay");
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NSubstitute;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class NoopFlagsClientTests
+    {
+        private NoopFlagsClient _client;
+        private IInternalLogger _logger;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _logger = Substitute.For<IInternalLogger>();
+            _client = new NoopFlagsClient("DISABLED", _logger);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _client.Dispose();
+        }
+
+        [Test]
+        public void State_IsAlwaysDisabled()
+        {
+            Assert.AreEqual(FlagsClientState.Disabled, _client.State);
+        }
+
+        [Test]
+        public void GetBooleanValue_ReturnsDefaultValue()
+        {
+            Assert.AreEqual(true, _client.GetBooleanValue("flag", true));
+            Assert.AreEqual(false, _client.GetBooleanValue("flag", false));
+        }
+
+        [Test]
+        public void GetStringValue_ReturnsDefaultValue()
+        {
+            Assert.AreEqual("default", _client.GetStringValue("flag", "default"));
+        }
+
+        [Test]
+        public void GetIntegerValue_ReturnsDefaultValue()
+        {
+            Assert.AreEqual(42, _client.GetIntegerValue("flag", 42));
+        }
+
+        [Test]
+        public void GetDoubleValue_ReturnsDefaultValue()
+        {
+            Assert.AreEqual(3.14, _client.GetDoubleValue("flag", 3.14));
+        }
+
+        [Test]
+        public void GetDetails_ReturnsDefaultValueWithConstructorReason_AndNoError()
+        {
+            var details = _client.GetBooleanDetails("flag", false);
+
+            Assert.AreEqual(false, details.Value);
+            Assert.AreEqual("DISABLED", details.Reason);
+            Assert.IsNull(details.Error);
+        }
+
+        [Test]
+        public void GetDetails_ReturnsConstructorReason_ForDifferentReasons()
+        {
+            var errorClient = new NoopFlagsClient("ERROR", _logger);
+            var details = errorClient.GetStringDetails("flag", "default");
+
+            Assert.AreEqual("ERROR", details.Reason);
+            Assert.IsNull(details.Error);
+            errorClient.Dispose();
+        }
+
+        [Test]
+        public void GetDetails_LogsDebugMessage_OnEachEvaluation()
+        {
+            _client.GetBooleanDetails("my-flag", false);
+
+            _logger.Received(1).Log(
+                DdLogLevel.Debug,
+                Arg.Is<string>(s => s.Contains("my-flag") && s.Contains("DISABLED")));
+        }
+
+        [Test]
+        public void SetEvaluationContext_InvokesCallbackWithFalse_Synchronously()
+        {
+            bool? result = null;
+            _client.SetEvaluationContext(new FlagsEvaluationContext("user-1"), success => result = success);
+
+            Assert.AreEqual(false, result, "onComplete should be called synchronously with false");
+        }
+
+        [Test]
+        public void SetEvaluationContext_NullCallback_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() =>
+                _client.SetEvaluationContext(new FlagsEvaluationContext("user-1")));
+        }
+
+        [Test]
+        public void StateChanged_NeverFires()
+        {
+            var fired = false;
+            _client.StateChanged += (_, _) => fired = true;
+
+            _client.SetEvaluationContext(new FlagsEvaluationContext("user-1"));
+
+            Assert.IsFalse(fired);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/NoopFlagsClientTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7e2d4a1f9b63508d2c5e87a4f1b9c32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
+++ b/samples/Datadog Sample/Assets/Scripts/FlagsBehavior.cs
@@ -46,7 +46,7 @@ public class FlagsBehavior : MonoBehaviour
             });
     }
 
-    private void EvaluateFlags(FlagsClient client)
+    private void EvaluateFlags(IFlagsClient client)
     {
         // Simple value accessors
         var showNewUI = client.GetBooleanValue("show-new-ui", false);


### PR DESCRIPTION
## Summary

Hardens \`DdFlags.Enable()\` against misconfiguration and makes \`FlagsClient\` and \`DdFlags\` robust against pre-configuration use.

### \`DdFlags\` singleton redesign

\`DdFlags.Instance\` is now a \`public static readonly\` singleton — always non-null. \`Enable()\` configures it; \`Shutdown()\` resets \`_isEnabled\`. A single lock (\`_enableLock\`) guards configuration with no outer fast-path check (removed — \`Enable()\` is main-thread-only and called once, so the double-check offered nothing).

**ENV / ClientToken validation in \`Enable()\`:**
- **Editor / debug builds**: throws \`InvalidOperationException\` immediately
- **Production builds**: logs \`DdLogLevel.Error\` and returns without configuring

\`CreateClient()\` returns a \`NoopFlagsClient("DEFAULT", logger)\` when not yet enabled.

\`ReportMisconfiguration()\` helper consolidates the editor/debug throw vs. production log branching.

### \`IFlagsClient\` interface + \`NoopFlagsClient\`

- \`IFlagsClient\` extracted — \`FlagsClient\` implements it; \`DdFlags.CreateClient()\` returns \`IFlagsClient\`
- \`NoopFlagsClient(reason, logger)\` always returns \`defaultValue\` with a \`"DEFAULT"\` reason and no error field; logs \`Debug\` on each evaluation; fires immediate \`NotReady → NotReady\` replay on \`StateChanged\` subscription (matching the \`IFlagsClient\` contract and Android SDK behavior)
- State is \`NotReady\` — consistent with the Android SDK; no custom \`Disabled\` state

### Shutdown / CreateClient race fix

\`Shutdown()\` only flips \`_isEnabled = false\` — it no longer nulls configuration fields. The volatile release/acquire semantics on \`_isEnabled\` make \`_configuration\` safely visible to any thread that observes \`_isEnabled == true\`.

### Fetcher diagnostics

\`PrecomputeAssignmentsFetcher\` now parses the JSON:API error response body (or flat \`{"error":"..."}\` for Fastly-level errors) and logs the extracted message at \`Warn\` level, rather than logging the raw body.

## Test plan

- [x] \`DdFlagsTests.Enable_ThrowsWhenEnvNotConfigured\` — throw fires in editor when \`Env\` is blank
- [x] \`NoopFlagsClientTests\` — all evaluation paths, Debug logging, reason strings, StateChanged replay
- [x] Android integration tests: 27/29 passing (pre-existing \`TrackedWebRequestScenario\` and \`TelemetryIntegrationScenario\` timing flakes, unrelated to this work)
- [x] Existing \`FlagsIntegrationTests\` pass — \`Env = "integration-test"\` is set by \`integration_test.py\` so the guard does not fire
- [x] All CI checks green