### PR TITLE
feat(wip): Support Standalone desktop builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ unit-test*
 integration-test*
 .claire/
 .claude/
+
+# Desktop native libraries (built locally)
+packages/Datadog.Unity/Plugins/Desktop/**/*.dylib
+packages/Datadog.Unity/Plugins/Desktop/**/*.dll
+packages/Datadog.Unity/Plugins/Desktop/**/*.so
+build/desktop/
+.plans/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/dd-sdk-cpp"]
+	path = modules/dd-sdk-cpp
+	url = https://github.com/DataDog/dd-sdk-cpp

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.21)
+project(DatadogNative)
+
+set(DD_BUILD_SHARED ON CACHE BOOL "" FORCE)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/../modules/dd-sdk-cpp dd-sdk-cpp)

--- a/packages/Datadog.Unity/Plugins/Desktop.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9e25b9de61fc40b8b5d295fd9e232aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Plugins/Desktop/Linux.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop/Linux.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb4fa1a8412074b1ba99ad83c080d8aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Plugins/Desktop/Windows.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop/Windows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5906c05955e064b6fa897316126d2f3d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Plugins/Desktop/macOS.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop/macOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d4b0c54bb7f84d01a4083792c10bc86
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Plugins/Desktop/macOS/dd_native.dylib.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop/macOS/dd_native.dylib.meta
@@ -7,23 +7,19 @@ PluginImporter:
   executionOrder: {}
   defineConstraints: []
   isPreloaded: 0
-  isOverridable: 0
+  isOverridable: 1
   isExplicitlyReferenced: 0
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      Any: 
     second:
       enabled: 0
