### PR TITLE
FFL-2510: Thread allocationKey into FlagDetails.Metadata

### DIFF
--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -20,8 +20,7 @@ namespace Datadog.Unity.Flags
             bool doLog,
             string allocationKey,
             string variationKey,
-            string reason,
-            JObject extraLogging = null)
+            string reason)
         {
             VariationType = variationType ?? string.Empty;
             VariationValue = variationValue;
@@ -29,7 +28,6 @@ namespace Datadog.Unity.Flags
             AllocationKey = allocationKey ?? string.Empty;
             VariationKey = variationKey ?? string.Empty;
             Reason = reason ?? string.Empty;
-            ExtraLogging = extraLogging ?? new JObject();
         }
 
         /// <summary>
@@ -61,11 +59,6 @@ namespace Datadog.Unity.Flags
         /// Gets the resolution reason (DEFAULT, TARGETING_MATCH, RULE_MATCH, etc.).
         /// </summary>
         public string Reason { get; }
-
-        /// <summary>
-        /// Gets the extra logging metadata for this flag.
-        /// </summary>
-        public JObject ExtraLogging { get; }
 
         /// <summary>
         /// Attempts to get the variation value as the specified type.

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -25,7 +25,7 @@ namespace Datadog.Unity.Flags
             VariationType = variationType ?? string.Empty;
             VariationValue = variationValue;
             DoLog = doLog;
-            AllocationKey = allocationKey ?? string.Empty;
+            AllocationKey = allocationKey;
             VariationKey = variationKey ?? string.Empty;
             Reason = reason ?? string.Empty;
         }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -20,7 +20,8 @@ namespace Datadog.Unity.Flags
             bool doLog,
             string allocationKey,
             string variationKey,
-            string reason)
+            string reason,
+            JObject extraLogging = null)
         {
             VariationType = variationType ?? string.Empty;
             VariationValue = variationValue;
@@ -28,6 +29,7 @@ namespace Datadog.Unity.Flags
             AllocationKey = allocationKey ?? string.Empty;
             VariationKey = variationKey ?? string.Empty;
             Reason = reason ?? string.Empty;
+            ExtraLogging = extraLogging ?? new JObject();
         }
 
         /// <summary>
@@ -59,6 +61,11 @@ namespace Datadog.Unity.Flags
         /// Gets the resolution reason (DEFAULT, TARGETING_MATCH, RULE_MATCH, etc.).
         /// </summary>
         public string Reason { get; }
+
+        /// <summary>
+        /// Gets the extra logging metadata for this flag.
+        /// </summary>
+        public JObject ExtraLogging { get; }
 
         /// <summary>
         /// Attempts to get the variation value as the specified type.

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -2,17 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-
 namespace Datadog.Unity.Flags
 {
-    internal static class EmptyMetadata
-    {
-        internal static readonly IReadOnlyDictionary<string, object> Instance =
-            new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
-    }
-
     /// <summary>
     /// Error codes for flag evaluation failures.
     /// </summary>
@@ -40,8 +31,7 @@ namespace Datadog.Unity.Flags
             string variant = null,
             string reason = null,
             FlagEvaluationError? error = null,
-            string allocationKey = null,
-            IReadOnlyDictionary<string, object> metadata = null)
+            string allocationKey = null)
         {
             Key = key;
             Value = value;
@@ -49,7 +39,6 @@ namespace Datadog.Unity.Flags
             Reason = reason;
             Error = error;
             AllocationKey = allocationKey ?? string.Empty;
-            Metadata = metadata ?? EmptyMetadata.Instance;
         }
 
         /// <summary>Gets the flag key.</summary>
@@ -69,8 +58,5 @@ namespace Datadog.Unity.Flags
 
         /// <summary>Gets the allocation key for this evaluation.</summary>
         public string AllocationKey { get; }
-
-        /// <summary>Gets the evaluation metadata including allocationKey.</summary>
-        public IReadOnlyDictionary<string, object> Metadata { get; }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -38,7 +38,7 @@ namespace Datadog.Unity.Flags
             Variant = variant;
             Reason = reason;
             Error = error;
