### PR TITLE
Cache configuration for bootstrap/offline

### DIFF
--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -124,6 +124,17 @@ namespace Datadog.Unity.Flags
 
             lock (_lock)
             {
+                // Re-check _isEnabled inside _lock to close the Shutdown / CreateClient race:
+                // Shutdown flips _isEnabled = false under _enableLock and then calls
+                // ShutdownInternal under _lock. Without this check, a CreateClient call that
+                // observed _isEnabled == true before Shutdown ran can enter _lock after
+                // ShutdownInternal clears _clients, add a new client, and return it to the
+                // caller — who then holds a reference to a client disposed by ShutdownInternal.
+                if (!_isEnabled)
+                {
+                    return new NoopFlagsClient("DEFAULT", DatadogSdk.Instance?.InternalLogger);
+                }
+
                 if (_clients.TryGetValue(name, out var existingClient))
                 {
                     return existingClient;

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -168,6 +168,15 @@ namespace Datadog.Unity.Flags
                     env: options?.Env ?? string.Empty,
                     logger: _logger);
 
+                // site: DatadogSite.Us1.ToString() → "Us1"; .ToLowerInvariant() → "us1".
+                // Us1Fed → "us1fed" (no underscore). Phase 2 bootstrap uses the same conversion.
+                var cacheStore = new FlagsCacheStore(
+                    store: new PlayerPrefsKeyValueStore(),
+                    site: (options?.Site ?? DatadogSite.Us1).ToString().ToLowerInvariant(),
+                    env: options?.Env ?? string.Empty,
+                    clientToken: options?.ClientToken ?? string.Empty,
+                    logger: _logger);
+
                 var client = new FlagsClient(
                     repository: new FlagsRepository(),
                     exposureTracker: new ExposureTracker(),
@@ -176,7 +185,8 @@ namespace Datadog.Unity.Flags
                     logger: _logger,
                     trackExposures: _configuration.TrackExposures,
                     trackEvaluations: _configuration.TrackEvaluations,
-                    onExposure: onExposure);
+                    onExposure: onExposure,
+                    cacheWriter: cacheStore);
 
                 _clients[name] = client;
                 return client;

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -35,6 +35,7 @@ namespace Datadog.Unity.Flags
         public static readonly DdFlags Instance = new();
 
         private FlagsConfiguration _configuration;
+        private DatadogConfigurationOptions _options;
         private EvpTelemetrySender _telemetrySender;
         private IInternalLogger _logger;
         private volatile bool _isEnabled;
@@ -90,7 +91,7 @@ namespace Datadog.Unity.Flags
                     return;
                 }
 
-                Instance.Configure(configuration, logger);
+                Instance.Configure(configuration, options, logger);
             }
         }
 
@@ -140,7 +141,7 @@ namespace Datadog.Unity.Flags
                     return existingClient;
                 }
 
-                var options = DatadogConfigurationOptions.Load();
+                var options = _options;
 
                 string precomputeEndpoint;
                 if (!string.IsNullOrEmpty(_configuration.CustomFlagsEndpoint))
@@ -215,9 +216,13 @@ namespace Datadog.Unity.Flags
         }
 
         // Sets configuration and marks the instance as enabled.
-        private void Configure(FlagsConfiguration configuration, IInternalLogger logger)
+        // options is captured here so CreateClient() always uses the same values
+        // that Enable() validated — preventing a cache-key mismatch if the asset
+        // is reloaded between Enable() and CreateClient() calls (e.g., in tests).
+        private void Configure(FlagsConfiguration configuration, DatadogConfigurationOptions options, IInternalLogger logger)
         {
             _configuration = configuration;
+            _options = options;
             _logger = logger;
             _isEnabled = true;
         }

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -197,7 +197,8 @@ namespace Datadog.Unity.Flags
                     trackExposures: _configuration.TrackExposures,
                     trackEvaluations: _configuration.TrackEvaluations,
                     onExposure: onExposure,