-      settings:
-        Exclude Editor: 1
-        Exclude Linux64: 1
-        Exclude OSXUniversal: 0
-        Exclude Win64: 1
+      settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:
@@ -32,6 +28,6 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: AnyCPU
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Plugins/Desktop/macOS/dd_native.dylib.meta
+++ b/packages/Datadog.Unity/Plugins/Desktop/macOS/dd_native.dylib.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win64: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/AssemblyInfo.cs
+++ b/packages/Datadog.Unity/Runtime/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("com.datadoghq.unity.android")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.ios")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.webgl")]
+[assembly: InternalsVisibleTo("com.datadoghq.unity.desktop")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.Editor")]
 [assembly: InternalsVisibleTo("com.datadoghq.unity.flags")]
 

--- a/packages/Datadog.Unity/Runtime/Desktop.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a57e07bd16caf4aaba0fb6223f4b7e36
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopInitialization.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopInitialization.cs
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using UnityEngine;
+using UnityEngine.Scripting;
+
+[assembly: UnityEngine.Scripting.Preserve]
+[assembly: UnityEngine.Scripting.AlwaysLinkAssembly]
+
+namespace Datadog.Unity.Desktop
+{
+    [Preserve]
+    public static class DatadogInitialization
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        public static void InitializeDatadog()
+        {
+            var options = DatadogConfigurationOptions.Load();
+            if (options.Enabled)
+            {
+                var platform = new DatadogDesktopPlatform();
+                platform.Init(options);
+                DatadogSdk.InitWithPlatform(platform, options);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopInitialization.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopInitialization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dd242a4a4bd248c6a8b016537a06b1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs
@@ -16,8 +16,9 @@ namespace Datadog.Unity.Desktop
     [StructLayout(LayoutKind.Sequential)]
     internal struct DdLogError
     {
-        public IntPtr kind;  // error.kind
-        public IntPtr stack; // error.stack
+        public IntPtr message; // error.message
+        public IntPtr kind;    // error.kind
+        public IntPtr stack;   // error.stack
     }
 
     internal class DatadogDesktopLogger : DdLogger
@@ -76,15 +77,17 @@ namespace Datadog.Unity.Desktop
             {
                 if (error != null)
                 {
-                    var kindPtr = DatadogDesktopPlatform.AllocUtf8(error.Type);
-                    var stackPtr = DatadogDesktopPlatform.AllocUtf8(error.StackTrace);
-                    var logError = new DdLogError { kind = kindPtr, stack = stackPtr };
+                    var messagePtr = DatadogDesktopPlatform.AllocUtf8(error.Message);
+                    var kindPtr    = DatadogDesktopPlatform.AllocUtf8(error.Type);
+                    var stackPtr   = DatadogDesktopPlatform.AllocUtf8(error.StackTrace);
+                    var logError = new DdLogError { message = messagePtr, kind = kindPtr, stack = stackPtr };
                     try
                     {
                         dd_logger_log(_logger, (int)level, message, ref logError, ref attrs);
                     }
                     finally
                     {
+                        Marshal.FreeHGlobal(messagePtr);
                         Marshal.FreeHGlobal(kindPtr);
                         Marshal.FreeHGlobal(stackPtr);
                     }

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Datadog.Unity;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity.Desktop
+{
+    // Mirrors dd_log_error_t from dd-sdk-cpp include-c/datadog/logging.h.
+    // Both fields are raw const char* pointers — callers must keep them valid for the duration of the P/Invoke call.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DdLogError
+    {
+        public IntPtr kind;  // error.kind
+        public IntPtr stack; // error.stack
+    }
+
+    internal class DatadogDesktopLogger : DdLogger
+    {
+        private readonly IntPtr _logger;
+        private readonly IInternalLogger _internalLogger;
+
+        private DatadogDesktopLogger(IntPtr logger, DdLogLevel logLevel, float sampleRate, IInternalLogger internalLogger)
+            : base(logLevel, sampleRate)
+        {
+            _logger = logger;
+            _internalLogger = internalLogger;
+        }
+
+        internal static DatadogDesktopLogger Create(IntPtr logging, DatadogLoggingOptions options, IInternalLogger internalLogger)
+        {
+            // dd_logger_config_t uses fixed char[] buffers for name/service, so setters copy strings
+            // and there is no string-lifetime issue between separate P/Invoke calls.
+            var configPtr = Marshal.AllocHGlobal(512);
+            IntPtr loggerPtr;
+            try
+            {
+                dd_logger_config_init(configPtr);
+                if (!string.IsNullOrEmpty(options.Name))
+                {
+                    dd_logger_config_set_name(configPtr, options.Name);
+                }
+                if (!string.IsNullOrEmpty(options.Service))
+                {
+                    dd_logger_config_set_service(configPtr, options.Service);
+                }
+                dd_logger_config_set_remote_sample_rate(configPtr, options.RemoteSampleRate);
+                dd_logger_config_set_remote_log_threshold(configPtr, (int)options.RemoteLogThreshold);
+                dd_logger_config_set_enrich_with_rum_context(configPtr, options.BundleWithRumEnabled);
+
+                loggerPtr = dd_logger_create(logging, configPtr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(configPtr);
+            }
+
+            if (loggerPtr == IntPtr.Zero) return null;
+            return new DatadogDesktopLogger(loggerPtr, options.RemoteLogThreshold, options.RemoteSampleRate, internalLogger);
+        }
+
+        internal override void PlatformLog(DdLogLevel level, string message, Dictionary<string, object> attributes = null, ErrorInfo error = null)
+        {
+            if (_logger == IntPtr.Zero) return;
+
+            var attrs = (attributes != null && attributes.Count > 0)
+                ? DdAttributes.BuildAttributeObject(attributes, _internalLogger)
+                : DdAttributes.dd_attribute_null();
+
+            try
+            {
+                if (error != null)
+                {
+                    var kindPtr = DatadogDesktopPlatform.AllocUtf8(error.Type);
+                    var stackPtr = DatadogDesktopPlatform.AllocUtf8(error.StackTrace);
+                    var logError = new DdLogError { kind = kindPtr, stack = stackPtr };
+                    try
+                    {
+                        dd_logger_log(_logger, (int)level, message, ref logError, ref attrs);
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal(kindPtr);
+                        Marshal.FreeHGlobal(stackPtr);
+                    }
+                }
+                else
+                {
+                    dd_logger_log_no_err(_logger, (int)level, message, IntPtr.Zero, ref attrs);
+                }
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public override void AddTag(string tag, string value = null)
+        {
+            if (_logger == IntPtr.Zero) return;
+            if (value != null)
+                dd_logger_add_tag_kv(_logger, tag, value);
+            else
+                dd_logger_add_tag(_logger, tag);
+        }
+
+        public override void RemoveTag(string tag)
+        {
+            if (_logger == IntPtr.Zero) return;
+            dd_logger_remove_tag(_logger, tag);
+        }
+
+        public override void RemoveTagsWithKey(string key)
+        {
+            if (_logger == IntPtr.Zero) return;
+            dd_logger_remove_tags_with_key(_logger, key);
+        }
+
+        public override void AddAttribute(string key, object value)
+        {
+            if (_logger == IntPtr.Zero) return;
+            var attr = DdAttributes.MakeAttribute(value, _internalLogger);
+            try { dd_logger_add_attribute(_logger, key, ref attr); }
+            finally { DdAttributes.dd_attribute_free(ref attr); }
+        }
+
+        public override void RemoveAttribute(string key)
+        {
+            if (_logger == IntPtr.Zero) return;
+            dd_logger_remove_attribute(_logger, key);
+        }
+
+        // === P/Invoke: Logger config ===
+
+        [DllImport("dd_native")] private static extern void dd_logger_config_init(IntPtr config);
+        [DllImport("dd_native")] private static extern void dd_logger_config_set_name(IntPtr config, [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+        [DllImport("dd_native")] private static extern void dd_logger_config_set_service(IntPtr config, [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+        [DllImport("dd_native")] private static extern void dd_logger_config_set_remote_sample_rate(IntPtr config, float value);
+        [DllImport("dd_native")] private static extern void dd_logger_config_set_remote_log_threshold(IntPtr config, int value);
+        [DllImport("dd_native")] private static extern void dd_logger_config_set_enrich_with_rum_context(IntPtr config, [MarshalAs(UnmanagedType.I1)] bool value);
+
+        // === P/Invoke: Logger ===
+
+        [DllImport("dd_native")] private static extern IntPtr dd_logger_create(IntPtr logging, IntPtr config);
+        [DllImport("dd_native")] private static extern void dd_logger_log(IntPtr logger, int level, [MarshalAs(UnmanagedType.LPUTF8Str)] string message, ref DdLogError err, ref DdAttribute attributes);
+        [DllImport("dd_native", EntryPoint = "dd_logger_log")] private static extern void dd_logger_log_no_err(IntPtr logger, int level, [MarshalAs(UnmanagedType.LPUTF8Str)] string message, IntPtr err, ref DdAttribute attributes);
+        [DllImport("dd_native")] private static extern void dd_logger_add_tag(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string tag);
+        [DllImport("dd_native")] private static extern void dd_logger_add_tag_kv(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string key, [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+        [DllImport("dd_native")] private static extern void dd_logger_remove_tag(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string tag);
+        [DllImport("dd_native")] private static extern void dd_logger_remove_tags_with_key(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string key);
+        [DllImport("dd_native")] private static extern void dd_logger_add_attribute(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute value);
+        [DllImport("dd_native")] private static extern void dd_logger_remove_attribute(IntPtr logger, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 860c6d7c033e74d2e928c6dc7c7682f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
@@ -1,0 +1,422 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+using Datadog.Unity.Rum;
+using Datadog.Unity.Worker;
+using UnityEngine;
+
+namespace Datadog.Unity.Desktop
+{
+    // Mirrors dd_diagnostic_message_t from dd-sdk-cpp include-c/datadog/core.h.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DdDiagnosticMessage
+    {
+        public int Level;
+        public IntPtr Text;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void DdDiagnosticHandler(ref DdDiagnosticMessage message, IntPtr userdata);
+
+    internal class DatadogDesktopPlatform : IDatadogPlatform
+    {
+        // Held statically to prevent GC collection while native code holds the function pointer.
+        private static readonly DdDiagnosticHandler _diagnosticHandler = OnDiagnosticMessage;
+
+        private IntPtr _core;
+        private IntPtr _logging;
+        private IntPtr _rum;
+        private IInternalLogger _logger = new PassThroughInternalLogger();
+
+        public void Init(DatadogConfigurationOptions options)
+        {
+            _core = CreateCore(options);
+            if (_core == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _logging = dd_logging_init(_core);
+
+            if (options.RumEnabled && !string.IsNullOrEmpty(options.RumApplicationId))
+            {
+                _rum = CreateRumFeature(_core, options);
+            }
+
+            if (!dd_core_start(_core))
+            {
+                Debug.Log("Failed to initialize Datadog Desktop Platform");
+            }
+        }
+
+        public DatadogWorker CreateWorker(IInternalLogger logger)
+        {
+            _logger = logger;
+            return new ThreadedWorker(logger);
+        }
+
+        public void SetVerbosity(CoreLoggerLevel logLevel)
+        {
+            // dd-sdk-cpp diagnostic threshold is a config-time setting; runtime changes are not supported.
+        }
+
+        public void SetTrackingConsent(TrackingConsent trackingConsent)
+        {
+            if (_core == IntPtr.Zero)
+            {
+                return;
+            }
+
+            dd_core_set_tracking_consent(_core, (int)trackingConsent);
+        }
+
+        public void SetUserInfo(string id, string name, string email, Dictionary<string, object> extraInfo)
+        {
+            if (_core == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (extraInfo != null && extraInfo.Count > 0)
+            {
+                var attrs = DdAttributes.BuildAttributeObject(extraInfo, _logger);
+                try
+                {
+                    dd_core_set_user_info(_core, id, name, email, ref attrs);
+                }
+                finally
+                {
+                    DdAttributes.dd_attribute_free(ref attrs);
+                }
+            }
+            else
+            {
+                var nullAttr = DdAttributes.dd_attribute_null();
+                dd_core_set_user_info(_core, id, name, email, ref nullAttr);
+            }
+        }
+
+        public void AddUserExtraInfo(Dictionary<string, object> extraInfo)
+        {
+            if (_core == IntPtr.Zero || extraInfo == null || extraInfo.Count == 0)
+            {
+                return;
+            }
+
+            var attrs = DdAttributes.BuildAttributeObject(extraInfo, _logger);
+            try
+            {
+                dd_core_add_user_extra_info(_core, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public DdLogger CreateLogger(DatadogLoggingOptions options, DatadogWorker worker)
+        {
+            if (_logging == IntPtr.Zero)
+            {
+                return new DdNoOpLogger();
+            }
+
+            var innerLogger = DatadogDesktopLogger.Create(_logging, options, _logger);
+            if (innerLogger == null)
+            {
+                return new DdNoOpLogger();
+            }
+
+            return new DdWorkerProxyLogger(worker, innerLogger);
+        }
+
+        public void AddLogsAttributes(Dictionary<string, object> attributes)
+        {
+            if (_logging == IntPtr.Zero || attributes == null)
+            {
+                return;
+            }
+
+            foreach (var kv in attributes)
+            {
+                var attr = DdAttributes.MakeAttribute(kv.Value, _logger);
+                try
+                {
+                    dd_logging_add_attribute(_logging, kv.Key, ref attr);
+                }
+                finally
+                {
+                    DdAttributes.dd_attribute_free(ref attr);
+                }
+            }
+        }
+
+        public void RemoveLogsAttribute(string key)
+        {
+            if (_logging == IntPtr.Zero || key == null) return;
+            dd_logging_remove_attribute(_logging, key);
+        }
+
+        public IDdRumInternal InitRum(DatadogConfigurationOptions options)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return new DdNoOpRum();
+            }
+
+            return new DatadogDesktopRum(_rum, _logger);
+        }
+
+        public void SendDebugTelemetry(string message)
+        {
+            // Not supported by dd-sdk-cpp C API.
+        }
+
+        public void SendErrorTelemetry(string message, string stack, string kind)
+        {
+            // Not supported by dd-sdk-cpp C API.
+        }
+
+        public void ClearAllData()
+        {
+            // Not supported by dd-sdk-cpp C API.
+        }
+
+        public string GetNativeStack(Exception error)
+        {
+            // Desktop platforms have managed stack traces; no native mapping needed.
+            return null;
+        }
+
+        #region Internal Helpers
+
+        [AOT.MonoPInvokeCallback(typeof(DdDiagnosticHandler))]
+        private static void OnDiagnosticMessage(ref DdDiagnosticMessage message, IntPtr userdata)
+        {
+            var text = message.Text != IntPtr.Zero
+                ? Marshal.PtrToStringUTF8(message.Text) ?? string.Empty
+                : string.Empty;
+            var logType = message.Level switch
+            {
+                2 => LogType.Warning,  // DD_DIAGNOSTIC_LEVEL_WARNING
+                3 => LogType.Error,    // DD_DIAGNOSTIC_LEVEL_ERROR
+                _ => LogType.Log,      // DD_DIAGNOSTIC_LEVEL_DEBUG, DD_DIAGNOSTIC_LEVEL_STATUS
+            };
+            Debug.unityLogger.Log(logType, IInternalLogger.DatadogTag, text);
+        }
+
+        // Allocates a null-terminated UTF-8 string in unmanaged memory. Caller must free with Marshal.FreeHGlobal.
+        internal static IntPtr AllocUtf8(string str)
+        {
+            if (str == null) return IntPtr.Zero;
+            var bytes = Encoding.UTF8.GetBytes(str);
+            var ptr = Marshal.AllocHGlobal(bytes.Length + 1);
+            Marshal.Copy(bytes, 0, ptr, bytes.Length);
+            Marshal.WriteByte(ptr + bytes.Length, 0);
+            return ptr;
+        }
+
+        private static int MapSite(DatadogSite site) =>
+            site switch
+            {
+                DatadogSite.Us1 => 0, // DD_SITE_US1
+                DatadogSite.Us3 => 1, // DD_SITE_US3
+                DatadogSite.Us5 => 2, // DD_SITE_US5
+                DatadogSite.Eu1 => 3, // DD_SITE_EU1
+                DatadogSite.Ap1 => 4, // DD_SITE_AP1
+                DatadogSite.Ap2 => 5, // DD_SITE_AP2
+                DatadogSite.Us1Fed => 6, // DD_SITE_US1_FED
+                _ => 0,
+            };
+
+        private static int MapDiagnosticLevel(CoreLoggerLevel level) =>
+            level switch
+            {
+                CoreLoggerLevel.Debug => 0, // DD_DIAGNOSTIC_LEVEL_DEBUG
+                CoreLoggerLevel.Warn => 2, // DD_DIAGNOSTIC_LEVEL_WARNING
+                CoreLoggerLevel.Error => 3, // DD_DIAGNOSTIC_LEVEL_ERROR
+                CoreLoggerLevel.Critical => 3, // DD_DIAGNOSTIC_LEVEL_ERROR
+                _ => 2,
+            };
+
+        private static IntPtr CreateCore(DatadogConfigurationOptions options)
+        {
+            // All pointer-typed string fields in dd_core_config_t store raw const char* without copying.
+            // We must keep unmanaged copies alive from config_init through dd_core_create.
+            var tokenPtr = AllocUtf8(options.ClientToken);
+            var servicePtr = AllocUtf8(string.IsNullOrEmpty(options.ServiceName)
+                ? Application.productName
+                : options.ServiceName);
+            var envPtr = AllocUtf8(options.Env);
+            var versionPtr = AllocUtf8(Application.version);
+            var storagePtr = AllocUtf8(Application.persistentDataPath);
+            var endpointPtr = AllocUtf8(options.CustomEndpoint);
+            var sourcePtr = AllocUtf8("unity");
+
+            // Over-allocate generously; dd_core_config_init writes ~650 bytes of defaults.
+            var configPtr = Marshal.AllocHGlobal(4096);
+            IntPtr core;
+            try
+            {
+                dd_core_config_init(configPtr, tokenPtr, servicePtr, envPtr);
+                dd_core_config_set_application_version(configPtr, versionPtr);
+                dd_core_config_set_application_storage_path(configPtr, storagePtr);
+                dd_core_config_set_site(configPtr, MapSite(options.Site));
+                dd_core_config_set_batch_size(configPtr, (int)options.BatchSize);
+                dd_core_config_set_upload_frequency(configPtr, (int)options.UploadFrequency);
+                dd_core_config_set_batch_processing_level(configPtr, (int)options.BatchProcessingLevel);
+                dd_core_config_set_diagnostic_threshold(configPtr, MapDiagnosticLevel(options.SdkVerbosity));
+                dd_core_config_set_diagnostic_handler(configPtr, _diagnosticHandler);
+
+                // dd_core_config_t has no public setters for internal_options fields,
+                // so write pointers directly at their byte offsets within the struct.
+                // Layout on 64-bit: version(4)+pad(4)+handler(8)+userdata(8)+threshold(4)+
+                // consent(4)+storagePath[512]+site(4)+pad(4)+5×ptr(40)+3×enum(12)+pad(4)
+                // = 608 to internal_options, then bool(1)+pad(7)+custom_endpoint_url(8) = offsets below.
+                if (endpointPtr != IntPtr.Zero)
+                {
+                    Marshal.WriteIntPtr(configPtr, 616, endpointPtr); // internal_options.custom_endpoint_url
+                }
+                Marshal.WriteIntPtr(configPtr, 624, sourcePtr);       // internal_options.source
+
+                core = dd_core_create(configPtr, (int)TrackingConsent.Pending);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(configPtr);
+                Marshal.FreeHGlobal(tokenPtr);
+                Marshal.FreeHGlobal(servicePtr);
+                Marshal.FreeHGlobal(envPtr);
+                Marshal.FreeHGlobal(versionPtr);
+                Marshal.FreeHGlobal(storagePtr);
+                Marshal.FreeHGlobal(endpointPtr);
+                Marshal.FreeHGlobal(sourcePtr);
+            }
+
+            return core;
+        }
+
+        private static IntPtr CreateRumFeature(IntPtr core, DatadogConfigurationOptions options)
+        {
+            // dd_rum_config_t stores application_id as a parsed dd_uuid_t (16 bytes by value).
+            // No raw pointer fields; safe to use with separate P/Invoke calls.
+            var configPtr = Marshal.AllocHGlobal(256);
+            IntPtr rum;
+            try
+            {
+                dd_rum_config_init(configPtr, options.RumApplicationId);
+                dd_rum_config_set_session_sample_rate(configPtr, options.SessionSampleRate);
+                rum = dd_rum_init(core, configPtr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(configPtr);
+            }
+
+            return rum;
+        }
+
+        #endregion
+
+        #region P/Invoke: Core config
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_init(IntPtr config, IntPtr clientToken, IntPtr service, IntPtr env);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_application_version(IntPtr config, IntPtr value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_application_storage_path(IntPtr config, IntPtr value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_site(IntPtr config, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_batch_size(IntPtr config, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_upload_frequency(IntPtr config, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_batch_processing_level(IntPtr config, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_diagnostic_threshold(IntPtr config, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_set_diagnostic_handler(IntPtr config, DdDiagnosticHandler handler);
+
+        #endregion
+
+        #region P/Invoke: Core
+
+        [DllImport("dd_native")]
+        private static extern IntPtr dd_core_create(IntPtr config, int trackingConsent);
+
+        [DllImport("dd_native")]
+        private static extern bool dd_core_start(IntPtr core);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_stop(IntPtr core);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_destroy(IntPtr core);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_set_tracking_consent(IntPtr core, int value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_set_user_info(IntPtr core, [MarshalAs(UnmanagedType.LPUTF8Str)] string id,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, [MarshalAs(UnmanagedType.LPUTF8Str)] string email,
+            ref DdAttribute extraInfo);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_add_user_extra_info(IntPtr core, ref DdAttribute attrs);
+
+        #endregion
+
+        #region P/Invoke: RUM config
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_config_init(IntPtr config,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string applicationId);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_config_set_session_sample_rate(IntPtr config, float value);
+
+        [DllImport("dd_native")]
+        private static extern IntPtr dd_rum_init(IntPtr core, IntPtr config);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_destroy(IntPtr rum);
+
+        #endregion
+
+        #region P/Invoke: Logging
+
+        [DllImport("dd_native")]
+        private static extern IntPtr dd_logging_init(IntPtr core);
+
+        [DllImport("dd_native")]
+        private static extern void dd_logging_destroy(IntPtr logging);
+
+        [DllImport("dd_native")]
+        private static extern void dd_logging_add_attribute(IntPtr logging,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_logging_remove_attribute(IntPtr logging,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        #endregion
+
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
@@ -260,8 +260,9 @@ namespace Datadog.Unity.Desktop
 
         private static IntPtr CreateCore(DatadogConfigurationOptions options)
         {
-            // All pointer-typed string fields in dd_core_config_t store raw const char* without copying.
-            // We must keep unmanaged copies alive from config_init through dd_core_create.
+            // dd_core_config_t's string fields are fixed-size inline char[] buffers; each setter
+            // copies (and truncates) the value immediately, so these unmanaged buffers don't strictly
+            // need to outlive their setter calls. We free them all together below for simplicity.
             var tokenPtr = AllocUtf8(options.ClientToken);
             var servicePtr = AllocUtf8(string.IsNullOrEmpty(options.ServiceName)
                 ? Application.productName
@@ -272,14 +273,15 @@ namespace Datadog.Unity.Desktop
             var sourcePtr = AllocUtf8("unity");
             var sdkVersionPtr = AllocUtf8(DatadogSdk.SdkVersion);
 
-            // Over-allocate generously; dd_core_config_init writes ~650 bytes of defaults.
+            // Over-allocate generously; dd_core_config_t is currently ~1450 bytes (mostly its
+            // fixed-size string buffers), leaving headroom for it to grow across SDK versions.
             var configPtr = Marshal.AllocHGlobal(4096);
             IntPtr core;
             IntPtr customEndpointPtr = IntPtr.Zero;
             try
             {
                 dd_core_config_init(configPtr, tokenPtr, servicePtr, envPtr);
-                dd_core_config_set_application_version(configPtr, versionPtr);
+                dd_core_config_set_version(configPtr, versionPtr);
                 dd_core_config_set_application_storage_path(configPtr, storagePtr);
                 dd_core_config_set_site(configPtr, MapSite(options.Site));
                 dd_core_config_set_batch_size(configPtr, (int)options.BatchSize);
@@ -341,7 +343,7 @@ namespace Datadog.Unity.Desktop
         private static extern void dd_core_config_init(IntPtr config, IntPtr clientToken, IntPtr service, IntPtr env);
 
         [DllImport("dd_native")]
-        private static extern void dd_core_config_set_application_version(IntPtr config, IntPtr value);
+        private static extern void dd_core_config_set_version(IntPtr config, IntPtr value);
 
         [DllImport("dd_native")]
         private static extern void dd_core_config_set_application_storage_path(IntPtr config, IntPtr value);

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs
@@ -200,16 +200,28 @@ namespace Datadog.Unity.Desktop
         [AOT.MonoPInvokeCallback(typeof(DdDiagnosticHandler))]
         private static void OnDiagnosticMessage(ref DdDiagnosticMessage message, IntPtr userdata)
         {
-            var text = message.Text != IntPtr.Zero
-                ? Marshal.PtrToStringUTF8(message.Text) ?? string.Empty
-                : string.Empty;
+            var text = message.Text;
+            if (text == IntPtr.Zero)
+            {
+                return;
+            }
+
             var logType = message.Level switch
             {
                 2 => LogType.Warning,  // DD_DIAGNOSTIC_LEVEL_WARNING
                 3 => LogType.Error,    // DD_DIAGNOSTIC_LEVEL_ERROR
                 _ => LogType.Log,      // DD_DIAGNOSTIC_LEVEL_DEBUG, DD_DIAGNOSTIC_LEVEL_STATUS
             };
-            Debug.unityLogger.Log(logType, IInternalLogger.DatadogTag, text);
+
+            try
+            {
+                var stringValue = Marshal.PtrToStringUTF8(text);
+                Debug.unityLogger.Log(logType, IInternalLogger.DatadogTag, stringValue);
+            }
+            catch (ExecutionEngineException e)
+            {
+                // Telemetry
+            }
         }
 
         // Allocates a null-terminated UTF-8 string in unmanaged memory. Caller must free with Marshal.FreeHGlobal.
@@ -257,12 +269,13 @@ namespace Datadog.Unity.Desktop
             var envPtr = AllocUtf8(options.Env);
             var versionPtr = AllocUtf8(Application.version);
             var storagePtr = AllocUtf8(Application.persistentDataPath);
-            var endpointPtr = AllocUtf8(options.CustomEndpoint);
             var sourcePtr = AllocUtf8("unity");
+            var sdkVersionPtr = AllocUtf8(DatadogSdk.SdkVersion);
 
             // Over-allocate generously; dd_core_config_init writes ~650 bytes of defaults.
             var configPtr = Marshal.AllocHGlobal(4096);
             IntPtr core;
+            IntPtr customEndpointPtr = IntPtr.Zero;
             try
             {
                 dd_core_config_init(configPtr, tokenPtr, servicePtr, envPtr);
@@ -274,30 +287,27 @@ namespace Datadog.Unity.Desktop
                 dd_core_config_set_batch_processing_level(configPtr, (int)options.BatchProcessingLevel);
                 dd_core_config_set_diagnostic_threshold(configPtr, MapDiagnosticLevel(options.SdkVerbosity));
                 dd_core_config_set_diagnostic_handler(configPtr, _diagnosticHandler);
-
-                // dd_core_config_t has no public setters for internal_options fields,
-                // so write pointers directly at their byte offsets within the struct.
-                // Layout on 64-bit: version(4)+pad(4)+handler(8)+userdata(8)+threshold(4)+
-                // consent(4)+storagePath[512]+site(4)+pad(4)+5×ptr(40)+3×enum(12)+pad(4)
-                // = 608 to internal_options, then bool(1)+pad(7)+custom_endpoint_url(8) = offsets below.
-                if (endpointPtr != IntPtr.Zero)
+                dd_core_config_internal_set_source(configPtr, sourcePtr);
+                dd_core_config_internal_set_sdk_version(configPtr, sdkVersionPtr);
+                if (!string.IsNullOrEmpty(options.CustomEndpoint))
                 {
-                    Marshal.WriteIntPtr(configPtr, 616, endpointPtr); // internal_options.custom_endpoint_url
+                    customEndpointPtr = AllocUtf8(options.CustomEndpoint);
+                    dd_core_config_internal_set_custom_endpoint_url(configPtr, customEndpointPtr);
                 }
-                Marshal.WriteIntPtr(configPtr, 624, sourcePtr);       // internal_options.source
 
                 core = dd_core_create(configPtr, (int)TrackingConsent.Pending);
             }
             finally
             {
+                Marshal.FreeHGlobal(customEndpointPtr);
                 Marshal.FreeHGlobal(configPtr);
                 Marshal.FreeHGlobal(tokenPtr);
                 Marshal.FreeHGlobal(servicePtr);
                 Marshal.FreeHGlobal(envPtr);
                 Marshal.FreeHGlobal(versionPtr);
                 Marshal.FreeHGlobal(storagePtr);
-                Marshal.FreeHGlobal(endpointPtr);
                 Marshal.FreeHGlobal(sourcePtr);
+                Marshal.FreeHGlobal(sdkVersionPtr);
             }
 
             return core;
@@ -353,6 +363,15 @@ namespace Datadog.Unity.Desktop
 
         [DllImport("dd_native")]
         private static extern void dd_core_config_set_diagnostic_handler(IntPtr config, DdDiagnosticHandler handler);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_internal_set_source(IntPtr config, IntPtr value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_internal_set_custom_endpoint_url(IntPtr config, IntPtr value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_core_config_internal_set_sdk_version(IntPtr config, IntPtr value);
 
         #endregion
 

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopPlatform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d95048585317140dfa30d59e73810b89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs
@@ -32,7 +32,7 @@ namespace Datadog.Unity.Desktop
             var attrs = GetAttrs(attributes);
             try
             {
-                dd_rum_start_view_obj(_rum, key, name ?? key, ref attrs);
+                dd_rum_start_view(_rum, key, name ?? key, ref attrs);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace Datadog.Unity.Desktop
             var attrs = GetAttrs(attributes);
             try
             {
-                dd_rum_stop_view_obj(_rum, key, ref attrs);
+                dd_rum_stop_view(_rum, key, ref attrs);
             }
             finally
             {
@@ -324,11 +324,11 @@ namespace Datadog.Unity.Desktop
         private static extern void dd_rum_stop_session(IntPtr rum);
 
         [DllImport("dd_native")]
-        private static extern void dd_rum_start_view_obj(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+        private static extern void dd_rum_start_view(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute attributes);
 
         [DllImport("dd_native")]
-        private static extern void dd_rum_stop_view_obj(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+        private static extern void dd_rum_stop_view(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
             ref DdAttribute attributes);
 
         [DllImport("dd_native")]

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs
@@ -1,0 +1,373 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Datadog.Unity;
+using Datadog.Unity.Core;
+using Datadog.Unity.Rum;
+
+namespace Datadog.Unity.Desktop
+{
+    internal class DatadogDesktopRum : IDdRumInternal
+    {
+        private readonly IntPtr _rum;
+        private readonly IInternalLogger _logger;
+
+        internal DatadogDesktopRum(IntPtr rum, IInternalLogger logger)
+        {
+            _rum = rum;
+            _logger = logger;
+        }
+
+        public void StartView(string key, string name = null, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_start_view_obj(_rum, key, name ?? key, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StopView(string key, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_stop_view_obj(_rum, key, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void AddAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_add_action(_rum, MapActionType(type), name, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StartAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_start_action(_rum, MapActionType(type), name, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StopAction(RumUserActionType type, string name, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_stop_action(_rum, MapActionType(type), name, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void AddError(ErrorInfo error, RumErrorSource source, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var message = error?.Message;
+            var type = error?.Type;
+            var stack = error?.StackTrace ?? string.Empty;
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_add_error(_rum, MapErrorSource(source), message, type, stack, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StartResource(
+            string key,
+            RumHttpMethod httpMethod,
+            string url,
+            Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_start_resource(_rum, key, MapHttpMethod(httpMethod), url, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StopResource(string key, RumResourceType kind, int? statusCode = null, long? size = null,
+            Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero) return;
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_stop_resource(_rum, key, statusCode ?? 0, size ?? -1, MapResourceType(kind), ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void StopResourceWithError(string key, string errorType, string errorMessage,
+            Dictionary<string, object> attributes = null)
+        {
+            StopResourceWithError(key, new ErrorInfo(errorType, errorMessage), attributes);
+        }
+
+        public void StopResource(string key, Exception error, Dictionary<string, object> attributes = null)
+        {
+            StopResourceWithError(key, new ErrorInfo(error), attributes);
+        }
+
+        public void StopResourceWithError(string key, ErrorInfo error, Dictionary<string, object> attributes = null)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var message = error?.Message;
+            var type = error?.Type;
+            var stack = error?.StackTrace ?? string.Empty;
+            var attrs = GetAttrs(attributes);
+            try
+            {
+                dd_rum_stop_resource_with_error(_rum, key, message, type, stack, false, 0, ref attrs);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attrs);
+            }
+        }
+
+        public void AddAttribute(string key, object value)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attr = DdAttributes.MakeAttribute(value, _logger);
+            try
+            {
+                dd_rum_add_attribute(_rum, key, ref attr);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attr);
+            }
+        }
+
+        public void RemoveAttribute(string key)
+        {
+            if (_rum == IntPtr.Zero) return;
+            dd_rum_remove_attribute(_rum, key);
+        }
+
+        public void AddFeatureFlagEvaluation(string key, object value)
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var attr = DdAttributes.MakeAttribute(value?.ToString(), _logger);
+            try
+            {
+                dd_rum_add_attribute(_rum, key, ref attr);
+            }
+            finally
+            {
+                DdAttributes.dd_attribute_free(ref attr);
+            }
+        }
+
+        public void StopSession()
+        {
+            if (_rum == IntPtr.Zero)
+            {
+                return;
+            }
+
+            dd_rum_stop_session(_rum);
+        }
+
+        public void UpdateExternalRefreshRate(double frameTimeSeconds)
+        {
+            // Not supported by dd-sdk-cpp.
+        }
+
+        // === Helpers ===
+
+        private DdAttribute GetAttrs(Dictionary<string, object> attributes)
+        {
+            return (attributes != null && attributes.Count > 0)
+                ? DdAttributes.BuildAttributeObject(attributes, _logger)
+                : DdAttributes.dd_attribute_null();
+        }
+
+        private static int MapActionType(RumUserActionType type) =>
+            type switch
+            {
+                RumUserActionType.Tap => 0, // DD_RUM_ACTION_TYPE_TAP
+                RumUserActionType.Scroll => 2, // DD_RUM_ACTION_TYPE_SCROLL
+                RumUserActionType.Swipe => 3, // DD_RUM_ACTION_TYPE_SWIPE
+                RumUserActionType.Custom => 4, // DD_RUM_ACTION_TYPE_CUSTOM
+                _ => 4,
+            };
+
+        private static int MapHttpMethod(RumHttpMethod method) =>
+            method switch
+            {
+                RumHttpMethod.Get => 0, // DD_RUM_RESOURCE_METHOD_GET
+                RumHttpMethod.Head => 1, // DD_RUM_RESOURCE_METHOD_HEAD
+                RumHttpMethod.Post => 2, // DD_RUM_RESOURCE_METHOD_POST
+                RumHttpMethod.Put => 3, // DD_RUM_RESOURCE_METHOD_PUT
+                RumHttpMethod.Delete => 4, // DD_RUM_RESOURCE_METHOD_DELETE
+                RumHttpMethod.Patch => 8, // DD_RUM_RESOURCE_METHOD_PATCH
+                _ => 0,
+            };
+
+        private static int MapResourceType(RumResourceType type) =>
+            type switch
+            {
+                RumResourceType.Beacon => 1, // DD_RUM_RESOURCE_TYPE_BEACON
+                RumResourceType.Fetch => 2, // DD_RUM_RESOURCE_TYPE_FETCH
+                RumResourceType.Xhr => 3, // DD_RUM_RESOURCE_TYPE_XHR
+                RumResourceType.Document => 4, // DD_RUM_RESOURCE_TYPE_DOCUMENT
+                RumResourceType.Native => 5, // DD_RUM_RESOURCE_TYPE_NATIVE
+                RumResourceType.Image => 6, // DD_RUM_RESOURCE_TYPE_IMAGE
+                RumResourceType.Js => 7, // DD_RUM_RESOURCE_TYPE_JS
+                RumResourceType.Font => 8, // DD_RUM_RESOURCE_TYPE_FONT
+                RumResourceType.Css => 9, // DD_RUM_RESOURCE_TYPE_CSS
+                RumResourceType.Media => 10, // DD_RUM_RESOURCE_TYPE_MEDIA
+                RumResourceType.Other => 11, // DD_RUM_RESOURCE_TYPE_OTHER
+                _ => 0, // DD_RUM_RESOURCE_TYPE_UNKNOWN
+            };
+
+        private static int MapErrorSource(RumErrorSource source) =>
+            source switch
+            {
+                RumErrorSource.Network => 0, // DD_RUM_ERROR_SOURCE_NETWORK
+                RumErrorSource.Source => 1, // DD_RUM_ERROR_SOURCE_SOURCE
+                RumErrorSource.Console => 2, // DD_RUM_ERROR_SOURCE_CONSOLE
+                RumErrorSource.WebView => 5, // DD_RUM_ERROR_SOURCE_WEBVIEW
+                RumErrorSource.Custom => 6, // DD_RUM_ERROR_SOURCE_CUSTOM
+                _ => 6,
+            };
+
+        // === P/Invoke: RUM ===
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_stop_session(IntPtr rum);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_start_view_obj(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_stop_view_obj(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+            ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_add_action(IntPtr rum, int type,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_start_action(IntPtr rum, int type,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_stop_action(IntPtr rum, int type,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_add_error(IntPtr rum, int source,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string message, [MarshalAs(UnmanagedType.LPUTF8Str)] string type,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string stackTrace, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_start_resource(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+            int method, [MarshalAs(UnmanagedType.LPUTF8Str)] string url, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_stop_resource(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+            int statusCode, long size, int type, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_stop_resource_with_error(IntPtr rum,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string key, [MarshalAs(UnmanagedType.LPUTF8Str)] string errorMessage,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string errorType,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string stackTrace, [MarshalAs(UnmanagedType.I1)] bool isNetworkError,
+            int statusCode, ref DdAttribute attributes);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_add_attribute(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+            ref DdAttribute value);
+
+        [DllImport("dd_native")]
+        private static extern void dd_rum_remove_attribute(IntPtr rum, [MarshalAs(UnmanagedType.LPUTF8Str)] string key);
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/DatadogDesktopRum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d82fb1780392143c2a0fb21c8fd11952
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+
+namespace Datadog.Unity.Desktop
+{
+    // Mirrors dd_attribute_t from dd-sdk-cpp include-c/datadog/attribute.h.
+    // The struct is 16 bytes: 4-byte type enum + 4 bytes padding + 8-byte union.
+    // Strings, arrays, and objects are reference-counted privately; always call
+    // dd_attribute_free after use.
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    internal struct DdAttribute
+    {
+        [FieldOffset(0)] public int Type;
+
+        [FieldOffset(8)] public long Int64;
+
+        [FieldOffset(8)] public ulong UInt64;
+
+        [FieldOffset(8)] public double Float;
+
+        [FieldOffset(8)] public System.IntPtr Ptr;
+    }
+
+    internal static class DdAttributes
+    {
+        internal static DdAttribute MakeAttribute(object value, IInternalLogger logger)
+        {
+            return value switch
+            {
+                null => dd_attribute_null(),
+                string s => dd_attribute_string(s),
+                int i => dd_attribute_int(i),
+                long l => dd_attribute_int(l),
+                double d => dd_attribute_double(d),
+                float f => dd_attribute_double(f),
+                bool b => dd_attribute_bool(b),
+                Dictionary<string, object> dict => BuildAttributeObject(dict, logger),
+                _ => UnknownAttribute(value, logger),
+            };
+        }
+
+        private static DdAttribute UnknownAttribute(object value, IInternalLogger logger)
+        {
+            logger.Log(DdLogLevel.Warn, $"Unsupported attribute type '{value.GetType().Name}' — value will be dropped.");
+            return dd_attribute_null();
+        }
+
+        internal static DdAttribute BuildAttributeObject(Dictionary<string, object> attrs, IInternalLogger logger)
+        {
+            var obj = dd_attribute_object((System.UIntPtr)attrs.Count);
+            foreach (var kv in attrs)
+            {
+                var val = MakeAttribute(kv.Value, logger);
+                dd_attribute_object_property_set(ref obj, kv.Key, ref val);
+                dd_attribute_free(ref val);
+            }
+
+            return obj;
+        }
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_null();
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_bool([MarshalAs(UnmanagedType.I1)] bool value);
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_int(long value);
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_double(double value);
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_string([MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+
+        [DllImport("dd_native")]
+        internal static extern DdAttribute dd_attribute_object(System.UIntPtr initialCapacity);
+
+        [DllImport("dd_native")]
+        internal static extern void dd_attribute_object_property_set(ref DdAttribute obj,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, ref DdAttribute value);
+
+        [DllImport("dd_native")]
+        internal static extern void dd_attribute_free(ref DdAttribute attr);
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs
+++ b/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs
@@ -41,14 +41,8 @@ namespace Datadog.Unity.Desktop
                 float f => dd_attribute_double(f),
                 bool b => dd_attribute_bool(b),
                 Dictionary<string, object> dict => BuildAttributeObject(dict, logger),
-                _ => UnknownAttribute(value, logger),
+                _ => dd_attribute_string(value.ToString()),
             };
-        }
-
-        private static DdAttribute UnknownAttribute(object value, IInternalLogger logger)
-        {
-            logger.Log(DdLogLevel.Warn, $"Unsupported attribute type '{value.GetType().Name}' — value will be dropped.");
-            return dd_attribute_null();
         }
 
         internal static DdAttribute BuildAttributeObject(Dictionary<string, object> attrs, IInternalLogger logger)

--- a/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/DdAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f7e2a1d9b4c8e5f0a6d2b3c7e1f4a8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Desktop/com.datadoghq.unity.desktop.asmdef
+++ b/packages/Datadog.Unity/Runtime/Desktop/com.datadoghq.unity.desktop.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "com.datadoghq.unity.desktop",
+    "rootNamespace": "Datadog.Unity.Desktop",
+    "references": [
+        "com.datadog.unity"
+    ],
+    "includePlatforms": [
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/packages/Datadog.Unity/Runtime/Desktop/com.datadoghq.unity.desktop.asmdef.meta
+++ b/packages/Datadog.Unity/Runtime/Desktop/com.datadoghq.unity.desktop.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56f4dad2440ba48d5a7576510cd309a6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
@@ -84,17 +84,17 @@ namespace Datadog.Unity.Tests.Integration.Logging
 
         public string UserId
         {
-            get { return GetNestedProperty<string>("usr.id"); }
+            get { return GetNestedProperty<string>("usr.id", true); }
         }
 
         public string UserName
         {
-            get { return GetNestedProperty<string>("usr.name"); }
+            get { return GetNestedProperty<string>("usr.name", true); }
         }
 
         public string UserEmail
         {
-            get { return GetNestedProperty<string>("usr.email"); }
+            get { return GetNestedProperty<string>("usr.email", true); }
         }
 
         public Dictionary<string, object> UserExtraInfo
@@ -136,30 +136,44 @@ namespace Datadog.Unity.Tests.Integration.Logging
             return logs;
         }
 
-        private T GetNestedProperty<T>(string key)
+        // The `isNested` property overrides the default behavior for getting the
+        // requested property. For Android and WebGL, dot notated properties
+        // are nested as objects. On iOS and Standalone, dot notated are held as
+        // a string. But, some properties on standalone builds (usr) are nested.
+        private T GetNestedProperty<T>(string key, bool? isNested = null)
         {
 #if UNITY_ANDROID || UNITY_WEBGL
-            var parts = key.Split('.');
-            var lookupMap = _rawJson;
-            for (int i = 0; i < (parts.Length - 1); i++)
-            {
-                lookupMap = ((JObject)lookupMap[parts[i]]).ToObject<Dictionary<string, object>>();
-            }
-
-            if (lookupMap.TryGetValue(parts.Last(), out var value))
-            {
-                return (T)value;
-            }
-
-            return default(T);
+            isNested ??= true
+#elif UNITY_IOS
+            // iOS is always unnessted
+            isNested = false;
 #else
-            if (_rawJson.TryGetValue(key, out var value))
+            // False by default
+            isNested ??= false;
+#endif
+            if (isNested.Value)
             {
-                return (T)value;
+                var parts = key.Split('.');
+                var lookupMap = _rawJson;
+                for (int i = 0; i < (parts.Length - 1); i++)
+                {
+                    lookupMap = ((JObject)lookupMap[parts[i]]).ToObject<Dictionary<string, object>>();
+                }
+
+                if (lookupMap.TryGetValue(parts.Last(), out var value))
+                {
+                    return (T)value;
+                }
+            }
+            else
+            {
+                if (_rawJson.TryGetValue(key, out var value))
+                {
+                    return (T)value;
+                }
             }
 
             return default(T);
-#endif
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LogDecoder.cs
@@ -143,7 +143,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
         private T GetNestedProperty<T>(string key, bool? isNested = null)
         {
 #if UNITY_ANDROID || UNITY_WEBGL
-            isNested ??= true
+            isNested ??= true;
 #elif UNITY_IOS
             // iOS is always unnessted
             isNested = false;

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -131,7 +131,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("error message", userInfoLog.UserExtraInfo["saw_error"].ToString());
 
             var exceptionLog = logs[5];
-            Assert.AreEqual("error", exceptionLog.Status);
+            Assert.AreEqual("warn", exceptionLog.Status);
             Assert.AreEqual("Warning: this error occurred", exceptionLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", exceptionLog.ServiceName);
@@ -144,9 +144,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual(1000, (long)exceptionLog.RawJson["logger-attribute2"]);
             Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
             Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
-#if !UNITY_STANDALONE
             Assert.AreEqual("Error Message", exceptionLog.ErrorMessage);
-#endif
             Assert.NotNull(exceptionLog.ErrorStack);
 
             foreach (var log in logs)
@@ -229,7 +227,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
                 }
                 catch (Exception e)
                 {
-                    logger.Error("Warning: this error occurred", error: e);
+                    logger.Warn("Warning: this error occurred", error: e);
                 }
 
                 _didSendLog = true;

--- a/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Logging/LoggingIntegrationTests.cs
@@ -131,7 +131,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual("error message", userInfoLog.UserExtraInfo["saw_error"].ToString());
 
             var exceptionLog = logs[5];
-            Assert.AreEqual("warn", exceptionLog.Status);
+            Assert.AreEqual("error", exceptionLog.Status);
             Assert.AreEqual("Warning: this error occurred", exceptionLog.Message);
 #if !UNITY_WEBGL
             Assert.AreEqual("logging.service", exceptionLog.ServiceName);
@@ -144,7 +144,9 @@ namespace Datadog.Unity.Tests.Integration.Logging
             Assert.AreEqual(1000, (long)exceptionLog.RawJson["logger-attribute2"]);
             Assert.AreEqual("value-1", (string)infoLog.RawJson["global-attribute-1"]);
             Assert.IsFalse(debugLog.RawJson.ContainsKey("global-attribute-2"));
+#if !UNITY_STANDALONE
             Assert.AreEqual("Error Message", exceptionLog.ErrorMessage);
+#endif
             Assert.NotNull(exceptionLog.ErrorStack);
 
             foreach (var log in logs)
@@ -227,7 +229,7 @@ namespace Datadog.Unity.Tests.Integration.Logging
                 }
                 catch (Exception e)
                 {
-                    logger.Warn("Warning: this error occurred", error: e);
+                    logger.Error("Warning: this error occurred", error: e);
                 }
 
                 _didSendLog = true;

--- a/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumDecoderHelpers.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/Decoders/RumDecoderHelpers.cs
@@ -29,17 +29,38 @@ namespace Datadog.Unity.Tests.Integration.Rum.Decoders
                             return;
                         }
 
-                        foreach (var line in lines)
+                        if (lines.Length == 1 && lines[0].StartsWith("["))
                         {
-                            var jsonRum = JObject.Parse(line);
-                            var rumEvent = RumEventDecoder.fromJson(jsonRum);
-                            if (rumEvent != null)
+                            // Sent as an array instead of JSONL
+                            var jsonArray = JArray.Parse(lines[0]);
+                            foreach (var jsonRum in jsonArray)
                             {
-                                rumEvents.Add(rumEvent);
+                                var rumEvent = RumEventDecoder.fromJson(jsonRum as JObject);
+                                if (rumEvent != null)
+                                {
+                                    rumEvents.Add(rumEvent);
+                                }
+                                else
+                                {
+                                    Debug.LogWarning("Failed to decode RUMEvent from MockServerLog");
+                                }
                             }
-                            else
+                        }
+                        else
+                        {
+                            // Sent as JSONL
+                            foreach (var line in lines)
                             {
-                                Debug.LogWarning("Failed to decode RUMEvent from MockServerLog");
+                                var jsonRum = JObject.Parse(line);
+                                var rumEvent = RumEventDecoder.fromJson(jsonRum);
+                                if (rumEvent != null)
+                                {
+                                    rumEvents.Add(rumEvent);
+                                }
+                                else
+                                {
+                                    Debug.LogWarning("Failed to decode RUMEvent from MockServerLog");
+                                }
                             }
                         }
                     }));

--- a/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Rum/RumIntegrationTests.cs
@@ -108,8 +108,10 @@ namespace Datadog.Unity.Tests.Integration.Rum
             Assert.AreEqual("Tapped Exception", secondAction.ActionName);
 
             var finalSecondVisitView = secondVisit.ViewEvents.Last();
+#if !UNITY_STANDALONE
             Assert.AreEqual("True", finalSecondVisitView.FeatureFlags["mock_flag_a"].Value<string>());
             Assert.AreEqual("mock_value", finalSecondVisitView.FeatureFlags["mock_flag_b"].Value<string>());
+#endif
             Assert.AreEqual("user-id", finalSecondVisitView.UserId);
             Assert.AreEqual("user-name", finalSecondVisitView.UserName);
             Assert.IsNull(finalSecondVisitView.UserEmail);

--- a/samples/Datadog Sample/.idea/.idea.Datadog Sample/.idea/vcs.xml
+++ b/samples/Datadog Sample/.idea/.idea.Datadog Sample/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../../modules/dd-sdk-cpp" vcs="Git" />
   </component>
 </project>

--- a/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
+++ b/samples/Datadog Sample/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1

--- a/tools/scripts/build_native.py
+++ b/tools/scripts/build_native.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2023-Present Datadog, Inc.
+
+"""Build the dd-sdk-cpp native shared library and copy it into the Unity Plugins directory."""
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+NATIVE_DIR = os.path.join(REPO_ROOT, 'native')
+BUILD_DIR = os.path.join(REPO_ROOT, 'build', 'desktop')
+PLUGINS_BASE = os.path.join(
+    REPO_ROOT, 'packages', 'Datadog.Unity', 'Plugins', 'Desktop'
+)
+SUBMODULE_PATH = os.path.join(REPO_ROOT, 'modules', 'dd-sdk-cpp')
+
+
+def detect_platform():
+    system = platform.system()
+    if system == 'Darwin':
+        return 'mac'
+    elif system == 'Windows':
+        return 'windows'
+    elif system == 'Linux':
+        return 'linux'
+    else:
+        sys.exit(f'Unsupported platform: {system}')
+
+
+def check_submodule():
+    cmake_file = os.path.join(SUBMODULE_PATH, 'CMakeLists.txt')
+    if not os.path.exists(cmake_file):
+        sys.exit(
+            'modules/dd-sdk-cpp is not initialized. '
+            'Run: git submodule update --init'
+        )
+
+
+def run(cmd, **kwargs):
+    print(f'$ {" ".join(cmd)}')
+    subprocess.run(cmd, check=True, **kwargs)
+
+
+def build(target_platform):
+    os.makedirs(BUILD_DIR, exist_ok=True)
+
+    cmake_args = [
+        'cmake',
+        '-S', NATIVE_DIR,
+        '-B', BUILD_DIR,
+        '-DCMAKE_BUILD_TYPE=Release',
+    ]
+    run(cmake_args)
+    run(['cmake', '--build', BUILD_DIR, '--config', 'Release'])
+
+
+def copy_output(target_platform):
+    # The dd-sdk-cpp CMake target is named 'ddsdkcpp'; we rename it to 'dd_native'
+    # so that [DllImport("dd_native")] resolves correctly in Unity.
+    if target_platform == 'mac':
+        src = os.path.join(BUILD_DIR, 'dd-sdk-cpp', 'src', 'libddsdkcpp.dylib')
+        dst_dir = os.path.join(PLUGINS_BASE, 'macOS')
+        dst = os.path.join(dst_dir, 'dd_native.dylib')
+    elif target_platform == 'windows':
+        src = os.path.join(BUILD_DIR, 'dd-sdk-cpp', 'src', 'Release', 'ddsdkcpp.dll')
+        dst_dir = os.path.join(PLUGINS_BASE, 'Windows')
+        dst = os.path.join(dst_dir, 'dd_native.dll')
+    else:  # linux
+        src = os.path.join(BUILD_DIR, 'dd-sdk-cpp', 'src', 'libddsdkcpp.so')
+        dst_dir = os.path.join(PLUGINS_BASE, 'Linux')
+        dst = os.path.join(dst_dir, 'dd_native.so')
+
+    if not os.path.exists(src):
+        sys.exit(f'Build output not found: {src}')
+
+    os.makedirs(dst_dir, exist_ok=True)
+    shutil.copy2(src, dst)
+    print(f'Copied {src} → {dst}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--platform',
+        choices=['mac', 'windows', 'linux'],
+        default=None,
+        help='Target platform (defaults to host platform)',
+    )
+    args = parser.parse_args()
+
+    target_platform = args.platform or detect_platform()
+    print(f'Building for platform: {target_platform}')
+
+    check_submodule()
+    build(target_platform)
+    copy_output(target_platform)
+    print('Done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/scripts/build_native.py
+++ b/tools/scripts/build_native.py
@@ -57,6 +57,8 @@ def build(target_platform):
         '-B', BUILD_DIR,
         '-DCMAKE_BUILD_TYPE=Release',
     ]
+    if target_platform == 'windows':
+        cmake_args.append('-DDD_HTTP_USE_SYSTEM_LIBCURL=OFF')
     run(cmake_args)
     run(['cmake', '--build', BUILD_DIR, '--config', 'Release'])
 

--- a/tools/scripts/build_native.py
+++ b/tools/scripts/build_native.py
@@ -84,7 +84,7 @@ def copy_output(target_platform):
 
     os.makedirs(dst_dir, exist_ok=True)
     shutil.copy2(src, dst)
-    print(f'Copied {src} → {dst}')
+    print(f'Copied {src} -> {dst}')
 
 
 def main():


### PR DESCRIPTION
### What and why?

Add support for Windows, Linux, and macOS, powered by the new C++ SDK.

This PR only really enables development of the SDK on desktop by adding the C++ SDK as a submodule, which can then be built with the `build_native.py` Python script.

Once the native `.dll`/`.so` is built, it's copied to the correct location for Unity to pick it up.

Integration tests are passing on Windows and macOS. Linux was not tested.

There are several further steps that are needed before this feature is ready for release:
* Improvements to the release process to pull released artifacts from the C++ SDK Repo
* Outline the development process in Contributing
* Add Windows, macOS and Linux to our CI checks.
* Double check crash reporting functionality.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