-            AllocationKey = allocationKey ?? string.Empty;
+            AllocationKey = allocationKey;
         }
 
         /// <summary>Gets the flag key.</summary>

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -70,7 +70,7 @@ namespace Datadog.Unity.Flags
         /// <summary>Gets the allocation key for this evaluation.</summary>
         public string AllocationKey { get; }
 
-        /// <summary>Gets the evaluation metadata including allocationKey and extraLogging fields.</summary>
+        /// <summary>Gets the evaluation metadata including allocationKey.</summary>
         public IReadOnlyDictionary<string, object> Metadata { get; }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -2,6 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
 namespace Datadog.Unity.Flags
 {
     /// <summary>
@@ -25,13 +28,22 @@ namespace Datadog.Unity.Flags
     /// <typeparam name="T">The type of the flag value.</typeparam>
     public class FlagDetails<T>
     {
-        internal FlagDetails(string key, T value, string variant = null, string reason = null, FlagEvaluationError? error = null)
+        internal FlagDetails(
+            string key,
+            T value,
+            string variant = null,
+            string reason = null,
+            FlagEvaluationError? error = null,
+            string allocationKey = null,
+            IReadOnlyDictionary<string, object> metadata = null)
         {
             Key = key;
             Value = value;
             Variant = variant;
             Reason = reason;
             Error = error;
+            AllocationKey = allocationKey ?? string.Empty;
+            Metadata = metadata ?? new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
         }
 
         /// <summary>Gets the flag key.</summary>
@@ -48,5 +60,11 @@ namespace Datadog.Unity.Flags
 
         /// <summary>Gets the evaluation error (null if successful).</summary>
         public FlagEvaluationError? Error { get; }
+
+        /// <summary>Gets the allocation key for this evaluation.</summary>
+        public string AllocationKey { get; }
+
+        /// <summary>Gets the evaluation metadata including allocationKey and extraLogging fields.</summary>
+        public IReadOnlyDictionary<string, object> Metadata { get; }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagDetails.cs
@@ -7,6 +7,12 @@ using System.Collections.ObjectModel;
 
 namespace Datadog.Unity.Flags
 {
+    internal static class EmptyMetadata
+    {
+        internal static readonly IReadOnlyDictionary<string, object> Instance =
+            new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+    }
+
     /// <summary>
     /// Error codes for flag evaluation failures.
     /// </summary>
@@ -43,7 +49,7 @@ namespace Datadog.Unity.Flags
             Reason = reason;
             Error = error;
             AllocationKey = allocationKey ?? string.Empty;
-            Metadata = metadata ?? new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+            Metadata = metadata ?? EmptyMetadata.Instance;
         }
 
         /// <summary>Gets the flag key.</summary>

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -3,8 +3,6 @@
 // Copyright 2025-Present Datadog, Inc.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Datadog.Unity.Flags
 {
@@ -232,14 +230,12 @@ namespace Datadog.Unity.Flags
                 return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.TypeMismatch);
             }
 
-            var metadata = BuildMetadata(assignment);
             var details = new FlagDetails<T>(
                 key: key,
                 value: value,
                 variant: assignment.VariationKey,
                 reason: assignment.Reason,
-                allocationKey: assignment.AllocationKey,
-                metadata: metadata);
+                allocationKey: assignment.AllocationKey);
 
             TrackEvaluation(key, assignment, null);
             return details;
@@ -270,17 +266,6 @@ namespace Datadog.Unity.Flags
         {
             return GetDetails(key, defaultValue).Value;
         }