-                    cacheWriter: cacheStore);
+                    cacheWriter: cacheStore,
+                    cacheReader: cacheStore);
 
                 _clients[name] = client;
                 return client;

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using Newtonsoft.Json;
+
+namespace Datadog.Unity.Flags
+{
+    internal class FlagsCacheEnvelopeDto
+    {
+        [JsonProperty("cachedAt")]
+        public string CachedAt { get; set; }
+
+        [JsonProperty("payload")]
+        public string Payload { get; set; }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Datadog.Unity.Flags
@@ -13,5 +14,17 @@ namespace Datadog.Unity.Flags
 
         [JsonProperty("payload")]
         public string Payload { get; set; }
+
+        [JsonProperty("context")]
+        public FlagsEvaluationContextDto Context { get; set; }
+
+        internal class FlagsEvaluationContextDto
+        {
+            [JsonProperty("targetingKey")]
+            public string TargetingKey { get; set; }
+
+            [JsonProperty("attributes")]
+            public Dictionary<string, string> Attributes { get; set; }
+        }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheEnvelopeDto.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e41f46f5bfa843b69178190b8c7cdb0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -136,7 +136,10 @@ namespace Datadog.Unity.Flags
         {
             // Force AOT compilation of the envelope deserialization path used by Phase 2 bootstrap.
             // Without this, IL2CPP strips DeserializeObject<FlagsCacheEnvelopeDto> on tvOS/iOS.
-            _ = Newtonsoft.Json.JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto>(string.Empty);
+            // Pass null (not string.Empty) — DeserializeObject<T>(null) returns null without
+            // throwing, while string.Empty throws JsonReaderException. Both force the AOT
+            // compiler to emit the generic deserialization stub for IL2CPP.
+            _ = Newtonsoft.Json.JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto>(null);
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Text;
+using Datadog.Unity.Core;
+using Datadog.Unity.Logs;
+using Newtonsoft.Json;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Writes serialized flag configuration to a <see cref="IKeyValueStore"/> under a scoped key.
+    /// Key format: dd_flags_v1_{site}_{env}_{clientToken[-8:]}
+    /// Payload is wrapped in a <see cref="FlagsCacheEnvelopeDto"/> before serialization.
+    /// Size gate: payloads >= 500 KB are skipped (warn log); payloads >= 400 KB log a warn but write.
+    /// </summary>
+    internal class FlagsCacheStore : IFlagsCacheWriter
+    {
+        internal const string KeyPrefix = "dd_flags_v1";
+        internal const int WarnThresholdBytes = 400 * 1024;
+        internal const int SkipThresholdBytes = 500 * 1024;
+
+        private readonly IKeyValueStore _store;
+        private readonly string _site;
+        private readonly string _env;
+        private readonly string _clientToken;
+        private readonly IInternalLogger _logger;
+
+        internal FlagsCacheStore(
+            IKeyValueStore store,
+            string site,
+            string env,
+            string clientToken,
+            IInternalLogger logger)
+        {
+            _store = store;
+            _site = site;
+            _env = env;
+            _clientToken = clientToken;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Computes the PlayerPrefs key for the given site, env, and client token.
+        /// Uses the last 8 characters of clientToken if its length >= 8; verbatim otherwise.
+        /// Null token is treated as an empty string.
+        /// </summary>
+        internal static string ComputeKey(string site, string env, string clientToken)
+        {
+            var token = clientToken ?? string.Empty;
+            var suffix = token.Length >= 8 ? token.Substring(token.Length - 8) : token;
+            return $"{KeyPrefix}_{site}_{env}_{suffix}";
+        }
+
+        /// <inheritdoc/>
+        public void Write(string rawJson, FlagsEvaluationContext context)
+        {
+            try
+            {
+                var envelope = new FlagsCacheEnvelopeDto
+                {
+                    CachedAt = DateTimeOffset.UtcNow.ToString("o"),
+                    Payload = rawJson,
+                };
+
+                var serialized = JsonConvert.SerializeObject(envelope);
+                var byteCount = Encoding.UTF8.GetByteCount(serialized);
+
+                if (byteCount >= SkipThresholdBytes)
+                {
+                    _logger?.Log(DdLogLevel.Warn,
+                        $"[Flags] Cache write skipped: payload {byteCount} bytes exceeds {SkipThresholdBytes} byte limit.");
+                    return;
+                }
+
+                if (byteCount >= WarnThresholdBytes)
+                {
+                    _logger?.Log(DdLogLevel.Warn,
+                        $"[Flags] Cache payload is large ({byteCount} bytes); approaching tvOS NSUserDefaults limit.");
+                }
+
+                var key = ComputeKey(_site, _env, _clientToken);
+                _store.SetString(key, serialized);
+                _store.Save();
+            }
+            catch (Exception e)
+            {
+                _logger?.Log(DdLogLevel.Warn, $"[Flags] Cache write failed: {e.Message}");
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -78,7 +78,7 @@ namespace Datadog.Unity.Flags
                 if (byteCount >= SkipThresholdBytes)
                 {
                     _logger?.Log(DdLogLevel.Warn,
-                        $"[Flags] Cache write skipped: payload {byteCount} bytes exceeds {SkipThresholdBytes} byte limit.");
+                        $"[Flags] Cache write skipped: serialized envelope {byteCount} bytes exceeds {SkipThresholdBytes} byte limit.");
                     return;
                 }
 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -56,6 +56,12 @@ namespace Datadog.Unity.Flags
         }
 
         /// <inheritdoc/>
+        /// <remarks>
+        /// The <paramref name="context"/> parameter is received to satisfy the
+        /// <see cref="IFlagsCacheWriter"/> interface contract. It is reserved for future use
+        /// (e.g., per-context cache scoping in a later phase). The current implementation
+        /// derives the storage key from the static site/env/clientToken fields only.
+        /// </remarks>
         public void Write(string rawJson, FlagsEvaluationContext context)
         {
             try

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -105,7 +105,7 @@ namespace Datadog.Unity.Flags
         /// (e.g., per-context cache scoping in a later phase). The current implementation
         /// derives the storage key from the static site/env/clientToken fields only.
         /// </remarks>
-        public FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context)
+        public FlagsCacheEnvelopeDto? Read(FlagsEvaluationContext context)
         {
             try
             {

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -57,19 +57,29 @@ namespace Datadog.Unity.Flags
 
         /// <inheritdoc/>
         /// <remarks>
-        /// The <paramref name="context"/> parameter is received to satisfy the
-        /// <see cref="IFlagsCacheWriter"/> interface contract. It is reserved for future use
-        /// (e.g., per-context cache scoping in a later phase). The current implementation
-        /// derives the storage key from the static site/env/clientToken fields only.
+        /// The <paramref name="context"/> parameter is serialized into the envelope alongside the
+        /// payload, enabling bootstrap to restore the evaluation context on the next startup.
+        /// The storage key is derived from the static site/env/clientToken fields only.
         /// </remarks>
         public void Write(string rawJson, FlagsEvaluationContext context)
         {
             try
             {
+                FlagsCacheEnvelopeDto.FlagsEvaluationContextDto contextDto = null;
+                if (context != null)
+                {
+                    contextDto = new FlagsCacheEnvelopeDto.FlagsEvaluationContextDto
+                    {
+                        TargetingKey = context.TargetingKey,
+                        Attributes = new System.Collections.Generic.Dictionary<string, string>(context.Attributes),
+                    };
+                }
+
                 var envelope = new FlagsCacheEnvelopeDto
                 {
                     CachedAt = DateTimeOffset.UtcNow.ToString("o"),
                     Payload = rawJson,
+                    Context = contextDto,
                 };
 
                 var serialized = JsonConvert.SerializeObject(envelope);
@@ -140,6 +150,8 @@ namespace Datadog.Unity.Flags
             // throwing, while string.Empty throws JsonReaderException. Both force the AOT
             // compiler to emit the generic deserialization stub for IL2CPP.
             _ = Newtonsoft.Json.JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto>(null);
+            // Force AOT compilation for the nested context DTO added in Phase 3.
+            _ = Newtonsoft.Json.JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto.FlagsEvaluationContextDto>(null);
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Datadog.Unity.Core;
 using Datadog.Unity.Logs;
 using Newtonsoft.Json;
+using UnityEngine.Scripting;
 
 namespace Datadog.Unity.Flags
 {
@@ -89,6 +90,21 @@ namespace Datadog.Unity.Flags
             {
                 _logger?.Log(DdLogLevel.Warn, $"[Flags] Cache write failed: {e.Message}");
             }
+        }
+
+        /// <summary>
+        /// Forces AOT compilation of the FlagsCacheEnvelopeDto deserialization path used by Phase 2
+        /// bootstrap. Without this hint, IL2CPP strips DeserializeObject&lt;FlagsCacheEnvelopeDto&gt;
+        /// on tvOS/iOS because no reachable call site is visible at link time.
+        /// This method is never called at runtime — [Preserve] prevents the tree-shaker from
+        /// removing the generated generic deserialization code.
+        /// </summary>
+        [Preserve]
+        private static void EnsureTypes()
+        {
+            // Force AOT compilation of the envelope deserialization path used by Phase 2 bootstrap.
+            // Without this, IL2CPP strips DeserializeObject<FlagsCacheEnvelopeDto> on tvOS/iOS.
+            _ = Newtonsoft.Json.JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto>(string.Empty);
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs
@@ -17,7 +17,7 @@ namespace Datadog.Unity.Flags
     /// Payload is wrapped in a <see cref="FlagsCacheEnvelopeDto"/> before serialization.
     /// Size gate: payloads >= 500 KB are skipped (warn log); payloads >= 400 KB log a warn but write.
     /// </summary>
-    internal class FlagsCacheStore : IFlagsCacheWriter
+    internal class FlagsCacheStore : IFlagsCacheWriter, IFlagsCacheReader
     {
         internal const string KeyPrefix = "dd_flags_v1";
         internal const int WarnThresholdBytes = 400 * 1024;
@@ -95,6 +95,32 @@ namespace Datadog.Unity.Flags
             catch (Exception e)
             {
                 _logger?.Log(DdLogLevel.Warn, $"[Flags] Cache write failed: {e.Message}");
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The <paramref name="context"/> parameter is received to satisfy the
+        /// <see cref="IFlagsCacheReader"/> interface contract. It is reserved for future use
+        /// (e.g., per-context cache scoping in a later phase). The current implementation
+        /// derives the storage key from the static site/env/clientToken fields only.
+        /// </remarks>
+        public FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context)
+        {
+            try
+            {
+                var key = ComputeKey(_site, _env, _clientToken);
+                var json = _store.GetString(key, null);
+                if (string.IsNullOrEmpty(json))
+                {
+                    return null;
+                }
+                return JsonConvert.DeserializeObject<FlagsCacheEnvelopeDto>(json);
+            }
+            catch (Exception e)
+            {
+                _logger?.Log(DdLogLevel.Warn, $"[Flags] Cache read failed: {e.Message}");
+                return null;
             }
         }
 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsCacheStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 908adc29c56f4182b221f3589193033c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -361,8 +361,12 @@ namespace Datadog.Unity.Flags
             _repository.SetFlagsAndContext(restoredContext, flags);
 
             // Direct field write, not TransitionState — no subscribers yet at construction time
-            // (see RESEARCH.md Pitfall 1).
-            _state = FlagsClientState.Ready;
+            // (see RESEARCH.md Pitfall 1). Lock for memory model consistency with every other
+            // _state write.
+            lock (_lock)
+            {
+                _state = FlagsClientState.Ready;
+            }
             _logger?.Log(Logs.DdLogLevel.Debug, "[Flags] Bootstrapped from cache.");
         }
 

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -280,7 +280,10 @@ namespace Datadog.Unity.Flags
             var context = _repository.Context;
 
             // Exposure tracking
-            if (_trackExposures && assignment != null && assignment.DoLog && flagError == null)
+            // Guard: skip exposure dispatch when context is null (e.g., bootstrapped from cache
+            // before SetEvaluationContext is called). Firing an exposure with an empty subject ID
+            // would corrupt server-side attribution data.
+            if (_trackExposures && context != null && assignment != null && assignment.DoLog && flagError == null)
             {
                 var exposureKey = new ExposureTracker.ExposureKey(
                     targetingKey: context?.TargetingKey ?? string.Empty,

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -43,6 +43,12 @@ namespace Datadog.Unity.Flags
             IFlagsCacheReader cacheReader = null,
             FlagsClientState initialState = FlagsClientState.NotReady)
         {
+            if (trackExposures && exposureTracker == null)
+            {
+                throw new ArgumentNullException(nameof(exposureTracker),
+                    "exposureTracker must not be null when trackExposures is true.");
+            }
+
             _repository = repository;
             _exposureTracker = exposureTracker;
             _evaluationAggregator = evaluationAggregator;

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -24,6 +24,7 @@ namespace Datadog.Unity.Flags
         private readonly bool _trackExposures;
         private readonly bool _trackEvaluations;
         private readonly Action<ExposureEvent> _onExposure;
+        private readonly IFlagsCacheWriter _cacheWriter;
 
         private FlagsClientState _state;
         private bool _disposed;
@@ -37,6 +38,7 @@ namespace Datadog.Unity.Flags
             bool trackExposures,
             bool trackEvaluations,
             Action<ExposureEvent> onExposure,
+            IFlagsCacheWriter cacheWriter = null,
             FlagsClientState initialState = FlagsClientState.NotReady)
         {
             _repository = repository;
@@ -47,6 +49,7 @@ namespace Datadog.Unity.Flags
             _trackExposures = trackExposures;
             _trackEvaluations = trackEvaluations;
             _onExposure = onExposure;
+            _cacheWriter = cacheWriter;
             _state = initialState;
         }
 
@@ -127,10 +130,11 @@ namespace Datadog.Unity.Flags
 
             TransitionState(FlagsClientState.Reconciling);
 
-            _fetcher.Fetch(context, flags =>
+            _fetcher.Fetch(context, (rawJson, flags) =>
             {
                 if (flags != null)
                 {
+                    _cacheWriter?.Write(rawJson, context);
                     _repository.SetFlagsAndContext(context, flags);
                     TransitionState(FlagsClientState.Ready);
                     onComplete?.Invoke(true);

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -25,6 +25,7 @@ namespace Datadog.Unity.Flags
         private readonly bool _trackEvaluations;
         private readonly Action<ExposureEvent> _onExposure;
         private readonly IFlagsCacheWriter _cacheWriter;
+        private readonly IFlagsCacheReader _cacheReader;
 
         private FlagsClientState _state;
         private bool _disposed;
@@ -39,6 +40,7 @@ namespace Datadog.Unity.Flags
             bool trackEvaluations,
             Action<ExposureEvent> onExposure,
             IFlagsCacheWriter cacheWriter = null,
+            IFlagsCacheReader cacheReader = null,
             FlagsClientState initialState = FlagsClientState.NotReady)
         {
             _repository = repository;
@@ -50,7 +52,9 @@ namespace Datadog.Unity.Flags
             _trackEvaluations = trackEvaluations;
             _onExposure = onExposure;
             _cacheWriter = cacheWriter;
+            _cacheReader = cacheReader;
             _state = initialState;
+            BootstrapFromCache();
         }
 
         /// <summary>
@@ -304,6 +308,40 @@ namespace Datadog.Unity.Flags
             {
                 _evaluationAggregator?.RecordEvaluation(key, assignment, context, flagError);
             }
+        }
+
+        private void BootstrapFromCache()
+        {
+            if (_cacheReader == null) return;
+
+            var envelope = _cacheReader.Read(null);
+            if (envelope == null)
+            {
+                _logger?.Log(Logs.DdLogLevel.Debug, "[Flags] No cached flags found.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(envelope.Payload))
+            {
+                _logger?.Log(Logs.DdLogLevel.Debug, "[Flags] Cached payload is empty — skipping bootstrap.");
+                return;
+            }
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(envelope.Payload);
+            if (flags == null)
+            {
+                _logger?.Log(Logs.DdLogLevel.Debug, "[Flags] Cached payload parse failed — skipping bootstrap.");
+                return;
+            }
+
+            // Seed repository with null context. Real context is set when SetEvaluationContext is called.
+            // Bootstrap result wins over initialState — this is intentional (see RESEARCH.md Pitfall 2).
+            _repository.SetFlagsAndContext(null, flags);
+
+            // Direct field write, not TransitionState — no subscribers yet at construction time
+            // (see RESEARCH.md Pitfall 1).
+            _state = FlagsClientState.Ready;
+            _logger?.Log(Logs.DdLogLevel.Debug, "[Flags] Bootstrapped from cache.");
         }
 
         private void TransitionState(FlagsClientState newState)

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -351,6 +351,13 @@ namespace Datadog.Unity.Flags
             FlagsEvaluationContext restoredContext = null;
             if (envelope.Context != null && !string.IsNullOrEmpty(envelope.Context.TargetingKey))
             {
+                // The DTO stores attributes as Dictionary<string,string> (already flattened by Write).
+                // The public constructor accepts Dictionary<string,object>, so we cast each value to
+                // object. The constructor then calls Flatten which immediately calls .ToString() on each
+                // object value — a no-op round-trip for strings. The data is correct: the cached
+                // attributes were already flattened at write time, and the re-flatten on a dict with
+                // no nested objects is harmless. An internal bypass constructor was considered but
+                // deferred to keep the change scope narrow.
                 var attrs = envelope.Context.Attributes?.Count > 0
                     ? envelope.Context.Attributes
                           .ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value)

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Datadog.Unity.Flags
 {
@@ -343,9 +345,20 @@ namespace Datadog.Unity.Flags
                 return;
             }
 
-            // Seed repository with null context. Real context is set when SetEvaluationContext is called.
-            // Bootstrap result wins over initialState — this is intentional (see RESEARCH.md Pitfall 2).
-            _repository.SetFlagsAndContext(null, flags);
+            // Seed repository with restored context from cache envelope. Context is non-null when the
+            // envelope was written by a previous SetEvaluationContext call, enabling exposure tracking
+            // immediately after bootstrap.
+            FlagsEvaluationContext restoredContext = null;
+            if (envelope.Context != null && !string.IsNullOrEmpty(envelope.Context.TargetingKey))
+            {
+                var attrs = envelope.Context.Attributes?.Count > 0
+                    ? envelope.Context.Attributes
+                          .ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value)
+                    : null;
+                restoredContext = new FlagsEvaluationContext(envelope.Context.TargetingKey, attrs);
+            }
+
+            _repository.SetFlagsAndContext(restoredContext, flags);
 
             // Direct field write, not TransitionState — no subscribers yet at construction time
             // (see RESEARCH.md Pitfall 1).

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    internal interface IFlagsCacheReader
+    {
+        /// <summary>
+        /// Reads the cached flag envelope from the cache store.
+        /// Returns <c>null</c> when no cached data exists or the stored data is corrupt.
+        /// </summary>
+        /// <param name="context">
+        /// The evaluation context at read time. Reserved for future use
+        /// (e.g., per-context cache scoping). Not used by the current implementation.
+        /// </param>
+        FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context);
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
@@ -14,6 +14,6 @@ namespace Datadog.Unity.Flags
         /// The evaluation context at read time. Reserved for future use
         /// (e.g., per-context cache scoping). Not used by the current implementation.
         /// </param>
-        FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context);
+        FlagsCacheEnvelopeDto? Read(FlagsEvaluationContext context);
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs
@@ -13,6 +13,8 @@ namespace Datadog.Unity.Flags
         /// <param name="context">
         /// The evaluation context at read time. Reserved for future use
         /// (e.g., per-context cache scoping). Not used by the current implementation.
+        /// Implementations must accept <c>null</c> — the caller at bootstrap time has
+        /// no context available yet.
         /// </param>
         FlagsCacheEnvelopeDto? Read(FlagsEvaluationContext context);
     }

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5df9a37dc5504839a1654743ec91e291
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
@@ -6,6 +6,14 @@ namespace Datadog.Unity.Flags
 {
     internal interface IFlagsCacheWriter
     {
+        /// <summary>
+        /// Writes the raw server response JSON to the cache store.
+        /// </summary>
+        /// <param name="rawJson">The raw JSON string from the server response.</param>
+        /// <param name="context">
+        /// The evaluation context in effect at write time. Reserved for future use
+        /// (e.g., per-context cache scoping). Not used by the current implementation.
+        /// </param>
         void Write(string rawJson, FlagsEvaluationContext context);
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
@@ -11,8 +11,9 @@ namespace Datadog.Unity.Flags
         /// </summary>
         /// <param name="rawJson">The raw JSON string from the server response.</param>
         /// <param name="context">
-        /// The evaluation context in effect at write time. Reserved for future use
-        /// (e.g., per-context cache scoping). Not used by the current implementation.
+        /// The evaluation context to serialize alongside the flag payload. Used to restore
+        /// context after bootstrap so exposure tracking works without requiring a
+        /// SetEvaluationContext call. May be null if no context has been established yet.
         /// </param>
         void Write(string rawJson, FlagsEvaluationContext context);
     }

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    internal interface IFlagsCacheWriter
+    {
+        void Write(string rawJson, FlagsEvaluationContext context);
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/IFlagsCacheWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e9244b2cfc24c4f86634535ad5436c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/IKeyValueStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/IKeyValueStore.cs
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+namespace Datadog.Unity.Flags
+{
+    internal interface IKeyValueStore
+    {
+        string GetString(string key, string defaultValue);
+        void SetString(string key, string value);
+        void DeleteKey(string key);
+        void Save();
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/IKeyValueStore.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/IKeyValueStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47a16b45537d49c0a7da4f20e9f3bf62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/PlayerPrefsKeyValueStore.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PlayerPrefsKeyValueStore.cs
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using UnityEngine;
+
+namespace Datadog.Unity.Flags
+{
+    internal class PlayerPrefsKeyValueStore : IKeyValueStore
+    {
+        public string GetString(string key, string defaultValue) =>
+            PlayerPrefs.GetString(key, defaultValue);
+
+        public void SetString(string key, string value) =>
+            PlayerPrefs.SetString(key, value);
+
+        public void DeleteKey(string key) =>
+            PlayerPrefs.DeleteKey(key);
+
+        public void Save() =>
+            PlayerPrefs.Save();
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/PlayerPrefsKeyValueStore.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/PlayerPrefsKeyValueStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30feabcab6b146a7912f5f71904e6cac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -169,11 +169,9 @@ namespace Datadog.Unity.Flags
 
         internal static Dictionary<string, FlagAssignment> ParseResponse(string json)
         {
-            var flags = new Dictionary<string, FlagAssignment>();
-
             if (string.IsNullOrEmpty(json))
             {
-                return flags;
+                return null; // treat as parse failure so caller skips cache write
             }
 
             AssignmentsResponseDto response;
@@ -183,15 +181,16 @@ namespace Datadog.Unity.Flags
             }
             catch
             {
-                return flags;
+                return null; // malformed JSON — signal failure to caller
             }
 
             var flagsDict = response?.Data?.Attributes?.Flags;
             if (flagsDict == null)
             {
-                return flags;
+                return null; // structurally invalid response — signal failure
             }
 
+            var flags = new Dictionary<string, FlagAssignment>();
             foreach (var kvp in flagsDict)
             {
                 var dto = kvp.Value;

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -43,7 +43,7 @@ namespace Datadog.Unity.Flags
         /// Fetches precomputed assignments for the given evaluation context.
         /// Uses a callback since UnityWebRequest can be used from coroutines.
         /// </summary>
-        public void Fetch(FlagsEvaluationContext context, Action<Dictionary<string, FlagAssignment>> onComplete)
+        public void Fetch(FlagsEvaluationContext context, Action<string, Dictionary<string, FlagAssignment>> onComplete)
         {
             try
             {
@@ -72,19 +72,19 @@ namespace Datadog.Unity.Flags
                             var errorDetail = ExtractServerError(request.downloadHandler?.text, request.responseCode);
                             _logger?.Log(Logs.DdLogLevel.Warn,
                                 $"Failed to fetch flag assignments (HTTP {request.responseCode}): {errorDetail}");
-                            onComplete?.Invoke(null);
+                            onComplete?.Invoke(null, null);
                             return;
                         }
 
                         var responseText = request.downloadHandler.text;
                         var flags = ParseResponse(responseText);
-                        onComplete?.Invoke(flags);
+                        onComplete?.Invoke(responseText, flags);
                     }
                     catch (Exception e)
                     {
                         _logger?.Log(Logs.DdLogLevel.Warn, $"Error parsing flag assignments: {e.Message}");
                         _logger?.TelemetryError("Error parsing flag assignments", e);
-                        onComplete?.Invoke(null);
+                        onComplete?.Invoke(null, null);
                     }
                     finally
                     {
@@ -96,7 +96,7 @@ namespace Datadog.Unity.Flags
             {
                 _logger?.Log(Logs.DdLogLevel.Warn, $"Error fetching flag assignments: {e.Message}");
                 _logger?.TelemetryError("Error fetching flag assignments", e);
-                onComplete?.Invoke(null);
+                onComplete?.Invoke(null, null);
             }
         }
 

--- a/packages/Datadog.Unity/Runtime/Flags/link.xml
+++ b/packages/Datadog.Unity/Runtime/Flags/link.xml
@@ -1,7 +1,8 @@
 <linker>
-  <!-- Open question A4: assembly fullname must match the compiled DLL name, not necessarily the asmdef
-       filename. "com.datadoghq.unity.flags" is the asmdef name and first attempt. If IL2CPP build
-       validation shows stripping still occurs, try fullname="Datadog.Unity.Flags" instead. -->
+  <!-- Assembly fullname matches the asmdef "name" field in com.datadoghq.unity.flags.asmdef,
+       which Unity uses as the compiled DLL name. Confirmed: "com.datadoghq.unity.flags" is correct.
+       If IL2CPP build validation ever shows stripping still occurs, the alternative to try is
+       fullname="Datadog.Unity.Flags" (the rootNamespace value), though this should not be needed. -->
   <assembly fullname="com.datadoghq.unity.flags">
     <type fullname="Datadog.Unity.Flags.FlagsCacheEnvelopeDto" preserve="all"/>
   </assembly>

--- a/packages/Datadog.Unity/Runtime/Flags/link.xml
+++ b/packages/Datadog.Unity/Runtime/Flags/link.xml
@@ -5,5 +5,6 @@
        fullname="Datadog.Unity.Flags" (the rootNamespace value), though this should not be needed. -->
   <assembly fullname="com.datadoghq.unity.flags">
     <type fullname="Datadog.Unity.Flags.FlagsCacheEnvelopeDto" preserve="all"/>
+    <type fullname="Datadog.Unity.Flags.FlagsCacheEnvelopeDto+FlagsEvaluationContextDto" preserve="all"/>
   </assembly>
 </linker>

--- a/packages/Datadog.Unity/Runtime/Flags/link.xml
+++ b/packages/Datadog.Unity/Runtime/Flags/link.xml
@@ -1,0 +1,8 @@
+<linker>
+  <!-- Open question A4: assembly fullname must match the compiled DLL name, not necessarily the asmdef
+       filename. "com.datadoghq.unity.flags" is the asmdef name and first attempt. If IL2CPP build
+       validation shows stripping still occurs, try fullname="Datadog.Unity.Flags" instead. -->
+  <assembly fullname="com.datadoghq.unity.flags">
+    <type fullname="Datadog.Unity.Flags.FlagsCacheEnvelopeDto" preserve="all"/>
+  </assembly>
+</linker>

--- a/packages/Datadog.Unity/Runtime/Flags/link.xml.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a4b648df023748be8d44f1de4e3986cb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/DictionaryKeyValueStore.cs
+++ b/packages/Datadog.Unity/Tests/Flags/DictionaryKeyValueStore.cs
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    /// <summary>
+    /// An in-memory <see cref="IKeyValueStore"/> test double backed by a <see cref="Dictionary{K,V}"/>.
+    /// Placed in the Tests assembly only — never ships to end users (RESEARCH.md Pitfall 5, T-03-01).
+    /// The public <see cref="Store"/> field exposes the underlying dictionary for test assertions.
+    /// </summary>
+    internal class DictionaryKeyValueStore : IKeyValueStore
+    {
+        /// <summary>
+        /// Exposes the underlying dictionary so test code can assert on keys and values directly.
+        /// </summary>
+        public readonly Dictionary<string, string> Store = new();
+
+        public string GetString(string key, string defaultValue) =>
+            Store.TryGetValue(key, out var v) ? v : defaultValue;
+
+        public void SetString(string key, string value) => Store[key] = value;
+
+        public void DeleteKey(string key) => Store.Remove(key);
+
+        public void Save() { } // intentional no-op — no persistence layer to flush
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/DictionaryKeyValueStore.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/DictionaryKeyValueStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fec2d9f6a466477ca018dde9ce6e0d79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
@@ -229,9 +229,94 @@ namespace Datadog.Unity.Flags.Tests
                 "Attributes must survive bootstrap from envelope context");
         }
 
+        // ── LIFE-05: bootstrap → network fetch → cache updated + repo refreshed ──
+
+        /// <summary>
+        /// Verifies the LIFE-05 contract at the storage layer: after a successful fetch
+        /// the cache writer receives the new payload and the repository reflects updated flags.
+        ///
+        /// Note: <c>SetEvaluationContext</c> is the LIFE-05 trigger in production but requires a
+        /// real <c>PrecomputeAssignmentsFetcher</c> (no interface abstraction exists yet). This test
+        /// covers the downstream contract — that the components wired together by
+        /// <c>SetEvaluationContext</c> (cache write + repository update) behave correctly — using
+        /// a <c>CapturingWriter</c> and direct repository manipulation to simulate a successful
+        /// fetch response.
+        /// </summary>
+        [Test]
+        public void Life05_BootstrapThenFetchSucceeds_CacheAndRepositoryUpdated()
+        {
+            // Arrange: bootstrap from cache with old flags (empty).
+            var capturedWrites = new List<string>();
+            var writer = new CapturingWriter(capturedWrites);
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+                Context = new FlagsCacheEnvelopeDto.FlagsEvaluationContextDto { TargetingKey = "user-old" },
+            });
+            var repo = new FlagsRepository();
+            var client = MakeClient(cacheReader: reader, cacheWriter: writer, repository: repo);
+
+            Assert.AreEqual(FlagsClientState.Ready, client.State,
+                "Bootstrap must set state to Ready (pre-condition for LIFE-05)");
+            Assert.IsFalse(client.GetBooleanValue("show-feature", false),
+                "Flag must not exist before the fetch updates the repository");
+
+            // Act: simulate a successful network fetch — the same steps SetEvaluationContext
+            // executes inside its Fetch callback when flags != null.
+            var newContext = new FlagsEvaluationContext("user-new");
+            var newFlags = PrecomputeAssignmentsFetcher.ParseResponse(ValidPayloadWithBoolFlag);
+            writer.Write(ValidPayloadWithBoolFlag, newContext);   // mirrors _cacheWriter?.Write(rawJson, context)
+            repo.SetFlagsAndContext(newContext, newFlags);         // mirrors _repository.SetFlagsAndContext(context, flags)
+
+            // Assert: cache received the new write and repository serves the updated flag.
+            Assert.AreEqual(1, capturedWrites.Count,
+                "Cache writer must receive exactly one write after fetch (LIFE-05)");
+            Assert.IsTrue(client.GetBooleanValue("show-feature", false),
+                "Repository must serve updated flag value after fetch completes (LIFE-05)");
+            Assert.AreEqual("user-new", repo.Context.TargetingKey,
+                "Repository context must reflect the new evaluation context after fetch");
+        }
+
+        /// <summary>
+        /// Verifies that after bootstrap from cache, the cache store (using the real
+        /// <c>FlagsCacheStore</c>) is updated on a subsequent write — covering the full
+        /// write→read→bootstrap→write round-trip at the storage layer.
+        /// </summary>
+        [Test]
+        public void Life05_BootstrapThenWrite_CacheStoreReflectsNewData()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var initialContext = new FlagsEvaluationContext("user-old");
+
+            // Write initial (empty) flags into the cache.
+            cacheStore.Write(MinimalValidPayloadEmpty, initialContext);
+
+            // Bootstrap: a new client reads from the cache.
+            var client = MakeClient(cacheReader: cacheStore, repository: new FlagsRepository());
+            Assert.AreEqual(FlagsClientState.Ready, client.State,
+                "Client must be Ready after bootstrapping from real FlagsCacheStore");
+
+            // Simulate a successful fetch: write updated flags into the same cache store.
+            var updatedContext = new FlagsEvaluationContext("user-new");
+            cacheStore.Write(ValidPayloadWithBoolFlag, updatedContext);
+
+            // Verify the store now holds the updated envelope.
+            var updatedEnvelope = ((IFlagsCacheReader)cacheStore).Read(null);
+            Assert.IsNotNull(updatedEnvelope, "Store must return envelope after second write");
+            Assert.AreEqual(ValidPayloadWithBoolFlag, updatedEnvelope.Payload,
+                "Payload must reflect the updated flags from the fetch");
+            Assert.AreEqual("user-new", updatedEnvelope.Context?.TargetingKey,
+                "Context in envelope must reflect the new evaluation context");
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────
 
-        private static FlagsClient MakeClient(IFlagsCacheReader cacheReader = null, FlagsRepository repository = null)
+        private static FlagsClient MakeClient(
+            IFlagsCacheReader cacheReader = null,
+            IFlagsCacheWriter cacheWriter = null,
+            FlagsRepository repository = null)
         {
             return new FlagsClient(
                 repository: repository ?? new FlagsRepository(),
@@ -242,6 +327,7 @@ namespace Datadog.Unity.Flags.Tests
                 trackExposures: false,
                 trackEvaluations: false,
                 onExposure: null,
+                cacheWriter: cacheWriter,
                 cacheReader: cacheReader);
         }
 
@@ -255,6 +341,21 @@ namespace Datadog.Unity.Flags.Tests
             }
 
             public FlagsCacheEnvelopeDto? Read(FlagsEvaluationContext context) => _envelope;
+        }
+
+        private class CapturingWriter : IFlagsCacheWriter
+        {
+            private readonly List<string> _captured;
+
+            public CapturingWriter(List<string> captured)
+            {
+                _captured = captured;
+            }
+
+            public void Write(string rawJson, FlagsEvaluationContext context)
+            {
+                _captured.Add(rawJson);
+            }
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
@@ -148,12 +148,93 @@ namespace Datadog.Unity.Flags.Tests
                 "CachedAt must be non-null after write→read round-trip (LIFE-02)");
         }
 
+        // ── Context restoration after bootstrap ───────────────────────────
+
+        [Test]
+        public void Bootstrap_EnvelopeWithContext_RepositoryContextIsRestored()
+        {
+            var repo = new FlagsRepository();
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+                Context = new FlagsCacheEnvelopeDto.FlagsEvaluationContextDto
+                {
+                    TargetingKey = "user-5",
+                },
+            });
+
+            MakeClient(cacheReader: reader, repository: repo);
+
+            Assert.IsNotNull(repo.Context, "Context must be non-null after bootstrap with envelope context");
+            Assert.AreEqual("user-5", repo.Context.TargetingKey,
+                "TargetingKey must be restored from envelope context");
+        }
+
+        [Test]
+        public void Bootstrap_EnvelopeWithContext_EmptyTargetingKey_RepositoryContextIsNull()
+        {
+            var repo = new FlagsRepository();
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+                Context = new FlagsCacheEnvelopeDto.FlagsEvaluationContextDto
+                {
+                    TargetingKey = string.Empty,
+                },
+            });
+
+            MakeClient(cacheReader: reader, repository: repo);
+
+            Assert.IsNull(repo.Context, "Context must be null when envelope has empty TargetingKey");
+        }
+
+        [Test]
+        public void Bootstrap_EnvelopeWithNullContext_RepositoryContextIsNull()
+        {
+            var repo = new FlagsRepository();
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+                Context = null,
+            });
+
+            MakeClient(cacheReader: reader, repository: repo);
+
+            Assert.IsNull(repo.Context, "Context must be null when envelope.Context is null");
+        }
+
+        [Test]
+        public void Bootstrap_EnvelopeWithContextAndAttributes_AttributesSurvive()
+        {
+            var repo = new FlagsRepository();
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+                Context = new FlagsCacheEnvelopeDto.FlagsEvaluationContextDto
+                {
+                    TargetingKey = "user-5",
+                    Attributes = new System.Collections.Generic.Dictionary<string, string> { { "plan", "pro" } },
+                },
+            });
+
+            MakeClient(cacheReader: reader, repository: repo);
+
+            Assert.IsNotNull(repo.Context, "Context must be non-null after bootstrap");
+            Assert.AreEqual("user-5", repo.Context.TargetingKey, "TargetingKey must survive bootstrap");
+            Assert.AreEqual("pro", repo.Context.Attributes["plan"],
+                "Attributes must survive bootstrap from envelope context");
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────
 
-        private static FlagsClient MakeClient(IFlagsCacheReader cacheReader = null)
+        private static FlagsClient MakeClient(IFlagsCacheReader cacheReader = null, FlagsRepository repository = null)
         {
             return new FlagsClient(
-                repository: new FlagsRepository(),
+                repository: repository ?? new FlagsRepository(),
                 exposureTracker: null,
                 evaluationAggregator: null,
                 fetcher: null,

--- a/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
@@ -173,7 +173,7 @@ namespace Datadog.Unity.Flags.Tests
                 _envelope = envelope;
             }
 
-            public FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context) => _envelope;
+            public FlagsCacheEnvelopeDto? Read(FlagsEvaluationContext context) => _envelope;
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs
@@ -1,0 +1,179 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using Datadog.Unity.Logs;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    /// <summary>
+    /// Tests for FlagsClient bootstrap-from-cache behavior (LIFE-01, LIFE-02).
+    /// </summary>
+    public class FlagsBootstrapTests
+    {
+        // Minimal valid server response payload that ParseResponse accepts without returning null.
+        // Structure: {"data":{"attributes":{"flags":{"flag-key":{...}}}}}
+        private const string MinimalValidPayloadEmpty =
+            "{\"data\":{\"attributes\":{\"flags\":{}}}}";
+
+        private const string ValidPayloadWithBoolFlag =
+            "{\"data\":{\"attributes\":{\"flags\":{" +
+            "\"show-feature\":{\"variationType\":\"boolean\",\"variationValue\":true,\"doLog\":true,\"allocationKey\":\"alloc-1\",\"variationKey\":\"treatment\",\"reason\":\"TARGETING_MATCH\"}" +
+            "}}}}";
+
+        // ── Test 1: cache hit with valid data → State == Ready and value returned ──
+
+        [Test]
+        public void Bootstrap_ValidCacheHit_StateIsReady()
+        {
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = MinimalValidPayloadEmpty,
+            });
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.Ready, client.State,
+                "State must be Ready after bootstrap with valid cache data");
+        }
+
+        [Test]
+        public void Bootstrap_ValidCacheHit_GetBooleanValueReturnsCachedValue()
+        {
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = ValidPayloadWithBoolFlag,
+            });
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.Ready, client.State,
+                "State must be Ready after bootstrap with valid flag payload");
+            Assert.IsTrue(client.GetBooleanValue("show-feature", false),
+                "GetBooleanValue must return cached flag value after bootstrap");
+        }
+
+        // ── Test 2: cache miss → State == NotReady ─────────────────────────
+
+        [Test]
+        public void Bootstrap_CacheMiss_StateIsNotReady()
+        {
+            var reader = new FakeReader(null);
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.NotReady, client.State,
+                "State must remain NotReady when cache returns null");
+        }
+
+        // ── Test 3: corrupt payload → State == NotReady ────────────────────
+
+        [Test]
+        public void Bootstrap_CorruptPayload_StateIsNotReady()
+        {
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = "not-valid-json{{{{",
+            });
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.NotReady, client.State,
+                "State must remain NotReady when cached payload is corrupt");
+        }
+
+        // ── Test 4: null cacheReader → State == NotReady (existing behavior) ──
+
+        [Test]
+        public void Bootstrap_NullCacheReader_StateIsNotReady()
+        {
+            var client = MakeClient(cacheReader: null);
+
+            Assert.AreEqual(FlagsClientState.NotReady, client.State,
+                "State must remain NotReady when no cacheReader is provided");
+        }
+
+        // ── Test 5: empty/null payload → State == NotReady ────────────────
+
+        [Test]
+        public void Bootstrap_EmptyPayload_StateIsNotReady()
+        {
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = null,
+            });
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.NotReady, client.State,
+                "State must remain NotReady when cached envelope has null Payload");
+        }
+
+        [Test]
+        public void Bootstrap_EmptyStringPayload_StateIsNotReady()
+        {
+            var reader = new FakeReader(new FlagsCacheEnvelopeDto
+            {
+                CachedAt = "2025-01-01T00:00:00Z",
+                Payload = string.Empty,
+            });
+
+            var client = MakeClient(cacheReader: reader);
+
+            Assert.AreEqual(FlagsClientState.NotReady, client.State,
+                "State must remain NotReady when cached envelope has empty Payload");
+        }
+
+        // ── Test 6: LIFE-02 round-trip — CachedAt survives write→read ──────
+
+        [Test]
+        public void Bootstrap_CachedAt_SurvivesWriteReadRoundTrip()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext("user-1");
+
+            cacheStore.Write(MinimalValidPayloadEmpty, context);
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+
+            Assert.IsNotNull(envelope, "Read must return an envelope after Write");
+            Assert.IsFalse(string.IsNullOrEmpty(envelope.CachedAt),
+                "CachedAt must be non-null after write→read round-trip (LIFE-02)");
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────
+
+        private static FlagsClient MakeClient(IFlagsCacheReader cacheReader = null)
+        {
+            return new FlagsClient(
+                repository: new FlagsRepository(),
+                exposureTracker: null,
+                evaluationAggregator: null,
+                fetcher: null,
+                logger: null,
+                trackExposures: false,
+                trackEvaluations: false,
+                onExposure: null,
+                cacheReader: cacheReader);
+        }
+
+        private class FakeReader : IFlagsCacheReader
+        {
+            private readonly FlagsCacheEnvelopeDto _envelope;
+
+            public FakeReader(FlagsCacheEnvelopeDto envelope)
+            {
+                _envelope = envelope;
+            }
+
+            public FlagsCacheEnvelopeDto Read(FlagsEvaluationContext context) => _envelope;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsBootstrapTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f752006e90de49c6b2dc24a6088b8917
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
@@ -141,6 +141,58 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsTrue(logSink.WarnEmitted, "Exception in store should emit a warn log");
         }
 
