### PR TITLE
RUM-17730 Add Performance Timeseries configuration to RUM

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Upgraded iOS SDK dependency to 3.11.1 and Android SDK dependency to 3.10.0.
+* Upgraded iOS SDK dependency to 3.16.0 and Android SDK dependency to 3.10.0.
+* **Experimental:** Add `EnableTimeseries` and `TimeseriesCollectTypes` RUM configuration options to collect memory and CPU timeseries events (iOS only for now). This API is experimental and may change without notice.
 * **Breaking:** `SetUserInfo` now requires a non-null `id`. Calls with a null `id` are rejected with a warning log.
 * Fixed Android builds on Unity 2022 and older: `androidx.core 1.15.0+` ships Java 21 bytecode that D8 in AGP 7.x cannot process; the Gradle post-processor now pins `androidx.core` to 1.13.1 in the root build.gradle for affected Unity versions.
 

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -113,6 +113,18 @@ namespace Datadog.Unity.Editor
             GUILayout.FlexibleSpace();
             EditorGUILayout.EndHorizontal();
 
+            EditorGUILayout.BeginHorizontal();
+            _options.EnableTimeseries = EditorGUILayout.ToggleLeft(
+                new GUIContent("Enable Timeseries", DatadogHelpStrings.EnableTimeseriesTooltip),
+                _options.EnableTimeseries);
+            EditorGUI.BeginDisabledGroup(!_options.EnableTimeseries);
+            _options.TimeseriesBatchSize = EditorGUILayout.IntField(
+                new GUIContent("Batch Size", DatadogHelpStrings.TimeseriesBatchSizeTooltip),
+                _options.TimeseriesBatchSize);
+            EditorGUI.EndDisabledGroup();
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+
             GUILayout.Space(12.0f);
 
             GUILayout.Label(new GUIContent("First Party Hosts", DatadogHelpStrings.FirstPartyHostsTooltip), EditorStyles.boldLabel);

--- a/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
+++ b/packages/Datadog.Unity/Editor/DatadogConfigurationWindow.cs
@@ -115,12 +115,12 @@ namespace Datadog.Unity.Editor
 
             EditorGUILayout.BeginHorizontal();
             _options.EnableTimeseries = EditorGUILayout.ToggleLeft(
-                new GUIContent("Enable Timeseries", DatadogHelpStrings.EnableTimeseriesTooltip),
+                new GUIContent("Enable Timeseries (Experimental)", DatadogHelpStrings.EnableTimeseriesTooltip),
                 _options.EnableTimeseries);
             EditorGUI.BeginDisabledGroup(!_options.EnableTimeseries);
-            _options.TimeseriesBatchSize = EditorGUILayout.IntField(
-                new GUIContent("Batch Size", DatadogHelpStrings.TimeseriesBatchSizeTooltip),
-                _options.TimeseriesBatchSize);
+            _options.TimeseriesTypes = (TimeseriesTypes)EditorGUILayout.EnumFlagsField(
+                new GUIContent("Collect Types", DatadogHelpStrings.TimeseriesTypesTooltip),
+                _options.TimeseriesTypes);
             EditorGUI.EndDisabledGroup();
             GUILayout.FlexibleSpace();
             EditorGUILayout.EndHorizontal();

--- a/packages/Datadog.Unity/Editor/DatadogDependencies.xml
+++ b/packages/Datadog.Unity/Editor/DatadogDependencies.xml
@@ -8,9 +8,9 @@
     </androidPackage>
   </androidPackages>
   <iosPods>
-    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="3.11.1" />
-    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="3.11.1" />
-    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="3.11.1" />
-    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="3.11.1" />
+    <iosPod name="DatadogCore" bitcodeEnabled="false" minTargetSdk="12.0" version="3.16.0" />
+    <iosPod name="DatadogLogs" bitcodeEnabled="false" minTargetSdk="12.0" version="3.16.0" />
+    <iosPod name="DatadogRUM" bitcodeEnabled="false" minTargetSdk="12.0" version="3.16.0" />
+    <iosPod name="DatadogCrashReporting" bitcodeEnabled="false" minTargetSdk="12.0" version="3.16.0" />
   </iosPods>
 </dependencies>