-
-        private static IReadOnlyDictionary<string, object> BuildMetadata(FlagAssignment assignment)
-        {
-            var dict = new Dictionary<string, object>();
-            if (!string.IsNullOrEmpty(assignment.AllocationKey))
-            {
-                dict["allocationKey"] = assignment.AllocationKey;
-            }
-            return new ReadOnlyDictionary<string, object>(dict);
-        }
-
         private void TrackEvaluation(string key, FlagAssignment assignment, string flagError)
         {
             var context = _repository.Context;

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -284,7 +284,7 @@ namespace Datadog.Unity.Flags
                     var exposureEvent = new ExposureEvent(
                         timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                         flag: new FlagRef(key),
-                        allocation: new FlagRef(assignment.AllocationKey),
+                        allocation: assignment.AllocationKey != null ? new FlagRef(assignment.AllocationKey) : null,
                         variant: new FlagRef(assignment.VariationKey),
                         subject: new ExposureSubject(
                             id: context?.TargetingKey ?? string.Empty,

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Newtonsoft.Json.Linq;
 
 namespace Datadog.Unity.Flags
 {
@@ -275,42 +274,10 @@ namespace Datadog.Unity.Flags
         private static IReadOnlyDictionary<string, object> BuildMetadata(FlagAssignment assignment)
         {
             var dict = new Dictionary<string, object>();
-
-            // Write extraLogging primitives first; skip any "allocationKey" key here
-            // because the typed AllocationKey field is written last and must win.
-            foreach (var prop in assignment.ExtraLogging.Properties())
-            {
-                if (prop.Name == "allocationKey") continue;
-                switch (prop.Value.Type)
-                {
-                    case JTokenType.String:
-                        dict[prop.Name] = prop.Value.Value<string>();
-                        break;
-                    case JTokenType.Boolean:
-                        dict[prop.Name] = prop.Value.Value<bool>();
-                        break;
-                    case JTokenType.Integer:
-                        // Convert.ToInt64 can throw OverflowException for BigInteger values that
-                        // exceed Int64 range. Fall back to the string representation so the value
-                        // is preserved in metadata rather than dropped entirely.
-                        try { dict[prop.Name] = Convert.ToInt64(prop.Value); }
-                        catch { dict[prop.Name] = prop.Value.ToString(); }
-                        break;
-                    case JTokenType.Float:
-                        // Convert.ToDouble can throw for decimal values outside double range.
-                        // Fall back to string so the value is preserved rather than dropped.
-                        try { dict[prop.Name] = Convert.ToDouble(prop.Value); }
-                        catch { dict[prop.Name] = prop.Value.ToString(); }
-                        break;
-                }
-            }
-
-            // allocationKey written last so it always wins over any extraLogging value
             if (!string.IsNullOrEmpty(assignment.AllocationKey))
             {
                 dict["allocationKey"] = assignment.AllocationKey;
             }
-
             return new ReadOnlyDictionary<string, object>(dict);
         }
 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -290,10 +290,17 @@ namespace Datadog.Unity.Flags
                         dict[prop.Name] = prop.Value.Value<bool>();
                         break;
                     case JTokenType.Integer:
-                        dict[prop.Name] = prop.Value.Value<long>();
+                        // Convert.ToInt64 can throw OverflowException for BigInteger values that
+                        // exceed Int64 range. Fall back to the string representation so the value
+                        // is preserved in metadata rather than dropped entirely.
+                        try { dict[prop.Name] = Convert.ToInt64(prop.Value); }
+                        catch { dict[prop.Name] = prop.Value.ToString(); }
                         break;
                     case JTokenType.Float:
-                        dict[prop.Name] = prop.Value.Value<double>();
+                        // Convert.ToDouble can throw for decimal values outside double range.
+                        // Fall back to string so the value is preserved rather than dropped.
+                        try { dict[prop.Name] = Convert.ToDouble(prop.Value); }
+                        catch { dict[prop.Name] = prop.Value.ToString(); }
                         break;
                 }
             }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Newtonsoft.Json.Linq;
 
 namespace Datadog.Unity.Flags
 {
@@ -231,11 +233,14 @@ namespace Datadog.Unity.Flags
                 return new FlagDetails<T>(key, defaultValue, error: FlagEvaluationError.TypeMismatch);
             }
 
+            var metadata = BuildMetadata(assignment);
             var details = new FlagDetails<T>(
                 key: key,
                 value: value,
                 variant: assignment.VariationKey,
-                reason: assignment.Reason);
+                reason: assignment.Reason,
+                allocationKey: assignment.AllocationKey,
+                metadata: metadata);
 
             TrackEvaluation(key, assignment, null);
             return details;
@@ -265,6 +270,41 @@ namespace Datadog.Unity.Flags
         private T GetValue<T>(string key, T defaultValue)
         {
             return GetDetails(key, defaultValue).Value;
+        }
+
+        private static IReadOnlyDictionary<string, object> BuildMetadata(FlagAssignment assignment)
+        {
+            var dict = new Dictionary<string, object>();
+
+            // Write extraLogging primitives first; skip any "allocationKey" key here
+            // because the typed AllocationKey field is written last and must win.
+            foreach (var prop in assignment.ExtraLogging.Properties())
+            {
+                if (prop.Name == "allocationKey") continue;
+                switch (prop.Value.Type)
+                {
+                    case JTokenType.String:
+                        dict[prop.Name] = prop.Value.Value<string>();
+                        break;
+                    case JTokenType.Boolean:
+                        dict[prop.Name] = prop.Value.Value<bool>();
+                        break;
+                    case JTokenType.Integer:
+                        dict[prop.Name] = prop.Value.Value<long>();
+                        break;
+                    case JTokenType.Float:
+                        dict[prop.Name] = prop.Value.Value<double>();
+                        break;
+                }
+            }
+
+            // allocationKey written last so it always wins over any extraLogging value
+            if (!string.IsNullOrEmpty(assignment.AllocationKey))
+            {
+                dict["allocationKey"] = assignment.AllocationKey;
+            }
+
+            return new ReadOnlyDictionary<string, object>(dict);
         }
 
         private void TrackEvaluation(string key, FlagAssignment assignment, string flagError)

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -201,8 +201,7 @@ namespace Datadog.Unity.Flags
                     doLog: dto.DoLog,
                     allocationKey: dto.AllocationKey,
                     variationKey: dto.VariationKey,
-                    reason: dto.Reason,
-                    extraLogging: dto.ExtraLogging);
+                    reason: dto.Reason);
             }
 
             return flags;