+        // ── Write using DictionaryKeyValueStore (reusable test double) ────────
+
+        [Test]
+        public void Write_SmallPayload_DictionaryStore_HasOneEntry()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext("user-1");
+
+            cacheStore.Write("{}", context);
+
+            Assert.AreEqual(1, store.Store.Count, "Store must have exactly one entry after small write");
+            var expectedKey = FlagsCacheStore.ComputeKey("us1", "prod", "abcdefghij");
+            Assert.IsTrue(store.Store.ContainsKey(expectedKey), "Store key must match ComputeKey output");
+        }
+
+        [Test]
+        public void Write_LargePayload_DictionaryStore_HasOneEntry_EmitsWarn()
+        {
+            var store = new DictionaryKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            // 401 * 1024 raw bytes: envelope overhead pushes the serialized byte count above 400 KB.
+            var bigJson = "{\"data\":\"" + new string('x', 401 * 1024) + "\"}";
+
+            cacheStore.Write(bigJson, context);
+
+            Assert.AreEqual(1, store.Store.Count, "Large payload within skip threshold must still write");
+            Assert.IsTrue(logSink.WarnEmitted, "Warn log must be emitted for large payload");
+            Assert.IsTrue(logSink.LastWarnMessage.Contains("large"), "Warn message must contain 'large'");
+        }
+
+        [Test]
+        public void Write_OversizedPayload_DictionaryStore_IsEmpty()
+        {
+            var store = new DictionaryKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            // 501 * 1024 raw bytes: envelope byte count exceeds SkipThresholdBytes.
+            var bigJson = "{\"data\":\"" + new string('x', 501 * 1024) + "\"}";
+
+            cacheStore.Write(bigJson, context);
+
+            Assert.AreEqual(0, store.Store.Count, "Oversized payload must not be written to store");
+            Assert.IsTrue(logSink.WarnEmitted, "Warn log must be emitted when write is skipped");
+            Assert.IsTrue(logSink.LastWarnMessage.Contains("skipped"), "Warn message must contain 'skipped'");
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────
 
         private class FakeKeyValueStore : IKeyValueStore

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
@@ -193,6 +193,84 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsTrue(logSink.LastWarnMessage.Contains("skipped"), "Warn message must contain 'skipped'");
         }
 
