### PR TITLE
fix: Unconditionally set `vitalsUpdateFrequency` in generated iOS config

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Setting `VitalsUpdateFrequency` to `None` now properly takes effect in iOS builds.
+
 ## 1.7.0
 
 * Add Feature Flags SDK. Remotely control feature availability in your Unity app using `DdFlags.Enable()`, `IFlagsClient`, and typed flag accessors (`GetBooleanValue`, `GetStringValue`, `GetIntegerValue`, `GetDoubleValue`, `GetObjectValue`). Flags are fetched once per evaluation context and evaluated locally with no network calls at read time.

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -170,10 +170,7 @@ func initializeDatadog() {{
                     sb.AppendLine($@"    rumConfig.customEndpoint = URL(string: ""{options.CustomEndpoint}/api/v2/rum"")");
                 }
 
-                if (options.VitalsUpdateFrequency != VitalsUpdateFrequency.None)
-                {
-                    sb.AppendLine($"    rumConfig.vitalsUpdateFrequency = {GetSwiftVitalsUpdateFrequency(options.VitalsUpdateFrequency)}");
-                }
+                sb.AppendLine($"    rumConfig.vitalsUpdateFrequency = {GetSwiftVitalsUpdateFrequency(options.VitalsUpdateFrequency)}");
 
                 sb.AppendLine($"    rumConfig.sessionSampleRate = {options.SessionSampleRate}");
                 sb.AppendLine($"    rumConfig.telemetrySampleRate = {options.TelemetrySampleRate}");

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -228,7 +228,7 @@ namespace Datadog.Unity.Editor.iOS
         }
 
         [Test]
-        public void GenerateOptionsFileRemovesVitalsUpdateFrequencyWhenNone()
+        public void GenerateOptionsFileWritesNilForVitalsUpdateFrequencyNone()
         {
             var options = new DatadogConfigurationOptions()
             {
@@ -240,7 +240,8 @@ namespace Datadog.Unity.Editor.iOS
 
             var lines = File.ReadAllLines(_initializationFilePath);
             var uploadFrequencyLines = lines.Where(l => l.Contains("vitalsUpdateFrequency =")).ToArray();
-            Assert.AreEqual(0, uploadFrequencyLines.Length);
+            Assert.AreEqual(1, uploadFrequencyLines.Length);
+            Assert.AreEqual("rumConfig.vitalsUpdateFrequency = nil", uploadFrequencyLines.First().Trim());
         }
 
         [TestCase(VitalsUpdateFrequency.Rare, ".rare")]


### PR DESCRIPTION
This fixes a bug noted in GitHub issue 221: when generating the Swift file that configures the iOS SDK on init, we conditionally emit an assignment to `rumConfig.vitalsUpdateFrequency` only when the `VitalsUpdateFrequency` configured in Unity is not `None`.

The iOS SDK defaults to an update frequency of `.average`, so this conditional assignment is in fact a bug that prevents a Unity-configured update frequency of `None` from ever taking effect.

The fix is to set `rumConfig.vitalsUpdateFrequency` unconditionally. `GetSwiftVitalsUpdateFrequency()`, which renders the appropriate Swift literal, already emits `nil` as intended when update frequency is `None`.