@@ -288,8 +287,6 @@ namespace Datadog.Unity.Flags
             [JsonProperty("reason")]
             public string Reason { get; set; }
 
-            [JsonProperty("extraLogging")]
-            public JObject ExtraLogging { get; set; }
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -201,7 +201,8 @@ namespace Datadog.Unity.Flags
                     doLog: dto.DoLog,
                     allocationKey: dto.AllocationKey,
                     variationKey: dto.VariationKey,
-                    reason: dto.Reason);
+                    reason: dto.Reason,
+                    extraLogging: dto.ExtraLogging);
             }
 
             return flags;
@@ -286,6 +287,9 @@ namespace Datadog.Unity.Flags
 
             [JsonProperty("reason")]
             public string Reason { get; set; }
+
+            [JsonProperty("extraLogging")]
+            public JObject ExtraLogging { get; set; }
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -3,6 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Datadog.Unity.Flags.Tests
@@ -15,6 +16,22 @@ namespace Datadog.Unity.Flags.Tests
         public void SetUp()
         {
             _repository = new FlagsRepository();
+        }
+
+        // Helper: build a minimal FlagsClient backed by an in-memory repository.
+        // trackExposures and trackEvaluations are false so null trackers are safe.
+        private FlagsClient MakeClient(FlagsRepository repo)
+        {
+            return new FlagsClient(
+                repository: repo,
+                exposureTracker: null,
+                evaluationAggregator: null,
+                fetcher: null,
+                logger: null,
+                trackExposures: false,
+                trackEvaluations: false,
+                onExposure: null,
+                initialState: FlagsClientState.Ready);
         }
 
         [Test]
@@ -131,6 +148,106 @@ namespace Datadog.Unity.Flags.Tests
             _repository.SetFlagsAndContext(new FlagsEvaluationContext("u1"), flags2);
             Assert.IsNull(_repository.GetFlagAssignment("flag-a"));
             Assert.IsNotNull(_repository.GetFlagAssignment("flag-b"));
