### PR TITLE
[FFL-2931] Add composable assignment request transport

### DIFF
--- a/packages/Datadog.Unity/CHANGELOG.md
+++ b/packages/Datadog.Unity/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Add opt-in timeout and retry configuration for Flags assignment requests with bounded jittered backoff and short HTTP 503 `Retry-After` hints. Timeout and retry defaults are both zero, so the SDK makes one initial request without an SDK-added timeout; timeout values above 2,147,483 seconds are capped for compatibility across Unity runtimes.
+* Add an assignment-only transport override with composable timeout and retry
+  helpers. The transport API uses immutable, fully formed request values and
+  fully buffered response values while the SDK owns and disposes native
+  `UnityWebRequest` instances.
 * Upgraded iOS SDK dependency to 3.11.1 and Android SDK dependency to 3.10.0.
 * **Breaking:** `SetUserInfo` now requires a non-null `id`. Calls with a null `id` are rejected with a warning log.
 * Fixed Android builds on Unity 2022 and older: `androidx.core 1.15.0+` ships Java 21 bytecode that D8 in AGP 7.x cannot process; the Gradle post-processor now pins `androidx.core` to 1.13.1 in the root build.gradle for affected Unity versions.

--- a/packages/Datadog.Unity/README.md
+++ b/packages/Datadog.Unity/README.md
@@ -36,6 +36,39 @@ openupm add com.datadoghq.unity
 
 For further instructions on how to set up the Datadog SDK, refer to the [RUM Unity Monitoring Setup documentation](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setup/unity/).
 
+## Feature Flags assignment requests
+
+Feature Flags assignment requests have no SDK-added timeout or retries by
+default (the underlying transport or platform may still impose its own bounds).
+The high-level configuration accepts independent convenience settings:
+
+```csharp
+DdFlags.Enable(new FlagsConfiguration(
+    assignmentRequestTimeoutSeconds: 2,
+    assignmentRequestRetryCount: 2));
+```
+
+For lower-level control, compose an assignment-only transport. A supplied
+transport is used verbatim, replacing the scalar timeout and retry settings:
+
+```csharp
+var assignmentTransport = AssignmentRequestTransports.Default
+    .WithTimeout(2)
+    .WithRetry(2);
+
+DdFlags.Enable(new FlagsConfiguration(assignmentTransport));
+```
+
+`WithTimeout(0)` returns the wrapped transport unchanged. Timeout values above
+2,147,483 seconds are capped for compatibility across Unity runtimes. Timeout
+covers the complete buffered response; at the deadline it requests cancellation
+and completes promptly. Retry creates a fresh native request for every attempt,
+retries transport failures, HTTP 408, and HTTP 5xx, and does not retry HTTP 429.
+The Unity SDK creates and disposes every `UnityWebRequest`; custom transports
+exchange immutable, fully formed request values (including the HTTP method) and
+fully buffered response values, retain ownership of their own resources, and
+must observe cancellation promptly.
+
 ## Contributing
 
 Pull requests are welcome. First, open an issue to discuss what you would like to change.