--- a/packages/Datadog.Unity/Editor/DatadogHelpStrings.cs
+++ b/packages/Datadog.Unity/Editor/DatadogHelpStrings.cs
@@ -97,5 +97,12 @@ namespace Datadog.Unity.Editor
 
         public const string TelemetrySampleRateTooltip =
             "The percentage rate at which Datadog sends internal telemetry data. A value of 100 means all telemetry data is sampled and sent to Datadog.";
+
+        public const string EnableTimeseriesTooltip =
+            "Enables collection of memory and CPU timeseries events throughout the session. Requires Vitals Update Frequency to be " +
+            "set to a value other than 'None' on iOS.";
+
+        public const string TimeseriesBatchSizeTooltip =
+            "The number of timeseries samples collected before a batch is flushed to Datadog.";
     }
 }

--- a/packages/Datadog.Unity/Editor/DatadogHelpStrings.cs
+++ b/packages/Datadog.Unity/Editor/DatadogHelpStrings.cs
@@ -99,10 +99,10 @@ namespace Datadog.Unity.Editor
             "The percentage rate at which Datadog sends internal telemetry data. A value of 100 means all telemetry data is sampled and sent to Datadog.";
 
         public const string EnableTimeseriesTooltip =
-            "Enables collection of memory and CPU timeseries events throughout the session. Requires Vitals Update Frequency to be " +
-            "set to a value other than 'None' on iOS.";
+            "Experimental: Enables collection of memory and CPU timeseries events, sampled every second and uploaded scoped to " +
+            "the RUM session. This API is experimental and may change without notice.";
 