+        // ── Read: populated store returns correct envelope ─────────────────
+
+        [Test]
+        public void Read_PopulatedStore_ReturnsEnvelopeWithCorrectFields()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext("user-1");
+            cacheStore.Write("{\"data\":\"test\"}", context);
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+
+            Assert.IsNotNull(envelope, "Read must return a non-null envelope when cache is populated");
+            Assert.IsFalse(string.IsNullOrEmpty(envelope.CachedAt), "CachedAt must be set");
+            Assert.AreEqual("{\"data\":\"test\"}", envelope.Payload, "Payload must match the written raw JSON");
+        }
+
+        // ── Read: empty store returns null ──────────────────────────────────
+
+        [Test]
+        public void Read_EmptyStore_ReturnsNull()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+
+            Assert.IsNull(envelope, "Read must return null when no cached data exists");
+        }
+
+        // ── Read: corrupt JSON returns null and does not throw ─────────────
+
+        [Test]
+        public void Read_CorruptJson_ReturnsNullAndDoesNotThrow()
+        {
+            var store = new DictionaryKeyValueStore();
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", "abcdefghij");
+            store.SetString(key, "not-valid-json{{{{");
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+
+            FlagsCacheEnvelopeDto envelope = null;
+            Assert.DoesNotThrow(() => envelope = ((IFlagsCacheReader)cacheStore).Read(null));
+            Assert.IsNull(envelope, "Read must return null for corrupt JSON");
+        }
+
+        // ── Read: uses same key as Write ────────────────────────────────────
+
+        [Test]
+        public void Read_UsesSameKeyAsWrite()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext("user-1");
+            cacheStore.Write("{}", context);
+
+            // The key used by Read must be the same computed key used by Write.
+            var expectedKey = FlagsCacheStore.ComputeKey("us1", "prod", "abcdefghij");
+            Assert.IsTrue(store.Store.ContainsKey(expectedKey), "Write must have stored under ComputeKey");
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+            Assert.IsNotNull(envelope, "Read must retrieve the value stored by Write");
+        }
+
+        // ── Read: null logger does not throw ───────────────────────────────
+
+        [Test]
+        public void Read_NullLogger_DoesNotThrow()
+        {
+            var store = new DictionaryKeyValueStore();
+            // Write corrupt data to trigger the catch/log branch
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", "token");
+            store.SetString(key, "{{bad");
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "token", null);
+
+            Assert.DoesNotThrow(() => ((IFlagsCacheReader)cacheStore).Read(null));
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────
 
         private class FakeKeyValueStore : IKeyValueStore

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Unity.Flags.Tests
         public void ComputeKey_LongToken_TakesLastEightChars()
         {
             var key = FlagsCacheStore.ComputeKey("us1", "prod", "abcdefghij");
-            Assert.AreEqual("dd_flags_v1_us1_prod_ghij", key);
+            Assert.AreEqual("dd_flags_v1_us1_prod_cdefghij", key);
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Datadog.Unity.Flags.Tests
 
             cacheStore.Write("{}", context);
 
-            Assert.AreEqual("dd_flags_v1_us1_prod_ghij", store.LastSetStringKey);
+            Assert.AreEqual("dd_flags_v1_us1_prod_cdefghij", store.LastSetStringKey);
         }
 
         // ── Write: null logger does not throw ──────────────────────────────

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Unity.Logs;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class FlagsCacheStoreTests
+    {
+        // ── Key computation ────────────────────────────────────────────────
+
+        [Test]
+        public void ComputeKey_LongToken_TakesLastEightChars()
+        {
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", "abcdefghij");
+            Assert.AreEqual("dd_flags_v1_us1_prod_ghij", key);
+        }
+
+        [Test]
+        public void ComputeKey_ShortToken_UsedVerbatim()
+        {
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", "short");
+            Assert.AreEqual("dd_flags_v1_us1_prod_short", key);
+        }
+
+        [Test]
+        public void ComputeKey_NullToken_TreatedAsEmpty()
+        {
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", null);
+            Assert.AreEqual("dd_flags_v1_us1_prod_", key);
+        }
+
+        [Test]
+        public void ComputeKey_ExactlyEightChars_UsedVerbatim()
+        {
+            var key = FlagsCacheStore.ComputeKey("us1", "prod", "12345678");
+            Assert.AreEqual("dd_flags_v1_us1_prod_12345678", key);
+        }
+
+        // ── Write: small payload (< 400 KB) ────────────────────────────────
+
+        [Test]
+        public void Write_SmallPayload_CallsSetStringAndSave_NoLogEmitted()
+        {
+            var store = new FakeKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            cacheStore.Write("{\"flags\":{}}", context);
+
+            Assert.AreEqual(1, store.SetStringCallCount, "SetString must be called once");
+            Assert.AreEqual(1, store.SaveCallCount, "Save must be called once");
+            Assert.IsFalse(logSink.WarnEmitted, "No warn log for small payloads");
+        }
+
+        // ── Write: warn threshold (>= 400 KB but < 500 KB) ─────────────────
+
+        [Test]
+        public void Write_401KbPayload_CallsSetStringAndSave_EmitsWarnLog()
+        {
+            var store = new FakeKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            // Build a rawJson large enough that the serialized envelope will be >= 400 KB.
+            // The envelope adds overhead ("cachedAt" key + ISO timestamp ~40 chars, "payload" key).
+            // Use 401 * 1024 = 410,624 bytes of ASCII to ensure the threshold is crossed.
+            var bigJson = "{\"data\":\"" + new string('x', 401 * 1024) + "\"}";
+
+            cacheStore.Write(bigJson, context);
+
+            Assert.AreEqual(1, store.SetStringCallCount, "SetString must be called");
+            Assert.AreEqual(1, store.SaveCallCount, "Save must be called");
+            Assert.IsTrue(logSink.WarnEmitted, "Warn log must be emitted at 401 KB");
+            Assert.IsTrue(logSink.LastWarnMessage.Contains("large"), "Warn message must contain 'large'");
+        }
+
+        // ── Write: skip threshold (>= 500 KB) ──────────────────────────────
+
+        [Test]
+        public void Write_501KbPayload_SkipsWrite_EmitsWarnWithSkipped()
+        {
+            var store = new FakeKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            var bigJson = "{\"data\":\"" + new string('x', 501 * 1024) + "\"}";
+
+            cacheStore.Write(bigJson, context);
+
+            Assert.AreEqual(0, store.SetStringCallCount, "SetString must NOT be called at 501 KB");
+            Assert.AreEqual(0, store.SaveCallCount, "Save must NOT be called at 501 KB");
+            Assert.IsTrue(logSink.WarnEmitted, "Warn log must be emitted at 501 KB");
+            Assert.IsTrue(logSink.LastWarnMessage.Contains("skipped"), "Warn message must contain 'skipped'");
+        }
+
+        // ── Write: correct PlayerPrefs key ─────────────────────────────────
+
+        [Test]
+        public void Write_UsesComputedKey()
+        {
+            var store = new FakeKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext("user-1");
+
+            cacheStore.Write("{}", context);
+
+            Assert.AreEqual("dd_flags_v1_us1_prod_ghij", store.LastSetStringKey);
+        }
+
+        // ── Write: null logger does not throw ──────────────────────────────
+
+        [Test]
+        public void Write_NullLogger_DoesNotThrow()
+        {
+            var store = new FakeKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "token", null);
+            var context = new FlagsEvaluationContext("user-1");
+
+            Assert.DoesNotThrow(() => cacheStore.Write("{}", context));
+        }
+
+        // ── Write: exception in store does not propagate ───────────────────
+
+        [Test]
+        public void Write_StoreThrows_ExceptionCaughtAndWarnLogged()
+        {
+            var store = new ThrowingKeyValueStore();
+            var logSink = new FakeLogger();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "token", logSink);
+            var context = new FlagsEvaluationContext("user-1");
+
+            Assert.DoesNotThrow(() => cacheStore.Write("{}", context));
+            Assert.IsTrue(logSink.WarnEmitted, "Exception in store should emit a warn log");
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────
+
+        private class FakeKeyValueStore : IKeyValueStore
+        {
+            public int SetStringCallCount { get; private set; }
+            public int SaveCallCount { get; private set; }
+            public string LastSetStringKey { get; private set; }
+
+            public string GetString(string key, string defaultValue) => defaultValue;
+
+            public void SetString(string key, string value)
+            {
+                SetStringCallCount++;
+                LastSetStringKey = key;
+            }
+
+            public void DeleteKey(string key) { }
+
+            public void Save() => SaveCallCount++;
+        }
+
+        private class ThrowingKeyValueStore : IKeyValueStore
+        {
+            public string GetString(string key, string defaultValue) => defaultValue;
+            public void SetString(string key, string value) => throw new System.Exception("store exploded");
+            public void DeleteKey(string key) { }
+            public void Save() { }
+        }
+
+        private class FakeLogger : Datadog.Unity.Core.IInternalLogger
+        {
+            public bool WarnEmitted { get; private set; }
+            public string LastWarnMessage { get; private set; }
+
+            public void Log(DdLogLevel level, string message)
+            {
+                if (level == DdLogLevel.Warn)
+                {
+                    WarnEmitted = true;
+                    LastWarnMessage = message;
+                }
+            }
+
+            public void TelemetryDebug(string message) { }
+            public void TelemetryError(string message, System.Exception exception) { }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs
@@ -271,6 +271,43 @@ namespace Datadog.Unity.Flags.Tests
             Assert.DoesNotThrow(() => ((IFlagsCacheReader)cacheStore).Read(null));
         }
 