+        }
+
+        // ─── GetDetails: AllocationKey threading ─────────────────────────────────────
+
+        [Test]
+        public void GetDetails_ReturnsAllocationKey()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["my-flag"] = new FlagAssignment("boolean", true, false, "alloc-xyz", "treatment", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var client = MakeClient(_repository);
+            var details = client.GetDetails("my-flag", false);
+
+            Assert.AreEqual("alloc-xyz", details.AllocationKey);
+        }
+
+        [Test]
+        public void GetDetails_MetadataContainsAllocationKey()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["my-flag"] = new FlagAssignment("boolean", true, false, "alloc-abc", "treatment", "TARGETING_MATCH"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var client = MakeClient(_repository);
+            var details = client.GetDetails("my-flag", false);
+
+            Assert.IsTrue(details.Metadata.ContainsKey("allocationKey"),
+                "Metadata must contain 'allocationKey'");
+            Assert.AreEqual("alloc-abc", details.Metadata["allocationKey"]);
+        }
+
+        [Test]
+        public void GetDetails_MetadataContainsExtraLoggingPrimitives()
+        {
+            var extraLogging = new JObject
+            {
+                ["experiment"] = "exp-42",
+                ["score"] = 99L,
+                ["active"] = true,
+                ["ratio"] = 0.75,
+            };
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["my-flag"] = new FlagAssignment(
+                    "boolean", true, false, "alloc-1", "treatment", "TARGETING_MATCH",
+                    extraLogging: extraLogging),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var client = MakeClient(_repository);
+            var details = client.GetDetails("my-flag", false);
+
+            Assert.AreEqual("exp-42", details.Metadata["experiment"]);
+            Assert.AreEqual(99L, details.Metadata["score"]);
+            Assert.AreEqual(true, details.Metadata["active"]);
+            Assert.AreEqual(0.75, details.Metadata["ratio"]);
+        }
+
+        [Test]
+        public void GetDetails_MetadataAllocationKeyWinsOverExtraLoggingAllocationKey()
+        {
+            // If extraLogging contains an "allocationKey" key, the typed AllocationKey
+            // from the assignment must win (written last, so it overwrites).
+            var extraLogging = new JObject
+            {
+                ["allocationKey"] = "should-be-overwritten",
+            };
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["my-flag"] = new FlagAssignment(
+                    "boolean", true, false, "real-alloc", "treatment", "TARGETING_MATCH",
+                    extraLogging: extraLogging),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var client = MakeClient(_repository);
+            var details = client.GetDetails("my-flag", false);
+
+            Assert.AreEqual("real-alloc", details.Metadata["allocationKey"]);
+        }
+
+        [Test]
+        public void GetDetails_EmptyAllocationKey_MetadataOmitsAllocationKeyEntry()
+        {
+            var flags = new Dictionary<string, FlagAssignment>
+            {
+                ["my-flag"] = new FlagAssignment("boolean", true, false, "", "treatment", "DEFAULT"),
+            };
+            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
+
+            var client = MakeClient(_repository);
+            var details = client.GetDetails("my-flag", false);
+
+            Assert.IsFalse(details.Metadata.ContainsKey("allocationKey"),
+                "allocationKey must not appear in Metadata when the assignment has no allocation key");
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -3,7 +3,6 @@
 // Copyright 2025-Present Datadog, Inc.
 
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Datadog.Unity.Flags.Tests
@@ -182,56 +181,6 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsTrue(details.Metadata.ContainsKey("allocationKey"),
                 "Metadata must contain 'allocationKey'");
             Assert.AreEqual("alloc-abc", details.Metadata["allocationKey"]);
-        }
-
-        [Test]
-        public void GetDetails_MetadataContainsExtraLoggingPrimitives()
-        {
-            var extraLogging = new JObject
-            {
-                ["experiment"] = "exp-42",
-                ["score"] = 99L,
-                ["active"] = true,
-                ["ratio"] = 0.75,
-            };
-            var flags = new Dictionary<string, FlagAssignment>
-            {
-                ["my-flag"] = new FlagAssignment(
-                    "boolean", true, false, "alloc-1", "treatment", "TARGETING_MATCH",
-                    extraLogging: extraLogging),
-            };
-            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
-
-            var client = MakeClient(_repository);
-            var details = client.GetDetails("my-flag", false);
-
-            Assert.AreEqual("exp-42", details.Metadata["experiment"]);
-            Assert.AreEqual(99L, details.Metadata["score"]);
-            Assert.AreEqual(true, details.Metadata["active"]);
-            Assert.AreEqual(0.75, details.Metadata["ratio"]);
-        }
-
-        [Test]
-        public void GetDetails_MetadataAllocationKeyWinsOverExtraLoggingAllocationKey()
-        {
-            // If extraLogging contains an "allocationKey" key, the typed AllocationKey
-            // from the assignment must win (written last, so it overwrites).
-            var extraLogging = new JObject
-            {
-                ["allocationKey"] = "should-be-overwritten",
-            };
-            var flags = new Dictionary<string, FlagAssignment>
-            {
-                ["my-flag"] = new FlagAssignment(
-                    "boolean", true, false, "real-alloc", "treatment", "TARGETING_MATCH",
-                    extraLogging: extraLogging),
-            };
-            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
-
-            var client = MakeClient(_repository);
-            var details = client.GetDetails("my-flag", false);
-
-            Assert.AreEqual("real-alloc", details.Metadata["allocationKey"]);
         }
 
         [Test]

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -167,19 +167,19 @@ namespace Datadog.Unity.Flags.Tests
         }
 
         [Test]