-        public const string TimeseriesBatchSizeTooltip =
-            "The number of timeseries samples collected before a batch is flushed to Datadog.";
+        public const string TimeseriesTypesTooltip =
+            "Experimental: The specific timeseries types to collect. Defaults to collecting all available types.";
     }
 }

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -179,6 +179,12 @@ func initializeDatadog() {{
                 sb.AppendLine(
                     $"    rumConfig.appHangThreshold = {appHangThreshold}");
 
+                if (options.EnableTimeseries)
+                {
+                    sb.AppendLine("    rumConfig.enableTimeseries = true");
+                    sb.AppendLine($"    rumConfig.timeseriesBatchSize = {options.TimeseriesBatchSize}");
+                }
+
                 // Uncomment to enable RUM Configuration Telemetry
                 // sb.AppendLine(@"    rumConfig._internal_mutation {
                 //     $0.configurationTelemetrySampleRate = 100.0

--- a/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
+++ b/packages/Datadog.Unity/Editor/iOS/PostBuildProcess.cs
@@ -98,7 +98,7 @@ namespace Datadog.Unity.Editor.iOS
 import Foundation
 import DatadogCore
 import DatadogLogs
-import DatadogRUM
+@_spi(Experimental) import DatadogRUM
 import DatadogCrashReporting
 
 @_cdecl(""initializeDatadog"")
@@ -181,8 +181,8 @@ func initializeDatadog() {{
 
                 if (options.EnableTimeseries)
                 {
-                    sb.AppendLine("    rumConfig.enableTimeseries = true");
-                    sb.AppendLine($"    rumConfig.timeseriesBatchSize = {options.TimeseriesBatchSize}");
+                    sb.AppendLine(
+                        $"    rumConfig.timeseries = RUM.Configuration.Timeseries(collectTypes: {GetSwiftTimeseriesCollectTypes(options.TimeseriesTypes)})");
                 }
 
                 // Uncomment to enable RUM Configuration Telemetry
@@ -347,6 +347,27 @@ find . -type d -name '*.dSYM' -exec cp -r '{{}}' ""$PROJECT_DIR/{SymbolAssemblyB
                 VitalsUpdateFrequency.Frequent => ".frequent",
                 _ => "nil",
             };
+        }
+
+        private static string GetSwiftTimeseriesCollectTypes(TimeseriesTypes collectTypes)
+        {
+            if (collectTypes == TimeseriesTypes.All)
+            {
+                return "nil";
+            }
+
+            var swiftTypes = new List<string>();
+            if (collectTypes.HasFlag(TimeseriesTypes.Memory))
+            {
+                swiftTypes.Add(".memory");
+            }
+
+            if (collectTypes.HasFlag(TimeseriesTypes.Cpu))
+            {
+                swiftTypes.Add(".cpu");
+            }
+
+            return $"[{string.Join(", ", swiftTypes)}]";
         }
 
         private static string GetSwiftSite(DatadogSite site)

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -132,6 +132,14 @@ namespace Datadog.Unity.Android
                 using var updateFrequency = DatadogConfigurationHelpers.GetVitalsUpdateFrequency(options.VitalsUpdateFrequency);
                 rumConfigBuilder.Call<AndroidJavaObject>("setVitalsUpdateFrequency", updateFrequency);
 
+                if (options.EnableTimeseries)
+                {
+                    using var timeseriesConfigBuilder = new AndroidJavaObject("com.datadog.android.rum.timeseries.TimeseriesConfiguration$Builder");
+                    timeseriesConfigBuilder.Call<AndroidJavaObject>("setBufferSize", options.TimeseriesBatchSize);
+                    using var timeseriesConfig = timeseriesConfigBuilder.Call<AndroidJavaObject>("build");
+                    rumConfigBuilder.Call<AndroidJavaObject>("setTimeseriesConfiguration", timeseriesConfig);
+                }
+
                 switch (options.TrackNonFatalAnrs)
                 {
                     case NonFatalAnrDetectionOption.Disabled:

--- a/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
+++ b/packages/Datadog.Unity/Runtime/Android/DatadogAndroidPlatform.cs
@@ -132,12 +132,12 @@ namespace Datadog.Unity.Android
                 using var updateFrequency = DatadogConfigurationHelpers.GetVitalsUpdateFrequency(options.VitalsUpdateFrequency);
                 rumConfigBuilder.Call<AndroidJavaObject>("setVitalsUpdateFrequency", updateFrequency);
 
+                // Experimental: Timeseries is not yet released on Android (still on feature/timeseries in dd-sdk-android).
+                // The wiring below is left unimplemented until the native API ships and its shape (expected to mirror
+                // iOS's `collectTypes`-based RUM.Configuration.Timeseries) is confirmed.
                 if (options.EnableTimeseries)
                 {
-                    using var timeseriesConfigBuilder = new AndroidJavaObject("com.datadog.android.rum.timeseries.TimeseriesConfiguration$Builder");
-                    timeseriesConfigBuilder.Call<AndroidJavaObject>("setBufferSize", options.TimeseriesBatchSize);
-                    using var timeseriesConfig = timeseriesConfigBuilder.Call<AndroidJavaObject>("build");
-                    rumConfigBuilder.Call<AndroidJavaObject>("setTimeseriesConfiguration", timeseriesConfig);
+                    Debug.LogWarning("Datadog: EnableTimeseries is not yet supported on Android.");
                 }
 
                 switch (options.TrackNonFatalAnrs)

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -248,6 +248,8 @@ namespace Datadog.Unity
         public NonFatalAnrDetectionOption TrackNonFatalAnrs = NonFatalAnrDetectionOption.Disabled;
         public bool TrackNonFatalAppHangs = false;
         public float NonFatalAppHangThreshold = 0.25f;
+        public bool EnableTimeseries;
+        public int TimeseriesBatchSize = 120;
 
         // Advanced RUM
         public float TelemetrySampleRate;

--- a/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
+++ b/packages/Datadog.Unity/Runtime/DatadogConfigurationOptions.cs
@@ -191,6 +191,34 @@ namespace Datadog.Unity
         Rare,
     }
 
+    /// <summary>
+    /// Experimental: The timeseries types that can be collected during a RUM session.
+    /// This API is experimental and may change without notice.
+    /// </summary>
+    [Flags]
+    public enum TimeseriesTypes
+    {
+        /// <summary>
+        /// Collect no timeseries types.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Collect memory footprint and percentage of total device RAM.
+        /// </summary>
+        Memory = 1 << 0,
+
+        /// <summary>
+        /// Collect CPU usage as a percentage.
+        /// </summary>
+        Cpu = 1 << 1,
+
+        /// <summary>
+        /// Collect all available timeseries types. This is the default when timeseries collection is enabled.
+        /// </summary>
+        All = Memory | Cpu,
+    }
+
     [Serializable]
     public class FirstPartyHostOption
     {
@@ -248,8 +276,9 @@ namespace Datadog.Unity
         public NonFatalAnrDetectionOption TrackNonFatalAnrs = NonFatalAnrDetectionOption.Disabled;
         public bool TrackNonFatalAppHangs = false;
         public float NonFatalAppHangThreshold = 0.25f;
+        // Experimental: Timeseries collection. This API is experimental and may change without notice.
         public bool EnableTimeseries;
-        public int TimeseriesBatchSize = 120;
+        public TimeseriesTypes TimeseriesTypes = TimeseriesTypes.All;
 
         // Advanced RUM
         public float TelemetrySampleRate;

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -75,7 +75,7 @@ namespace Datadog.Unity.Editor.Tests
             Assert.AreEqual(false, options.TrackNonFatalAppHangs);
             Assert.AreEqual(0.25f, options.NonFatalAppHangThreshold);
             Assert.IsFalse(options.EnableTimeseries);
-            Assert.AreEqual(120, options.TimeseriesBatchSize);
+            Assert.AreEqual(TimeseriesTypes.All, options.TimeseriesTypes);
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/DatadogConfigurationOptionsTests.cs
@@ -74,6 +74,8 @@ namespace Datadog.Unity.Editor.Tests
             Assert.AreEqual(NonFatalAnrDetectionOption.Disabled, options.TrackNonFatalAnrs);
             Assert.AreEqual(false, options.TrackNonFatalAppHangs);
             Assert.AreEqual(0.25f, options.NonFatalAppHangThreshold);
+            Assert.IsFalse(options.EnableTimeseries);
+            Assert.AreEqual(120, options.TimeseriesBatchSize);
         }
     }
 }

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -420,6 +420,47 @@ namespace Datadog.Unity.Editor.iOS
         }
 
         [Test]