--- a/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestRetryPolicy.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestRetryPolicy.cs
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Globalization;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Validation and retry-delay policy for assignment requests.
+    /// Kept separate from request execution so every edge case is deterministic and unit-testable.
+    /// </summary>
+    internal static class AssignmentRequestRetryPolicy
+    {
+        internal const int DisabledTimeoutSeconds = 0;
+        // Task.Delay(TimeSpan) on supported Unity runtimes is bounded by an
+        // Int32 millisecond timer. Keep whole seconds safely below that limit.
+        internal const int MaxTimeoutSeconds = int.MaxValue / 1_000;
+        internal const int DefaultRetryCount = 0;
+        internal const int MaxRetryCount = 10;
+        internal const int InitialBackoffMilliseconds = 100;
+        internal const int MaxBackoffMilliseconds = 30_000;
+        internal const int MaxRetryAfterMilliseconds = 30_000;
+
+        internal static int NormalizeTimeoutSeconds(int timeoutSeconds)
+        {
+            return timeoutSeconds < 0
+                ? DisabledTimeoutSeconds
+                : Math.Min(MaxTimeoutSeconds, timeoutSeconds);
+        }
+
+        internal static int NormalizeRetryCount(int retryCount)
+        {
+            return Math.Max(0, Math.Min(MaxRetryCount, retryCount));
+        }
+
+        internal static bool TryGetRetryDelayMilliseconds(
+            AssignmentRequestResult result,
+            long httpCode,
+            int attempt,
+            int retryCount,
+            string retryAfter,
+            DateTimeOffset utcNow,
+            double randomValue,
+            out int retryDelayMilliseconds)
+        {
+            retryDelayMilliseconds = 0;
+
+            if (attempt >= retryCount)
+                return false;
+
+            // HTTP status is authoritative even when a custom transport reports
+            // an inconsistent result classification. Rate limiting is explicitly
+            // not retried by this policy.
+            if (httpCode == 429)
+                return false;
+
+            var retryableTransportError = result == AssignmentRequestResult.ConnectionError ||
+                                          result == AssignmentRequestResult.DataProcessingError;
+            var retryableHttpStatus = httpCode == 408 || (httpCode >= 500 && httpCode <= 599);
+
+            if (!retryableTransportError && !retryableHttpStatus)
+                return false;
+
+            var retryAfterMilliseconds = 0L;
+            if (httpCode == 503 &&
+                TryParseRetryAfterMilliseconds(retryAfter, utcNow, out retryAfterMilliseconds) &&
+                retryAfterMilliseconds > MaxRetryAfterMilliseconds)
+            {
+                return false;
+            }
+
+            var jitterMilliseconds = GetJitterDelayMilliseconds(attempt, randomValue);
+            retryDelayMilliseconds = (int)Math.Min(
+                int.MaxValue,
+                retryAfterMilliseconds + jitterMilliseconds);
+            return true;
+        }
+
+        internal static int GetJitterDelayMilliseconds(int attempt, double randomValue)
+        {
+            var maximum = (int)Math.Min(
+                InitialBackoffMilliseconds * Math.Pow(2, Math.Max(0, attempt)),
+                MaxBackoffMilliseconds);
+
+            if (double.IsNaN(randomValue) || randomValue <= 0)
+                return 0;
+            if (randomValue >= 1)
+                return maximum - 1;
+
+            return (int)Math.Floor(randomValue * maximum);
+        }
+
+        private static bool TryParseRetryAfterMilliseconds(
+            string retryAfter,
+            DateTimeOffset utcNow,
+            out long retryAfterMilliseconds)
+        {
+            retryAfterMilliseconds = 0;
+            if (retryAfter == null)
+                return false;
+
+            var value = retryAfter.Trim();
+            if (value.Length == 0)
+                return false;
+
+            var containsOnlyDigits = true;
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (value[i] < '0' || value[i] > '9')
+                {
+                    containsOnlyDigits = false;
+                    break;
+                }
+            }
+
+            if (containsOnlyDigits)
+            {
+                if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds) ||
+                    seconds > long.MaxValue / 1_000)
+                {
+                    retryAfterMilliseconds = long.MaxValue;
+                    return true;
+                }
+
+                retryAfterMilliseconds = seconds * 1_000;
+                return true;
+            }
+
+            // Reject malformed numeric forms such as -1, 1.5, and 1e3 rather than
+            // letting the permissive date parser interpret them as dates.
+            if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                return false;
+
+            if (!DateTimeOffset.TryParse(
+                    value,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var retryDate))
+            {
+                return false;
+            }
+
+            retryAfterMilliseconds = Math.Max(0, (long)(retryDate - utcNow).TotalMilliseconds);
+            return true;
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestRetryPolicy.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestRetryPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7c94aa870fc4fe0b783fbb42288cab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestTransport.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestTransport.cs
@@ -1,0 +1,456 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine.Networking;
+
+namespace Datadog.Unity.Flags
+{
+    /// <summary>
+    /// Immutable assignment request passed to an <see cref="IAssignmentRequestTransport"/>.
+    /// </summary>
+    public sealed class AssignmentRequest
+    {
+        public AssignmentRequest(
+            string method,
+            string url,
+            string body,
+            IDictionary<string, string> headers)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            Url = url ?? throw new ArgumentNullException(nameof(url));
+            Body = body ?? string.Empty;
+            Headers = new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>(headers ?? new Dictionary<string, string>(),
+                    StringComparer.OrdinalIgnoreCase));
+        }
+
+        public string Method { get; }
+
+        public string Url { get; }
+
+        public string Body { get; }
+
+        public IReadOnlyDictionary<string, string> Headers { get; }
+    }
+
+    /// <summary>
+    /// Transport-level result of an assignment request.
+    /// </summary>
+    public enum AssignmentRequestResult
+    {
+        Success,
+        ConnectionError,
+        ProtocolError,
+        DataProcessingError,
+    }
+
+    /// <summary>
+    /// Immutable, fully buffered response returned by an assignment transport.
+    /// Custom transports must represent retryable connection and data-processing failures with
+    /// <see cref="AssignmentRequestResult.ConnectionError"/> or
+    /// <see cref="AssignmentRequestResult.DataProcessingError"/>. HTTP status is validated
+    /// independently: retry policy recognizes HTTP 408 and 5xx even if a custom transport reports
+    /// an inconsistent result, and assignment parsing still requires a successful 2xx response.
+    /// Unexpected implementation exceptions may be thrown and are not retried by
+    /// <see cref="AssignmentRequestTransports.WithRetry"/>.
+    /// </summary>
+    public sealed class AssignmentResponse
+    {
+        public AssignmentResponse(
+            AssignmentRequestResult result,
+            long statusCode,
+            string body = null,
+            IDictionary<string, string> headers = null)
+        {
+            Result = result;
+            StatusCode = statusCode;
+            Body = body ?? string.Empty;
+            Headers = new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>(headers ?? new Dictionary<string, string>(),
+                    StringComparer.OrdinalIgnoreCase));
+        }
+
+        public AssignmentRequestResult Result { get; }
+
+        public long StatusCode { get; }
+
+        public string Body { get; }
+
+        public IReadOnlyDictionary<string, string> Headers { get; }
+
+        public string GetHeader(string name)
+        {
+            return name != null && Headers.TryGetValue(name, out var value) ? value : null;
+        }
+    }
+
+    /// <summary>
+    /// Sends fully formed assignment requests and returns fully buffered responses.
+    /// Implementations own all native request objects they create and must release them before
+    /// completing the returned task. Callers retain ownership of the transport itself. Expected
+    /// connection and response-processing failures must be returned as an
+    /// <see cref="AssignmentResponse"/> with the corresponding <see cref="AssignmentRequestResult"/>;
+    /// thrown unexpected exceptions are not retried by the retry decorator. A configured transport
+    /// can be shared by multiple flags clients, so implementations must support concurrent calls
+    /// and promptly observe the supplied cancellation token to release in-flight resources.
+    /// </summary>
+    public interface IAssignmentRequestTransport
+    {
+        Task<AssignmentResponse> SendAsync(
+            AssignmentRequest request,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Assignment-only transport building blocks. The default transport uses
+    /// <see cref="UnityWebRequest"/> while keeping its lifecycle private to the SDK.
+    /// </summary>
+    public static class AssignmentRequestTransports
+    {
+        private static readonly IAssignmentRequestTransport DefaultTransport =
+            new UnityWebRequestAssignmentTransport();
+
+        /// <summary>
+        /// SDK-owned UnityWebRequest transport. Each call creates and disposes a fresh request.
+        /// </summary>
+        public static IAssignmentRequestTransport Default => DefaultTransport;
+
+        /// <summary>
+        /// Adds a timeout to each complete assignment request, including response-body download.
+        /// At the deadline, cancellation is requested from the inner transport and the timeout
+        /// completes promptly; the inner transport's cancellation contract is responsible for
+        /// promptly releasing its resources. Values above 2,147,483 seconds are capped for
+        /// compatibility across Unity runtimes. Zero returns <paramref name="inner"/> unchanged.
+        /// </summary>
+        public static IAssignmentRequestTransport WithTimeout(
+            this IAssignmentRequestTransport inner,
+            int timeoutSeconds)
+        {
+            if (inner == null)
+                throw new ArgumentNullException(nameof(inner));
+            if (timeoutSeconds < 0)
+                throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Timeout must not be negative.");
+            return timeoutSeconds == 0
+                ? inner
+                : new TimeoutAssignmentRequestTransport(
+                    inner,
+                    AssignmentRequestRetryPolicy.NormalizeTimeoutSeconds(timeoutSeconds));
+        }
+
+        /// <summary>
+        /// Adds retries after transient assignment request failures.
+        /// </summary>
+        public static IAssignmentRequestTransport WithRetry(
+            this IAssignmentRequestTransport inner,
+            int retries)
+        {
+            return BuildRetryTransport(inner, retries);
+        }
+
+        internal static IAssignmentRequestTransport BuildRetryTransport(
+            IAssignmentRequestTransport inner,
+            int retries,
+            Func<double> randomValue = null,
+            Func<DateTimeOffset> utcNow = null,
+            Func<int, CancellationToken, Task> delay = null)
+        {
+            if (inner == null)
+                throw new ArgumentNullException(nameof(inner));
+            if (retries < 0 || retries > AssignmentRequestRetryPolicy.MaxRetryCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(retries),
+                    $"Retries must be in [0, {AssignmentRequestRetryPolicy.MaxRetryCount}].");
+            }
+
+            if (retries == 0)
+                return inner;
+
+            var random = new Random();
+            var randomLock = new object();
+            var nextRandomValue = randomValue ?? new Func<double>(random.NextDouble);
+            return new RetryAssignmentRequestTransport(
+                inner,
+                retries,
+                () =>
+                {
+                    // A composed transport may be shared by concurrent clients.
+                    // System.Random and injected test sources are not required to
+                    // be thread-safe, so serialize access at the decorator edge.
+                    lock (randomLock)
+                    {
+                        return nextRandomValue();
+                    }
+                },
+                utcNow ?? new Func<DateTimeOffset>(() => DateTimeOffset.UtcNow),
+                delay ?? ((milliseconds, token) => Task.Delay(milliseconds, token)));
+        }
+    }
+
+    internal sealed class UnityWebRequestAssignmentTransport : IAssignmentRequestTransport
+    {
+        public Task<AssignmentResponse> SendAsync(
+            AssignmentRequest assignmentRequest,
+            CancellationToken cancellationToken = default)
+        {
+            if (assignmentRequest == null)
+                throw new ArgumentNullException(nameof(assignmentRequest));
+
+            var completion = new TaskCompletionSource<AssignmentResponse>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                completion.SetCanceled();
+                return completion.Task;
+            }
+
+            UnityWebRequest webRequest = null;
+            CancellationTokenRegistration cancellationRegistration = default;
+            try
+            {
+                webRequest = CreateUnityWebRequest(assignmentRequest);
+                var mainThreadContext = SynchronizationContext.Current;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationRegistration = cancellationToken.Register(() =>
+                    {
+                        void Abort()
+                        {
+                            try
+                            {
+                                webRequest.Abort();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                // Completion won the race and already released the native request.
+                            }
+                        }
+
+                        if (mainThreadContext != null)
+                        {
+                            // Always post, even when cancellation originates on
+                            // the main thread. This lets the cancellation callback
+                            // return before Abort can complete the operation and
+                            // dispose its own CancellationTokenRegistration.
+                            mainThreadContext.Post(_ => Abort(), null);
+                        }
+                        else
+                        {
+                            Abort();
+                        }
+                    });
+                }
+
+                var operation = webRequest.SendWebRequest();
+                operation.completed += _ =>
+                {
+                    AssignmentResponse response = null;
+                    Exception failure = null;
+                    var cancelled = cancellationToken.IsCancellationRequested;
+                    try
+                    {
+                        if (!cancelled)
+                            response = CreateResponse(webRequest);
+                    }
+                    catch (Exception exception)
+                    {
+                        failure = exception;
+                    }
+                    finally
+                    {
+                        // The public response contains no native Unity objects.
+                        // Release the complete attempt before completing the task
+                        // so continuations cannot observe ambiguous ownership.
+                        cancellationRegistration.Dispose();
+                        webRequest.Dispose();
+                    }
+
+                    if (cancelled)
+                        completion.TrySetCanceled();
+                    else if (failure != null)
+                        completion.TrySetException(failure);
+                    else
+                        completion.TrySetResult(response);
+                };
+            }
+            catch (Exception exception)
+            {
+                cancellationRegistration.Dispose();
+                webRequest?.Dispose();
+                completion.TrySetException(exception);
+            }
+
+            return completion.Task;
+        }
+
+        internal static UnityWebRequest CreateUnityWebRequest(AssignmentRequest request)
+        {
+            var webRequest = new UnityWebRequest(request.Url, request.Method)
+            {
+                uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(request.Body)),
+                downloadHandler = new DownloadHandlerBuffer(),
+            };
+            foreach (var header in request.Headers)
+            {
+                webRequest.SetRequestHeader(header.Key, header.Value);
+            }
+            return webRequest;
+        }
+
+        private static AssignmentResponse CreateResponse(UnityWebRequest request)
+        {
+            return new AssignmentResponse(
+                ToAssignmentResult(request.result),
+                request.responseCode,
+                request.downloadHandler?.text,
+                request.GetResponseHeaders());
+        }
+
+        private static AssignmentRequestResult ToAssignmentResult(UnityWebRequest.Result result)
+        {
+            switch (result)
+            {
+                case UnityWebRequest.Result.Success:
+                    return AssignmentRequestResult.Success;
+                case UnityWebRequest.Result.ProtocolError:
+                    return AssignmentRequestResult.ProtocolError;
+                case UnityWebRequest.Result.DataProcessingError:
+                    return AssignmentRequestResult.DataProcessingError;
+                default:
+                    return AssignmentRequestResult.ConnectionError;
+            }
+        }
+    }
+
+    internal sealed class TimeoutAssignmentRequestTransport : IAssignmentRequestTransport
+    {
+        private readonly IAssignmentRequestTransport _inner;
+        private readonly TimeSpan _timeout;
+
+        public TimeoutAssignmentRequestTransport(IAssignmentRequestTransport inner, int timeoutSeconds)
+            : this(
+                inner,
+                TimeSpan.FromSeconds(
+                    AssignmentRequestRetryPolicy.NormalizeTimeoutSeconds(timeoutSeconds)))
+        {
+        }
+
+        internal TimeoutAssignmentRequestTransport(IAssignmentRequestTransport inner, TimeSpan timeout)
+        {
+            _inner = inner;
+            _timeout = timeout;
+        }
+
+        public async Task<AssignmentResponse> SendAsync(
+            AssignmentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var timerCancellation = new CancellationTokenSource();
+            var callerCancellation = new TaskCompletionSource<bool>();
+            using var callerCancellationRegistration = cancellationToken.Register(
+                () => callerCancellation.TrySetResult(true));
+            var operation = _inner.SendAsync(request, requestCancellation.Token);
+            var timeout = Task.Delay(_timeout, timerCancellation.Token);
+            var completed = await Task.WhenAny(operation, timeout, callerCancellation.Task);
+
+            if (completed == operation)
+            {
+                timerCancellation.Cancel();
+                return await operation;
+            }
+
+            if (completed == callerCancellation.Task)
+                timerCancellation.Cancel();
+            requestCancellation.Cancel();
+            ObserveFault(operation);
+            if (completed == callerCancellation.Task)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            throw new TimeoutException($"The assignment request timed out after {_timeout.TotalMilliseconds} ms.");
+        }
+
+        private static void ObserveFault(Task operation)
+        {
+            operation.ContinueWith(
+                task =>
+                {
+                    var ignored = task.Exception;
+                },
+                TaskContinuationOptions.OnlyOnFaulted |
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
+    }
+
+    internal sealed class RetryAssignmentRequestTransport : IAssignmentRequestTransport
+    {
+        private readonly IAssignmentRequestTransport _inner;
+        private readonly int _retries;
+        private readonly Func<double> _randomValue;
+        private readonly Func<DateTimeOffset> _utcNow;
+        private readonly Func<int, CancellationToken, Task> _delay;
+
+        public RetryAssignmentRequestTransport(
+            IAssignmentRequestTransport inner,
+            int retries,
+            Func<double> randomValue,
+            Func<DateTimeOffset> utcNow,
+            Func<int, CancellationToken, Task> delay)
+        {
+            _inner = inner;
+            _retries = retries;
+            _randomValue = randomValue;
+            _utcNow = utcNow;
+            _delay = delay;
+        }
+
+        public async Task<AssignmentResponse> SendAsync(
+            AssignmentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            for (var attempt = 0; ; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AssignmentResponse response;
+                try
+                {
+                    response = await _inner.SendAsync(request, cancellationToken);
+                }
+                catch (TimeoutException) when (attempt < _retries)
+                {
+                    await _delay(
+                        AssignmentRequestRetryPolicy.GetJitterDelayMilliseconds(attempt, _randomValue()),
+                        cancellationToken);
+                    continue;
+                }
+
+                if (response == null)
+                    throw new InvalidOperationException("Assignment transport returned a null response.");
+
+                if (!AssignmentRequestRetryPolicy.TryGetRetryDelayMilliseconds(
+                        response.Result,
+                        response.StatusCode,
+                        attempt,
+                        _retries,
+                        response.GetHeader("Retry-After"),
+                        _utcNow(),
+                        _randomValue(),
+                        out var retryDelayMilliseconds))
+                {
+                    return response;
+                }
+
+                await _delay(retryDelayMilliseconds, cancellationToken);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestTransport.cs.meta
+++ b/packages/Datadog.Unity/Runtime/Flags/AssignmentRequestTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92a96b244dce4abfa063817e804c3238
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/DdFlags.cs
@@ -166,7 +166,10 @@ namespace Datadog.Unity.Flags
                     clientToken: options?.ClientToken ?? string.Empty,
                     applicationId: options?.RumApplicationId,
                     env: options?.Env ?? string.Empty,
-                    logger: _logger);
+                    logger: _logger,
+                    requestTimeoutSeconds: _configuration.AssignmentRequestTimeoutSeconds,
+                    requestRetryCount: _configuration.AssignmentRequestRetryCount,
+                    assignmentRequestTransport: _configuration.AssignmentRequestTransport);
 
                 var client = new FlagsClient(
                     repository: new FlagsRepository(),

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsConfiguration.cs
@@ -2,6 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+using System;
+
 namespace Datadog.Unity.Flags
 {
     /// <summary>
@@ -44,6 +46,26 @@ namespace Datadog.Unity.Flags
         /// </summary>
         public readonly string CustomEvaluationEndpoint;
 
+        /// <summary>
+        /// Timeout for each precomputed assignment request, in seconds. The timeout covers
+        /// receiving the complete response body. Set to 0 to disable; negative values are
+        /// normalized to 0 and values above 2,147,483 are capped. Default: 0.
+        /// </summary>
+        public readonly int AssignmentRequestTimeoutSeconds;
+
+        /// <summary>
+        /// Number of retries after the initial precomputed assignment request fails transiently.
+        /// Values are clamped to the range [0, 10]. Set to 0 to disable. Default: 0.
+        /// </summary>
+        public readonly int AssignmentRequestRetryCount;
+
+        /// <summary>
+        /// Fully configured transport used only for assignment requests. When non-null, this
+        /// transport is used verbatim and the scalar assignment timeout and retry settings are
+        /// not applied. The caller retains ownership of the transport.
+        /// </summary>
+        public readonly IAssignmentRequestTransport AssignmentRequestTransport;
+
         public FlagsConfiguration(
             bool trackExposures = true,
             bool trackEvaluations = true,
@@ -51,6 +73,77 @@ namespace Datadog.Unity.Flags
             string customFlagsEndpoint = null,
             string customExposureEndpoint = null,
             string customEvaluationEndpoint = null)
+            : this(
+                assignmentRequestTimeoutSeconds: 0,
+                assignmentRequestRetryCount: AssignmentRequestRetryPolicy.DefaultRetryCount,
+                trackExposures: trackExposures,
+                trackEvaluations: trackEvaluations,
+                evaluationFlushIntervalSeconds: evaluationFlushIntervalSeconds,
+                customFlagsEndpoint: customFlagsEndpoint,
+                customExposureEndpoint: customExposureEndpoint,
+                customEvaluationEndpoint: customEvaluationEndpoint,
+                assignmentRequestTransport: null)
+        {
+        }
+
+        public FlagsConfiguration(
+            int assignmentRequestTimeoutSeconds,
+            int assignmentRequestRetryCount,
+            bool trackExposures = true,
+            bool trackEvaluations = true,
+            float evaluationFlushIntervalSeconds = 10.0f,
+            string customFlagsEndpoint = null,
+            string customExposureEndpoint = null,
+            string customEvaluationEndpoint = null)
+            : this(
+                assignmentRequestTimeoutSeconds,
+                assignmentRequestRetryCount,
+                trackExposures,
+                trackEvaluations,
+                evaluationFlushIntervalSeconds,
+                customFlagsEndpoint,
+                customExposureEndpoint,
+                customEvaluationEndpoint,
+                assignmentRequestTransport: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a Flags configuration with a fully composed assignment-only transport.
+        /// The scalar convenience policy is not added to this transport.
+        /// </summary>
+        public FlagsConfiguration(
+            IAssignmentRequestTransport assignmentRequestTransport,
+            bool trackExposures = true,
+            bool trackEvaluations = true,
+            float evaluationFlushIntervalSeconds = 10.0f,
+            string customFlagsEndpoint = null,
+            string customExposureEndpoint = null,
+            string customEvaluationEndpoint = null)
+            : this(
+                assignmentRequestTimeoutSeconds: 0,
+                assignmentRequestRetryCount: AssignmentRequestRetryPolicy.DefaultRetryCount,
+                trackExposures: trackExposures,
+                trackEvaluations: trackEvaluations,
+                evaluationFlushIntervalSeconds: evaluationFlushIntervalSeconds,
+                customFlagsEndpoint: customFlagsEndpoint,
+                customExposureEndpoint: customExposureEndpoint,
+                customEvaluationEndpoint: customEvaluationEndpoint,
+                assignmentRequestTransport: assignmentRequestTransport ??
+                    throw new ArgumentNullException(nameof(assignmentRequestTransport)))
+        {
+        }
+
+        private FlagsConfiguration(
+            int assignmentRequestTimeoutSeconds,
+            int assignmentRequestRetryCount,
+            bool trackExposures,
+            bool trackEvaluations,
+            float evaluationFlushIntervalSeconds,
+            string customFlagsEndpoint,
+            string customExposureEndpoint,
+            string customEvaluationEndpoint,
+            IAssignmentRequestTransport assignmentRequestTransport)
         {
             TrackExposures = trackExposures;
             TrackEvaluations = trackEvaluations;
@@ -58,6 +151,11 @@ namespace Datadog.Unity.Flags
             CustomFlagsEndpoint = customFlagsEndpoint;
             CustomExposureEndpoint = customExposureEndpoint;
             CustomEvaluationEndpoint = customEvaluationEndpoint;
+            AssignmentRequestTimeoutSeconds = AssignmentRequestRetryPolicy.NormalizeTimeoutSeconds(
+                assignmentRequestTimeoutSeconds);
+            AssignmentRequestRetryCount = AssignmentRequestRetryPolicy.NormalizeRetryCount(
+                assignmentRequestRetryCount);
+            AssignmentRequestTransport = assignmentRequestTransport;
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -4,11 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Unity.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UnityEngine.Networking;
 
 namespace Datadog.Unity.Flags
 {
@@ -17,87 +17,99 @@ namespace Datadog.Unity.Flags
     /// </summary>
     internal class PrecomputeAssignmentsFetcher
     {
-        public const int FetchTimeoutSeconds = 30;
-
         private readonly string _endpointUrl;
         private readonly string _clientToken;
         private readonly string _applicationId;
         private readonly string _env;
         private readonly IInternalLogger _logger;
+        private readonly IAssignmentRequestTransport _transport;
 
         public PrecomputeAssignmentsFetcher(
             string endpointUrl,
             string clientToken,
             string applicationId,
             string env,
-            IInternalLogger logger)
+            IInternalLogger logger,
+            int requestTimeoutSeconds = AssignmentRequestRetryPolicy.DisabledTimeoutSeconds,
+            int requestRetryCount = AssignmentRequestRetryPolicy.DefaultRetryCount,
+            Func<double> randomValue = null,
+            Func<DateTimeOffset> utcNow = null,
+            Func<int, CancellationToken, Task> delay = null,
+            IAssignmentRequestTransport assignmentRequestTransport = null)
         {
             _endpointUrl = endpointUrl;
             _clientToken = clientToken;
             _applicationId = applicationId;
             _env = env;
             _logger = logger;
+            if (assignmentRequestTransport != null)
+            {
+                // A caller-supplied transport is a complete assignment-only
+                // override. Do not add the scalar convenience policy again.
+                _transport = assignmentRequestTransport;
+            }
+            else
+            {
+                var timeout = AssignmentRequestRetryPolicy.NormalizeTimeoutSeconds(requestTimeoutSeconds);
+                var retries = AssignmentRequestRetryPolicy.NormalizeRetryCount(requestRetryCount);
+                var timedTransport = AssignmentRequestTransports.Default.WithTimeout(timeout);
+                _transport = AssignmentRequestTransports.BuildRetryTransport(
+                    timedTransport,
+                    retries,
+                    randomValue,
+                    utcNow,
+                    delay);
+            }
         }
 
         /// <summary>
         /// Fetches precomputed assignments for the given evaluation context.
         /// Uses a callback since UnityWebRequest can be used from coroutines.
         /// </summary>
-        public void Fetch(FlagsEvaluationContext context, Action<Dictionary<string, FlagAssignment>> onComplete)
+        public async void Fetch(FlagsEvaluationContext context, Action<Dictionary<string, FlagAssignment>> onComplete)
         {
+            Dictionary<string, FlagAssignment> flags = null;
             try
             {
                 var requestBody = BuildRequestBody(context);
-                var bodyBytes = Encoding.UTF8.GetBytes(requestBody);
+                var response = await _transport.SendAsync(CreateRequest(requestBody), CancellationToken.None);
+                if (response == null)
+                    throw new InvalidOperationException("Assignment transport returned a null response.");
 
-                var request = new UnityWebRequest(_endpointUrl, "POST");
-                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
-                request.downloadHandler = new DownloadHandlerBuffer();
-                request.timeout = FetchTimeoutSeconds;
-                request.SetRequestHeader("Content-Type", "application/vnd.api+json");
-                request.SetRequestHeader("dd-client-token", _clientToken);
-
-                if (!string.IsNullOrEmpty(_applicationId))
+                if (response.Result == AssignmentRequestResult.Success &&
+                    response.StatusCode >= 200 &&
+                    response.StatusCode <= 299)
                 {
-                    request.SetRequestHeader("dd-application-id", _applicationId);
+                    flags = ParseResponse(response.Body);
                 }
-
-                var operation = request.SendWebRequest();
-                operation.completed += _ =>
+                else
                 {
-                    try
-                    {
-                        if (request.result != UnityWebRequest.Result.Success)
-                        {
-                            var errorDetail = ExtractServerError(request.downloadHandler?.text, request.responseCode);
-                            _logger?.Log(Logs.DdLogLevel.Warn,
-                                $"Failed to fetch flag assignments (HTTP {request.responseCode}): {errorDetail}");
-                            onComplete?.Invoke(null);
-                            return;
-                        }
-
-                        var responseText = request.downloadHandler.text;
-                        var flags = ParseResponse(responseText);
-                        onComplete?.Invoke(flags);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger?.Log(Logs.DdLogLevel.Warn, $"Error parsing flag assignments: {e.Message}");
-                        _logger?.TelemetryError("Error parsing flag assignments", e);
-                        onComplete?.Invoke(null);
-                    }
-                    finally
-                    {
-                        request.Dispose();
-                    }
-                };
+                    var errorDetail = ExtractServerError(response.Body, response.StatusCode);
+                    _logger?.Log(Logs.DdLogLevel.Warn,
+                        $"Failed to fetch flag assignments (HTTP {response.StatusCode}): {errorDetail}");
+                }
             }
             catch (Exception e)
             {
                 _logger?.Log(Logs.DdLogLevel.Warn, $"Error fetching flag assignments: {e.Message}");
                 _logger?.TelemetryError("Error fetching flag assignments", e);
-                onComplete?.Invoke(null);
             }
+            finally
+            {
+                onComplete?.Invoke(flags);
+            }
+        }
+
+        internal AssignmentRequest CreateRequest(string body)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                ["Content-Type"] = "application/vnd.api+json",
+                ["dd-client-token"] = _clientToken,
+            };
+            if (!string.IsNullOrEmpty(_applicationId))
+                headers["dd-application-id"] = _applicationId;
+            return new AssignmentRequest("POST", _endpointUrl, body, headers);
         }
 
         private string BuildRequestBody(FlagsEvaluationContext context)

--- a/packages/Datadog.Unity/Tests/Flags/AssignmentRequestRetryPolicyTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/AssignmentRequestRetryPolicyTests.cs
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class AssignmentRequestRetryPolicyTests
+    {
+        private static readonly DateTimeOffset RetryDate =
+            new DateTimeOffset(2026, 8, 28, 16, 0, 0, TimeSpan.Zero);
+
+        [TestCase(AssignmentRequestResult.ConnectionError, 0, true)]
+        [TestCase(AssignmentRequestResult.DataProcessingError, 0, true)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 408, true)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 500, true)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 599, true)]
+        [TestCase(AssignmentRequestResult.Success, 408, true)]
+        [TestCase(AssignmentRequestResult.Success, 503, true)]
+        [TestCase(AssignmentRequestResult.ConnectionError, 429, false)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 400, false)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 429, false)]
+        [TestCase(AssignmentRequestResult.ProtocolError, 600, false)]
+        [TestCase(AssignmentRequestResult.Success, 200, false)]
+        public void SelectsOnlyTransientFailuresForRetry(
+            AssignmentRequestResult result,
+            long statusCode,
+            bool expected)
+        {
+            var shouldRetry = TryGetRetryDelay(
+                result,
+                statusCode,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter: null,
+                out _);
+
+            Assert.AreEqual(expected, shouldRetry);
+        }
+
+        [TestCase(0, 0, false)]
+        [TestCase(1, 1, false)]
+        [TestCase(9, 10, true)]
+        public void RespectsRetryBudget(int attempt, int retryCount, bool expected)
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ConnectionError,
+                statusCode: 0,
+                attempt,
+                retryCount,
+                retryAfter: null,
+                out _);
+
+            Assert.AreEqual(expected, shouldRetry);
+        }
+
+        [Test]
+        public void UsesRetryAfterSecondsAsFloorBeforeJitter()
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode: 503,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter: "1",
+                out var delayMilliseconds);
+
+            Assert.IsTrue(shouldRetry);
+            Assert.AreEqual(1_050, delayMilliseconds);
+        }
+
+        [Test]
+        public void UsesRetryAfterDateAsFloorBeforeJitter()
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode: 503,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter: "Fri, 28 Aug 2026 16:00:01 GMT",
+                out var delayMilliseconds);
+
+            Assert.IsTrue(shouldRetry);
+            Assert.AreEqual(1_050, delayMilliseconds);
+        }
+
+        [TestCase("0")]
+        [TestCase("Fri, 28 Aug 2026 15:59:59 GMT")]
+        public void UsesJitterWhenRetryAfterIsImmediateOrPast(string retryAfter)
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode: 503,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter,
+                out var delayMilliseconds);
+
+            Assert.IsTrue(shouldRetry);
+            Assert.AreEqual(50, delayMilliseconds);
+        }
+
+        [TestCase("31")]
+        [TestCase("999999999999999999999999999999999999999")]
+        [TestCase("Fri, 28 Aug 2026 16:00:31 GMT")]
+        public void DoesNotRetryWhenRetryAfterExceedsMaximum(string retryAfter)
+        {
+            Assert.IsFalse(TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode: 503,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter,
+                out _));
+        }
+
+        [Test]
+        public void RetriesAtMaximumRetryAfter()
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode: 503,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter: "30",
+                out var delayMilliseconds);
+
+            Assert.IsTrue(shouldRetry);
+            Assert.AreEqual(30_050, delayMilliseconds);
+        }
+
+        [TestCase(500, "10")]
+        [TestCase(503, "")]
+        [TestCase(503, "1.5")]
+        [TestCase(503, "1e3")]
+        [TestCase(503, "-1")]
+        [TestCase(503, "not-a-date")]
+        public void IgnoresInapplicableOrMalformedRetryAfter(long statusCode, string retryAfter)
+        {
+            var shouldRetry = TryGetRetryDelay(
+                AssignmentRequestResult.ProtocolError,
+                statusCode,
+                attempt: 0,
+                retryCount: 1,
+                retryAfter,
+                out var delayMilliseconds);
+
+            Assert.IsTrue(shouldRetry);
+            Assert.AreEqual(50, delayMilliseconds);
+        }
+
+        [TestCase(0, 50)]
+        [TestCase(1, 100)]
+        [TestCase(9, 15_000)]
+        public void UsesBoundedExponentialFullJitter(int attempt, int expectedDelayMilliseconds)
+        {
+            Assert.AreEqual(
+                expectedDelayMilliseconds,
+                AssignmentRequestRetryPolicy.GetJitterDelayMilliseconds(attempt, randomValue: 0.5));
+        }
+
+        private static bool TryGetRetryDelay(
+            AssignmentRequestResult result,
+            long statusCode,
+            int attempt,
+            int retryCount,
+            string retryAfter,
+            out int retryDelayMilliseconds)
+        {
+            return AssignmentRequestRetryPolicy.TryGetRetryDelayMilliseconds(
+                result,
+                statusCode,
+                attempt,
+                retryCount,
+                retryAfter,
+                RetryDate,
+                randomValue: 0.5,
+                out retryDelayMilliseconds);
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/AssignmentRequestRetryPolicyTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/AssignmentRequestRetryPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0149df32190141798c464024bcfb33c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Flags/AssignmentRequestTransportTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/AssignmentRequestTransportTests.cs
@@ -1,0 +1,351 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class AssignmentRequestTransportTests
+    {
+        private static readonly AssignmentRequest Request = new AssignmentRequest(
+            "POST",
+            "https://example.com/assignments",
+            "body",
+            new Dictionary<string, string> { ["x-test"] = "value" });
+
+        [Test]
+        public void TimeoutZeroReturnsInnerTransport()
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(Success()));
+
+            Assert.AreSame(inner, inner.WithTimeout(0));
+        }
+
+        [Test]
+        public void RetryZeroReturnsInnerTransport()
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(Success()));
+
+            Assert.AreSame(inner, inner.WithRetry(0));
+        }
+
+        [Test]
+        public void TimeoutRejectsNegativeValues()
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(Success()));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => inner.WithTimeout(-1));
+        }
+
+        [TestCase(AssignmentRequestRetryPolicy.MaxTimeoutSeconds)]
+        [TestCase(AssignmentRequestRetryPolicy.MaxTimeoutSeconds + 1)]
+        [TestCase(int.MaxValue)]
+        public async Task TimeoutAcceptsAndCapsUnityTimerBoundaryBeforeSending(int timeoutSeconds)
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(Success()));
+            var transport = inner.WithTimeout(timeoutSeconds);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [TestCase(-1)]
+        [TestCase(11)]
+        public void RetryRejectsValuesOutsidePublicBounds(int retries)
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(Success()));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => inner.WithRetry(retries));
+        }
+
+        [Test]
+        public void RequestAndResponseDefensivelyCopyHeaders()
+        {
+            var requestHeaders = new Dictionary<string, string> { ["x-test"] = "before" };
+            var responseHeaders = new Dictionary<string, string> { ["retry-after"] = "1" };
+            var request = new AssignmentRequest("PUT", "https://example.com", "body", requestHeaders);
+            var response = new AssignmentResponse(
+                AssignmentRequestResult.ProtocolError,
+                503,
+                headers: responseHeaders);
+
+            requestHeaders["x-test"] = "after";
+            responseHeaders["retry-after"] = "after";
+
+            Assert.AreEqual("before", request.Headers["x-test"]);
+            Assert.AreEqual("PUT", request.Method);
+            Assert.AreEqual("1", response.GetHeader("Retry-After"));
+        }
+
+        [Test]
+        public async Task TimeoutCancelsTheCompleteTransportOperation()
+        {
+            var cancellationObserved = new TaskCompletionSource<bool>();
+            var inner = new DelegateTransport((_, cancellationToken) =>
+            {
+                var response = new TaskCompletionSource<AssignmentResponse>();
+                cancellationToken.Register(() =>
+                {
+                    cancellationObserved.TrySetResult(true);
+                    response.TrySetCanceled();
+                });
+                return response.Task;
+            });
+            var transport = new TimeoutAssignmentRequestTransport(
+                inner,
+                TimeSpan.FromMilliseconds(10));
+
+            Assert.ThrowsAsync<TimeoutException>(async () => await transport.SendAsync(Request));
+            Assert.IsTrue(await cancellationObserved.Task);
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [Test]
+        [Timeout(1_000)]
+        public void TimeoutDoesNotWaitForNonCooperativeInnerTransport()
+        {
+            var cancellationObserved = false;
+            var innerCompletion = new TaskCompletionSource<AssignmentResponse>();
+            var inner = new DelegateTransport((_, cancellationToken) =>
+            {
+                cancellationToken.Register(() => cancellationObserved = true);
+                return innerCompletion.Task;
+            });
+            var transport = new TimeoutAssignmentRequestTransport(
+                inner,
+                TimeSpan.FromMilliseconds(10));
+
+            Assert.ThrowsAsync<TimeoutException>(async () => await transport.SendAsync(Request));
+            Assert.IsTrue(cancellationObserved);
+            Assert.IsFalse(innerCompletion.Task.IsCompleted);
+
+            // The timeout continuation observes faults that arrive after the
+            // caller has already received its TimeoutException.
+            innerCompletion.TrySetException(new InvalidOperationException("late failure"));
+        }
+
+        [Test]
+        public async Task RetryComposesOutsidePerAttemptTimeout()
+        {
+            var attempts = 0;
+            var inner = new DelegateTransport((_, cancellationToken) =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    var pending = new TaskCompletionSource<AssignmentResponse>();
+                    cancellationToken.Register(() => pending.TrySetCanceled());
+                    return pending.Task;
+                }
+                return Task.FromResult(Success());
+            });
+            var timed = new TimeoutAssignmentRequestTransport(
+                inner,
+                TimeSpan.FromMilliseconds(10));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                timed,
+                retries: 1,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(AssignmentRequestResult.Success, response.Result);
+            Assert.AreEqual(2, attempts);
+        }
+
+        [TestCase(408)]
+        [TestCase(500)]
+        [TestCase(599)]
+        public async Task RetriesTransientProtocolResponses(int statusCode)
+        {
+            var attempts = 0;
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                ++attempts == 1
+                    ? new AssignmentResponse(AssignmentRequestResult.ProtocolError, statusCode)
+                    : Success()));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 1,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(AssignmentRequestResult.Success, response.Result);
+            Assert.AreEqual(2, attempts);
+        }
+
+        [Test]
+        public async Task RetriesServerStatusReportedAsSuccessByCustomTransport()
+        {
+            var attempts = 0;
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                ++attempts == 1
+                    ? new AssignmentResponse(AssignmentRequestResult.Success, 503)
+                    : Success()));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 1,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(2, attempts);
+        }
+
+        [Test]
+        public async Task DoesNotRetryRateLimitedResponses()
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                new AssignmentResponse(AssignmentRequestResult.ProtocolError, 429)));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 3,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(429, response.StatusCode);
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [Test]
+        public async Task DoesNotRetryRateLimitReportedAsTransportError()
+        {
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                new AssignmentResponse(AssignmentRequestResult.ConnectionError, 429)));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 3,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            var response = await transport.SendAsync(Request);
+
+            Assert.AreEqual(429, response.StatusCode);
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [Test]
+        public async Task SerializesJitterSourceAcrossConcurrentRequests()
+        {
+            var activeCalls = 0;
+            var maximumConcurrentCalls = 0;
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                new AssignmentResponse(AssignmentRequestResult.Success, 500)));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 1,
+                randomValue: () =>
+                {
+                    var active = Interlocked.Increment(ref activeCalls);
+                    var observedMaximum = maximumConcurrentCalls;
+                    while (active > observedMaximum)
+                    {
+                        var previous = Interlocked.CompareExchange(
+                            ref maximumConcurrentCalls,
+                            active,
+                            observedMaximum);
+                        if (previous == observedMaximum)
+                            break;
+                        observedMaximum = previous;
+                    }
+
+                    Thread.Sleep(5);
+                    Interlocked.Decrement(ref activeCalls);
+                    return 0;
+                },
+                delay: (_, __) => Task.CompletedTask);
+            var operations = new Task<AssignmentResponse>[32];
+            for (var i = 0; i < operations.Length; i++)
+            {
+                operations[i] = Task.Run(async () => await transport.SendAsync(Request));
+            }
+
+            await Task.WhenAll(operations);
+
+            Assert.AreEqual(1, maximumConcurrentCalls);
+        }
+
+        [Test]
+        public void CallerCancellationInterruptsRetryDelay()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var delayStarted = new TaskCompletionSource<bool>();
+            var inner = new DelegateTransport((_, __) => Task.FromResult(
+                new AssignmentResponse(AssignmentRequestResult.ProtocolError, 500)));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 1,
+                randomValue: () => 0,
+                delay: (_, cancellationToken) =>
+                {
+                    delayStarted.TrySetResult(true);
+                    return Task.Delay(System.Threading.Timeout.Infinite, cancellationToken);
+                });
+
+            var operation = transport.SendAsync(Request, cancellation.Token);
+            Assert.IsTrue(delayStarted.Task.IsCompleted);
+            cancellation.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await operation);
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [Test]
+        public void UnexpectedTransportExceptionsAreNotRetried()
+        {
+            var inner = new DelegateTransport((_, __) =>
+            {
+                var failure = new TaskCompletionSource<AssignmentResponse>();
+                failure.SetException(new InvalidOperationException("bad transport"));
+                return failure.Task;
+            });
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                retries: 3,
+                randomValue: () => 0,
+                delay: (_, __) => Task.CompletedTask);
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await transport.SendAsync(Request));
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        private static AssignmentResponse Success()
+        {
+            return new AssignmentResponse(AssignmentRequestResult.Success, 200, "{}");
+        }
+
+        private sealed class DelegateTransport : IAssignmentRequestTransport
+        {
+            private readonly Func<AssignmentRequest, CancellationToken, Task<AssignmentResponse>> _send;
+
+            public DelegateTransport(
+                Func<AssignmentRequest, CancellationToken, Task<AssignmentResponse>> send)
+            {
+                _send = send;
+            }
+
+            public int SendCount { get; private set; }
+
+            public Task<AssignmentResponse> SendAsync(
+                AssignmentRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                SendCount++;
+                return _send(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/AssignmentRequestTransportTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/AssignmentRequestTransportTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9ed5b6f589641e1969d0c808c789aa2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Flags/FlagsConfigurationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsConfigurationTests.cs
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class FlagsConfigurationTests
+    {
+        [Test]
+        public void DefaultsToNoAssignmentRequestTimeoutAndNoRetries()
+        {
+            var configuration = new FlagsConfiguration();
+
+            Assert.AreEqual(0, configuration.AssignmentRequestTimeoutSeconds);
+            Assert.AreEqual(0, configuration.AssignmentRequestRetryCount);
+        }
+
+        [Test]
+        public async Task DefaultConfigurationMakesExactlyOneInitialRequest()
+        {
+            var configuration = new FlagsConfiguration();
+            var inner = new StubTransport(new AssignmentResponse(
+                AssignmentRequestResult.ConnectionError,
+                0));
+            var transport = AssignmentRequestTransports.BuildRetryTransport(
+                inner,
+                configuration.AssignmentRequestRetryCount);
+
+            Assert.AreSame(inner, transport);
+            await transport.SendAsync(new AssignmentRequest(
+                "POST",
+                "https://example.com/assignments",
+                "body",
+                null));
+
+            Assert.AreEqual(1, inner.SendCount);
+        }
+
+        [Test]
+        public void AcceptsCustomAssignmentRequestLimits()
+        {
+            var configuration = new FlagsConfiguration(
+                assignmentRequestTimeoutSeconds: 3,
+                assignmentRequestRetryCount: 2);
+
+            Assert.AreEqual(3, configuration.AssignmentRequestTimeoutSeconds);
+            Assert.AreEqual(2, configuration.AssignmentRequestRetryCount);
+        }
+
+        [Test]
+        public void ZeroDisablesAssignmentRequestLimits()
+        {
+            var configuration = new FlagsConfiguration(
+                assignmentRequestTimeoutSeconds: 0,
+                assignmentRequestRetryCount: 0);
+
+            Assert.AreEqual(0, configuration.AssignmentRequestTimeoutSeconds);
+            Assert.AreEqual(0, configuration.AssignmentRequestRetryCount);
+        }
+
+        [TestCase(-1, -1, 0, 0)]
+        [TestCase(1, 11, 1, 10)]
+        [TestCase(
+            AssignmentRequestRetryPolicy.MaxTimeoutSeconds,
+            1,
+            AssignmentRequestRetryPolicy.MaxTimeoutSeconds,
+            1)]
+        [TestCase(
+            AssignmentRequestRetryPolicy.MaxTimeoutSeconds + 1,
+            1,
+            AssignmentRequestRetryPolicy.MaxTimeoutSeconds,
+            1)]
+        [TestCase(
+            int.MaxValue,
+            1,
+            AssignmentRequestRetryPolicy.MaxTimeoutSeconds,
+            1)]
+        public void NormalizesInvalidAssignmentRequestLimits(
+            int timeoutSeconds,
+            int retryCount,
+            int expectedTimeoutSeconds,
+            int expectedRetryCount)
+        {
+            var configuration = new FlagsConfiguration(
+                assignmentRequestTimeoutSeconds: timeoutSeconds,
+                assignmentRequestRetryCount: retryCount);
+
+            Assert.AreEqual(expectedTimeoutSeconds, configuration.AssignmentRequestTimeoutSeconds);
+            Assert.AreEqual(expectedRetryCount, configuration.AssignmentRequestRetryCount);
+        }
+
+        [Test]
+        public void AcceptsAssignmentOnlyTransportOverride()
+        {
+            var transport = new StubTransport();
+
+            var configuration = new FlagsConfiguration(assignmentRequestTransport: transport);
+
+            Assert.AreSame(transport, configuration.AssignmentRequestTransport);
+            Assert.AreEqual(0, configuration.AssignmentRequestTimeoutSeconds);
+            Assert.AreEqual(0, configuration.AssignmentRequestRetryCount);
+        }
+
+        [Test]
+        public void PreservesPublishedConstructorSignatures()
+        {
+            Assert.IsNotNull(typeof(FlagsConfiguration).GetConstructor(new[]
+            {
+                typeof(bool),
+                typeof(bool),
+                typeof(float),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+            }));
+            Assert.IsNotNull(typeof(FlagsConfiguration).GetConstructor(new[]
+            {
+                typeof(int),
+                typeof(int),
+                typeof(bool),
+                typeof(bool),
+                typeof(float),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+            }));
+            Assert.IsNotNull(typeof(FlagsConfiguration).GetConstructor(new[]
+            {
+                typeof(IAssignmentRequestTransport),
+                typeof(bool),
+                typeof(bool),
+                typeof(float),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+            }));
+            Assert.AreEqual(3, typeof(FlagsConfiguration).GetConstructors().Length);
+        }
+
+        private sealed class StubTransport : IAssignmentRequestTransport
+        {
+            private readonly AssignmentResponse _response;
+
+            public StubTransport(AssignmentResponse response = null)
+            {
+                _response = response ?? new AssignmentResponse(
+                    AssignmentRequestResult.Success,
+                    200);
+            }
+
+            public int SendCount { get; private set; }
+
+            public Task<AssignmentResponse> SendAsync(
+                AssignmentRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                SendCount++;
+                return Task.FromResult(_response);
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/FlagsConfigurationTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/FlagsConfigurationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 273b49b015674da3b81668ca16740668
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeAssignmentsFetcherRequestTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeAssignmentsFetcherRequestTests.cs
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Datadog.Unity.Flags.Tests
+{
+    public class PrecomputeAssignmentsFetcherRequestTests
+    {
+        [Test]
+        public void CreatesImmutableRequestWithPreservedSettings()
+        {
+            var fetcher = new PrecomputeAssignmentsFetcher(
+                endpointUrl: "https://example.com/assignments",
+                clientToken: "client-token",
+                applicationId: "application-id",
+                env: "test",
+                logger: null);
+
+            var request = fetcher.CreateRequest("body");
+
+            Assert.AreEqual("POST", request.Method);
+            Assert.AreEqual("https://example.com/assignments", request.Url);
+            Assert.AreEqual("body", request.Body);
+            Assert.AreEqual("application/vnd.api+json", request.Headers["Content-Type"]);
+            Assert.AreEqual("client-token", request.Headers["dd-client-token"]);
+            Assert.AreEqual("application-id", request.Headers["dd-application-id"]);
+        }
+
+        [Test]
+        public void DefaultTransportCreatesFreshUnityWebRequests()
+        {
+            var request = new AssignmentRequest(
+                "PATCH",
+                "https://example.com/assignments",
+                "body",
+                new Dictionary<string, string> { ["x-test"] = "value" });
+
+            using var first = UnityWebRequestAssignmentTransport.CreateUnityWebRequest(request);
+            using var second = UnityWebRequestAssignmentTransport.CreateUnityWebRequest(request);
+
+            Assert.AreNotSame(first, second);
+            Assert.AreEqual("PATCH", first.method);
+            Assert.AreEqual("value", first.GetRequestHeader("x-test"));
+        }
+
+        [Test]
+        public void CustomTransportBypassesScalarPolicy()
+        {
+            var transport = new RecordingTransport(new AssignmentResponse(
+                AssignmentRequestResult.Success,
+                200,
+                @"{""data"":{""attributes"":{""flags"":{}}}}"));
+            var completionCount = 0;
+            Dictionary<string, FlagAssignment> completionResult = null;
+            var fetcher = new PrecomputeAssignmentsFetcher(
+                endpointUrl: "https://example.com/assignments",
+                clientToken: "client-token",
+                applicationId: null,
+                env: "test",
+                logger: null,
+                requestTimeoutSeconds: -1,
+                requestRetryCount: 10,
+                assignmentRequestTransport: transport);
+
+            fetcher.Fetch(new FlagsEvaluationContext("user-123"), result =>
+            {
+                completionCount++;
+                completionResult = result;
+            });
+
+            Assert.AreEqual(1, transport.SendCount);
+            Assert.AreEqual(1, completionCount);
+            Assert.IsNotNull(completionResult);
+        }
+
+        [Test]
+        public void DoesNotRetryUnexpectedTransportExceptions()
+        {
+            var transport = new ThrowingTransport();
+            var completionCount = 0;
+            var fetcher = new PrecomputeAssignmentsFetcher(
+                endpointUrl: "not a valid URL",
+                clientToken: "client-token",
+                applicationId: null,
+                env: "test",
+                logger: null,
+                requestTimeoutSeconds: 1,
+                requestRetryCount: 10,
+                assignmentRequestTransport: transport);
+
+            fetcher.Fetch(new FlagsEvaluationContext("user-123"), result =>
+            {
+                completionCount++;
+                Assert.IsNull(result);
+            });
+
+            Assert.AreEqual(1, transport.SendCount);
+            Assert.AreEqual(1, completionCount);
+        }
+
+        [Test]
+        public void DoesNotParseNon2xxResponseReportedAsSuccessByCustomTransport()
+        {
+            var transport = new RecordingTransport(new AssignmentResponse(
+                AssignmentRequestResult.Success,
+                503,
+                @"{""data"":{""attributes"":{""flags"":{}}}}"));
+            var completionCount = 0;
+            var fetcher = new PrecomputeAssignmentsFetcher(
+                endpointUrl: "https://example.com/assignments",
+                clientToken: "client-token",
+                applicationId: null,
+                env: "test",
+                logger: null,
+                assignmentRequestTransport: transport);
+
+            fetcher.Fetch(new FlagsEvaluationContext("user-123"), result =>
+            {
+                completionCount++;
+                Assert.IsNull(result);
+            });
+
+            Assert.AreEqual(1, transport.SendCount);
+            Assert.AreEqual(1, completionCount);
+        }
+
+        private sealed class RecordingTransport : IAssignmentRequestTransport
+        {
+            private readonly AssignmentResponse _response;
+
+            public RecordingTransport(AssignmentResponse response)
+            {
+                _response = response;
+            }
+
+            public int SendCount { get; private set; }
+
+            public Task<AssignmentResponse> SendAsync(
+                AssignmentRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                SendCount++;
+                return Task.FromResult(_response);
+            }
+        }
+
+        private sealed class ThrowingTransport : IAssignmentRequestTransport
+        {
+            public int SendCount { get; private set; }
+
+            public Task<AssignmentResponse> SendAsync(
+                AssignmentRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                SendCount++;
+                var completion = new TaskCompletionSource<AssignmentResponse>();
+                completion.SetException(new InvalidOperationException("invalid request configuration"));
+                return completion.Task;
+            }
+        }
+    }
+}

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeAssignmentsFetcherRequestTests.cs.meta
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeAssignmentsFetcherRequestTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d8323009598493686211403b9acc61f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Motivation

Applications need opt-in assignment-request latency bounds and retries without changing default request behavior. Advanced Unity callers also need a composable transport boundary that does not expose native `UnityWebRequest` ownership.

## Changes

- Keep scalar `AssignmentRequestTimeoutSeconds` and `AssignmentRequestRetryCount` defaults at `0`.
- Add immutable `AssignmentRequest` and fully buffered `AssignmentResponse`, `IAssignmentRequestTransport`, `AssignmentRequestTransports.Default`, `WithTimeout`, and `WithRetry`.
- Add a separate transport-first `FlagsConfiguration` overload; a supplied transport is assignment-only and used verbatim.
- Keep native requests SDK-owned, propagate the complete method/URL/body/headers, dispose completed attempts, request cancellation promptly, and observe late faults.
- Add focused configuration, constructor ABI, request mapping, status authority, retry, timeout, cancellation, concurrency, ownership, and boundary tests.

## Decisions

- Upgrading preserves request behavior: default configuration makes one request with no SDK-added timeout or retry; the platform/custom transport remains authoritative.
- A custom transport replaces scalar convenience policy and must support concurrent calls and prompt cancellation.
- HTTP status is SDK-authoritative even if a custom transport reports an inconsistent result: retry 408/5xx, never retry 429, and parse only `Success` plus 2xx.
- Timeout returns promptly even for a non-cooperative custom transport. Values above 2,147,483 seconds are capped for cross-Unity timer compatibility.
- Preserve the exact published six- and eight-parameter constructor IL signatures; add the transport-first overload without changing them.

## Validation

- Default-policy coverage proves the zero-retry helper preserves transport identity and makes exactly one send for a retryable result.
- `git diff --check` passes.
- Repository Python tooling: 22 passed; one unchanged XSLT exact-byte fixture mismatch remains.
- Independent re-review confirms all request, status, cancellation, concurrency, and constructor compatibility findings are resolved.
- Unity/C# compilation remains a PR CI gate because this workspace has no Unity Hub, Editor, `dotnet`, `csc`, or `mcs`.

## Jira

FFL-2931