-        public void GetDetails_EmptyAllocationKey_ReturnsEmptyString()
+        public void GetDetails_NullAllocationKey_ReturnsNull()
         {
             var flags = new Dictionary<string, FlagAssignment>
             {
-                ["my-flag"] = new FlagAssignment("boolean", true, false, "", "treatment", "DEFAULT"),
+                ["my-flag"] = new FlagAssignment("boolean", true, false, null, "treatment", "DEFAULT"),
             };
             _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
 
             var client = MakeClient(_repository);
             var details = client.GetDetails("my-flag", false);
 
-            Assert.AreEqual(string.Empty, details.AllocationKey,
-                "AllocationKey must be empty string when the assignment has no allocation key");
+            Assert.IsNull(details.AllocationKey,
+                "AllocationKey must be null when the assignment has no allocation key");
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagEvaluationTests.cs
@@ -167,24 +167,7 @@ namespace Datadog.Unity.Flags.Tests
         }
 
         [Test]
-        public void GetDetails_MetadataContainsAllocationKey()
-        {
-            var flags = new Dictionary<string, FlagAssignment>
-            {
-                ["my-flag"] = new FlagAssignment("boolean", true, false, "alloc-abc", "treatment", "TARGETING_MATCH"),
-            };
-            _repository.SetFlagsAndContext(new FlagsEvaluationContext("user-1"), flags);
-
-            var client = MakeClient(_repository);
-            var details = client.GetDetails("my-flag", false);
-
-            Assert.IsTrue(details.Metadata.ContainsKey("allocationKey"),
-                "Metadata must contain 'allocationKey'");
-            Assert.AreEqual("alloc-abc", details.Metadata["allocationKey"]);
-        }
-
-        [Test]
-        public void GetDetails_EmptyAllocationKey_MetadataOmitsAllocationKeyEntry()
+        public void GetDetails_EmptyAllocationKey_ReturnsEmptyString()
         {
             var flags = new Dictionary<string, FlagAssignment>
             {
@@ -195,8 +178,8 @@ namespace Datadog.Unity.Flags.Tests
             var client = MakeClient(_repository);
             var details = client.GetDetails("my-flag", false);
 
-            Assert.IsFalse(details.Metadata.ContainsKey("allocationKey"),
-                "allocationKey must not appear in Metadata when the assignment has no allocation key");
+            Assert.AreEqual(string.Empty, details.AllocationKey,
+                "AllocationKey must be empty string when the assignment has no allocation key");
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Datadog.Unity.Flags.Tests

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -124,5 +124,66 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsNotNull(flags);
             Assert.AreEqual(0, flags.Count);
         }
+
+        [Test]
+        public void ParsesExtraLoggingField()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""my-flag"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-1"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH"",
+                                ""extraLogging"": {
+                                    ""experiment"": ""exp-99"",
+                                    ""score"": 42
+                                }
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.IsTrue(flags.ContainsKey("my-flag"));
+            var flag = flags["my-flag"];
+            Assert.IsNotNull(flag.ExtraLogging);
+            Assert.AreEqual("exp-99", flag.ExtraLogging["experiment"]?.Value<string>());
+            Assert.AreEqual(42, flag.ExtraLogging["score"]?.Value<int>());
+        }
+
+        [Test]
+        public void ParsesMissingExtraLoggingAsEmptyObject()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""my-flag"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-1"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.IsTrue(flags.ContainsKey("my-flag"));
+            var flag = flags["my-flag"];
+            Assert.IsNotNull(flag.ExtraLogging, "ExtraLogging must be non-null when absent from response");
+            Assert.AreEqual(0, flag.ExtraLogging.Count, "ExtraLogging must be empty when absent from response");
+        }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -2,7 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Datadog.Unity.Flags.Tests
@@ -123,67 +122,6 @@ namespace Datadog.Unity.Flags.Tests
             var flags = PrecomputeAssignmentsFetcher.ParseResponse(null);
             Assert.IsNotNull(flags);
             Assert.AreEqual(0, flags.Count);