+        public void GenerateOptionsFileDoesNotWriteTimeseriesWhenDisabled()
+        {
+            var options = new DatadogConfigurationOptions()
+            {
+                Enabled = true,
+                RumEnabled = true,
+                EnableTimeseries = false,
+            };
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var enableTimeseriesLines = lines.Where(l => l.Contains("enableTimeseries")).ToArray();
+            var batchSizeLines = lines.Where(l => l.Contains("timeseriesBatchSize")).ToArray();
+            Assert.IsEmpty(enableTimeseriesLines);
+            Assert.IsEmpty(batchSizeLines);
+        }
+
+        [TestCase(1)]
+        [TestCase(120)]
+        [TestCase(500)]
+        public void GenerateOptionsFileWritesTimeseriesWhenEnabled(int batchSize)
+        {
+            var options = new DatadogConfigurationOptions()
+            {
+                Enabled = true,
+                RumEnabled = true,
+                EnableTimeseries = true,
+                TimeseriesBatchSize = batchSize,
+            };
+            PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
+
+            var lines = File.ReadAllLines(_initializationFilePath);
+            var enableTimeseriesLines = lines.Where(l => l.Contains("enableTimeseries")).ToArray();
+            var batchSizeLines = lines.Where(l => l.Contains("timeseriesBatchSize")).ToArray();
+            Assert.AreEqual(1, enableTimeseriesLines.Length);
+            Assert.AreEqual("rumConfig.enableTimeseries = true", enableTimeseriesLines.First().Trim());
+            Assert.AreEqual(1, batchSizeLines.Length);
+            Assert.AreEqual($"rumConfig.timeseriesBatchSize = {batchSize}", batchSizeLines.First().Trim());
+        }
+
+        [Test]
         public void AddInitializationToMainAddsDatadogBlocks()
         {
             var importString = "#import";

--- a/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
+++ b/packages/Datadog.Unity/Tests/Editor/iOS/PostBuildProcessTests.cs
@@ -431,33 +431,30 @@ namespace Datadog.Unity.Editor.iOS
             PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
 
             var lines = File.ReadAllLines(_initializationFilePath);
-            var enableTimeseriesLines = lines.Where(l => l.Contains("enableTimeseries")).ToArray();
-            var batchSizeLines = lines.Where(l => l.Contains("timeseriesBatchSize")).ToArray();
-            Assert.IsEmpty(enableTimeseriesLines);
-            Assert.IsEmpty(batchSizeLines);
+            var timeseriesLines = lines.Where(l => l.Contains("rumConfig.timeseries")).ToArray();
+            Assert.IsEmpty(timeseriesLines);
         }
 