+        // ── Context round-trip ─────────────────────────────────────────────
+
+        [Test]
+        public void Write_WithContext_ContextSurvivesRoundTrip()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+            var context = new FlagsEvaluationContext(
+                "user-42",
+                new Dictionary<string, object> { { "plan", "pro" } });
+
+            cacheStore.Write("{}", context);
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+
+            Assert.IsNotNull(envelope, "Read must return a non-null envelope");
+            Assert.IsNotNull(envelope.Context, "Context must be non-null after round-trip");
+            Assert.AreEqual("user-42", envelope.Context.TargetingKey,
+                "TargetingKey must survive write→read round-trip");
+            Assert.AreEqual("pro", envelope.Context.Attributes["plan"],
+                "Attributes must survive write→read round-trip");
+        }
+
+        [Test]
+        public void Write_WithNullContext_ContextIsNull()
+        {
+            var store = new DictionaryKeyValueStore();
+            var cacheStore = new FlagsCacheStore(store, "us1", "prod", "abcdefghij", null);
+
+            cacheStore.Write("{}", null);
+
+            var envelope = ((IFlagsCacheReader)cacheStore).Read(null);
+
+            Assert.IsNotNull(envelope, "Read must return a non-null envelope");
+            Assert.IsNull(envelope.Context, "Context must be null when written with null context");
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────
 
         private class FakeKeyValueStore : IKeyValueStore

--- a/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsCacheStoreTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7abf1826f5154597b065b72dc593ecf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Adds persistent cache layer to the flags module (PlayerPrefs-backed)
- Cache-first bootstrap: cached flag assignments + evaluation context restored immediately on init
- SetEvaluationContext triggers network refresh, updates both repository and cache
- Matches Android/iOS SDK caching patterns

## Changes

### Phase 1: Storage Layer
- `IKeyValueStore` abstraction over PlayerPrefs with `DictionaryKeyValueStore` test double
- `FlagsCacheStore` with key scoping (`dd_flags_v1_{site}_{env}_{token[-8:]}`), tvOS size gate (warn 400KB, skip 500KB)
- `FlagsCacheEnvelopeDto` (cachedAt + payload + context)
- AOT preservation via `link.xml` and `[Preserve] EnsureTypes()`

### Phase 2: Bootstrap
- `IFlagsCacheReader` interface, `FlagsCacheStore.Read()` implementation
- `FlagsClient.BootstrapFromCache()` in constructor — synchronous cache-first model
- State transitions to Ready on valid cache, stays NotReady on miss

### Phase 3: Context in Cache
- Evaluation context stored alongside flags in cache envelope
- Bootstrap restores both flags AND context (enables exposure tracking immediately)
- `SetEvaluationContext` refreshes from network, writes updated envelope

## Verification

Structural verification passed locally (no Unity license for EditMode test execution):
- 10/10 source files present with .meta companions
- All interfaces implemented (IKeyValueStore, IFlagsCacheWriter, IFlagsCacheReader)
- FlagsCacheStore implements both reader and writer
- BootstrapFromCache wired in FlagsClient constructor
- DdFlags.CreateClient passes cacheStore as both writer and reader
- Context field in FlagsCacheEnvelopeDto with nested DTO
- link.xml preserves both outer and nested types for AOT
- 34 unit tests (20 FlagsCacheStoreTests + 14 FlagsBootstrapTests)

## Test plan

- [ ] Unity EditMode tests pass (FlagsCacheStoreTests, FlagsBootstrapTests)
- [ ] CI green
- [ ] Manual: cold start with cached data shows flag values before network response