-        }
-
-        [Test]
-        public void ParsesExtraLoggingField()
-        {
-            var json = @"{
-                ""data"": {
-                    ""attributes"": {
-                        ""flags"": {
-                            ""my-flag"": {
-                                ""variationType"": ""boolean"",
-                                ""variationValue"": true,
-                                ""doLog"": true,
-                                ""allocationKey"": ""alloc-1"",
-                                ""variationKey"": ""treatment"",
-                                ""reason"": ""TARGETING_MATCH"",
-                                ""extraLogging"": {
-                                    ""experiment"": ""exp-99"",
-                                    ""score"": 42
-                                }
-                            }
-                        }
-                    }
-                }
-            }";
-
-            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
-
-            Assert.IsTrue(flags.ContainsKey("my-flag"));
-            var flag = flags["my-flag"];
-            Assert.IsNotNull(flag.ExtraLogging);
-            Assert.AreEqual("exp-99", flag.ExtraLogging["experiment"]?.Value<string>());
-            Assert.AreEqual(42, flag.ExtraLogging["score"]?.Value<int>());
-        }
-
-        [Test]
-        public void ParsesMissingExtraLoggingAsEmptyObject()
-        {
-            var json = @"{
-                ""data"": {
-                    ""attributes"": {
-                        ""flags"": {
-                            ""my-flag"": {
-                                ""variationType"": ""boolean"",
-                                ""variationValue"": true,
-                                ""doLog"": true,
-                                ""allocationKey"": ""alloc-1"",
-                                ""variationKey"": ""treatment"",
-                                ""reason"": ""TARGETING_MATCH""
-                            }
-                        }
-                    }
-                }
-            }";
-
-            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
-
-            Assert.IsTrue(flags.ContainsKey("my-flag"));
-            var flag = flags["my-flag"];
-            Assert.IsNotNull(flag.ExtraLogging, "ExtraLogging must be non-null when absent from response");
-            Assert.AreEqual(0, flag.ExtraLogging.Count, "ExtraLogging must be empty when absent from response");
         }
     }
 }


### PR DESCRIPTION
## What

FFL-2510 — threads \`allocationKey\` from the Precomputed Flags API response into \`FlagDetails.Metadata\`, consistent with Android (dd-sdk-android#3534) and iOS (dd-sdk-ios#2989).

## Threading flow

\`FlagAssignment.AllocationKey\` → \`FlagsClient.BuildMetadata\` → \`FlagDetails.Metadata\` (IReadOnlyDictionary). Key \`"allocationKey"\` is written only when the assignment has a non-empty \`AllocationKey\`.

## Files changed

- **\`FlagDetails<T>.cs\`**: Added \`AllocationKey: string\` and \`Metadata: IReadOnlyDictionary<string, object>\` properties; uses a static empty instance for error paths to avoid per-call allocations
- **\`FlagsClient.cs\`**: \`GetDetails<T>\` calls \`BuildMetadata(assignment)\` which writes \`allocationKey\` when non-empty; removed \`ExtraLogging\` handling
- **OpenFeature provider** (\`DatadogFeatureProvider.cs\`): \`ToFlagMetadata()\` maps \`FlagDetails.Metadata\` → \`ImmutableMetadata\` for \`ResolutionDetails.FlagMetadata\`