-        [TestCase(1)]
-        [TestCase(120)]
-        [TestCase(500)]
-        public void GenerateOptionsFileWritesTimeseriesWhenEnabled(int batchSize)
+        [TestCase(TimeseriesTypes.All, "nil")]
+        [TestCase(TimeseriesTypes.Memory, "[.memory]")]
+        [TestCase(TimeseriesTypes.Cpu, "[.cpu]")]
+        public void GenerateOptionsFileWritesTimeseriesWhenEnabled(TimeseriesTypes collectTypes, string expectedCollectTypes)
         {
             var options = new DatadogConfigurationOptions()
             {
                 Enabled = true,
                 RumEnabled = true,
                 EnableTimeseries = true,
-                TimeseriesBatchSize = batchSize,
+                TimeseriesTypes = collectTypes,
             };
             PostBuildProcess.GenerateInitializationFile(_initializationFilePath, options, null);
 
             var lines = File.ReadAllLines(_initializationFilePath);
-            var enableTimeseriesLines = lines.Where(l => l.Contains("enableTimeseries")).ToArray();
-            var batchSizeLines = lines.Where(l => l.Contains("timeseriesBatchSize")).ToArray();
-            Assert.AreEqual(1, enableTimeseriesLines.Length);
-            Assert.AreEqual("rumConfig.enableTimeseries = true", enableTimeseriesLines.First().Trim());
-            Assert.AreEqual(1, batchSizeLines.Length);
-            Assert.AreEqual($"rumConfig.timeseriesBatchSize = {batchSize}", batchSizeLines.First().Trim());
+            var timeseriesLines = lines.Where(l => l.Contains("rumConfig.timeseries")).ToArray();
+            Assert.AreEqual(1, timeseriesLines.Length);
+            Assert.AreEqual(
+                $"rumConfig.timeseries = RUM.Configuration.Timeseries(collectTypes: {expectedCollectTypes})",
+                timeseriesLines.First().Trim());
         }
 
         [Test]

--- a/samples/Datadog Sample/Assets/Resources/DatadogSettings.asset
+++ b/samples/Datadog Sample/Assets/Resources/DatadogSettings.asset
@@ -39,3 +39,5 @@ MonoBehaviour:
   TrackNonFatalAppHangs: 1
   NonFatalAppHangThreshold: 0.25
   TelemetrySampleRate: 100
+  EnableTimeseries: 1
+  TimeseriesBatchSize: 120


### PR DESCRIPTION
## What and why?

Exposes the native Timeseries RUM feature (dense memory/CPU sampling events) through the public RUM configuration API.

> [!WARNING]
> This is currently blocked from compiling: the pinned native SDK versions (dd-sdk-android 3.10.0, dd-sdk-ios 3.11.1) don't yet contain Timeseries. Do not open this for real review until native work is merged and released.

## Review checklist
- [ ] This pull request has appropriate unit and / or integration tests
- [ ] This pull request references a Github or JIRA issue