### PR TITLE
EX-3421: Send the split serial id on exposure events

### DIFF
--- a/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureEvent.cs
@@ -43,18 +43,23 @@ namespace Datadog.Unity.Flags
         [JsonProperty("subject")]
         public readonly ExposureSubject Subject;
 
+        [JsonProperty("serial_id", NullValueHandling = NullValueHandling.Ignore)]
+        public readonly int? SerialId;
+
         public ExposureEvent(
             long timestamp,
             FlagRef flag,
             FlagRef allocation,
             FlagRef variant,
-            ExposureSubject subject)
+            ExposureSubject subject,
+            int? serialId = null)
         {
             Timestamp = timestamp;
             Flag = flag;
             Allocation = allocation;
             Variant = variant;
             Subject = subject;
+            SerialId = serialId;
         }
     }
 }

--- a/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/ExposureTracker.cs
@@ -20,13 +20,20 @@ namespace Datadog.Unity.Flags
             public readonly string FlagKey;
             public readonly string AllocationKey;
             public readonly string VariationKey;
+            public readonly int? SerialId;
 
-            public ExposureKey(string targetingKey, string flagKey, string allocationKey, string variationKey)
+            public ExposureKey(
+                string targetingKey,
+                string flagKey,
+                string allocationKey,
+                string variationKey,
+                int? serialId = null)
             {
                 TargetingKey = targetingKey;
                 FlagKey = flagKey;
                 AllocationKey = allocationKey;
                 VariationKey = variationKey;
+                SerialId = serialId;
             }
 
             public bool Equals(ExposureKey other)
@@ -34,7 +41,8 @@ namespace Datadog.Unity.Flags
                 return TargetingKey == other.TargetingKey
                     && FlagKey == other.FlagKey
                     && AllocationKey == other.AllocationKey
-                    && VariationKey == other.VariationKey;
+                    && VariationKey == other.VariationKey
+                    && SerialId == other.SerialId;
             }
 
             public override bool Equals(object obj)
@@ -43,7 +51,7 @@ namespace Datadog.Unity.Flags
             }
 
             public override int GetHashCode()
-                => HashCode.Combine(TargetingKey, FlagKey, AllocationKey, VariationKey);
+                => HashCode.Combine(TargetingKey, FlagKey, AllocationKey, VariationKey, SerialId);
         }
 
         public const int DefaultCountLimit = 1_000;

--- a/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagAssignment.cs
@@ -20,7 +20,8 @@ namespace Datadog.Unity.Flags
             bool doLog,
             string allocationKey,
             string variationKey,
-            string reason)
+            string reason,
+            int? serialId = null)
         {
             VariationType = variationType ?? string.Empty;
             VariationValue = variationValue;
@@ -28,6 +29,7 @@ namespace Datadog.Unity.Flags
             AllocationKey = allocationKey;
             VariationKey = variationKey ?? string.Empty;
             Reason = reason ?? string.Empty;
+            SerialId = serialId;
         }
 
         /// <summary>
@@ -59,6 +61,12 @@ namespace Datadog.Unity.Flags
         /// Gets the resolution reason (DEFAULT, TARGETING_MATCH, RULE_MATCH, etc.).
         /// </summary>
         public string Reason { get; }
+
+        /// <summary>
+        /// Gets the serial identifier of the split this assignment comes from, or null when the
+        /// server sends none.
+        /// </summary>
+        public int? SerialId { get; }
 
         /// <summary>
         /// Attempts to get the variation value as the specified type.

--- a/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/FlagsClient.cs
@@ -277,7 +277,8 @@ namespace Datadog.Unity.Flags
                     targetingKey: context?.TargetingKey ?? string.Empty,
                     flagKey: key,
                     allocationKey: assignment.AllocationKey,
-                    variationKey: assignment.VariationKey);
+                    variationKey: assignment.VariationKey,
+                    serialId: assignment.SerialId);
 
                 if (_exposureTracker.TrackExposure(exposureKey))
                 {
@@ -288,7 +289,8 @@ namespace Datadog.Unity.Flags
                         variant: new FlagRef(assignment.VariationKey),
                         subject: new ExposureSubject(
                             id: context?.TargetingKey ?? string.Empty,
-                            attributes: context?.Attributes?.Count > 0 ? context.Attributes : null));
+                            attributes: context?.Attributes?.Count > 0 ? context.Attributes : null),
+                        serialId: assignment.SerialId);
 
                     _onExposure?.Invoke(exposureEvent);
                 }

--- a/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
+++ b/packages/Datadog.Unity/Runtime/Flags/PrecomputeAssignmentsFetcher.cs
@@ -201,7 +201,8 @@ namespace Datadog.Unity.Flags
                     doLog: dto.DoLog,
                     allocationKey: dto.AllocationKey,
                     variationKey: dto.VariationKey,
-                    reason: dto.Reason);
+                    reason: dto.Reason,
+                    serialId: dto.SerialId);
             }
 
             return flags;
@@ -286,6 +287,9 @@ namespace Datadog.Unity.Flags
 
             [JsonProperty("reason")]
             public string Reason { get; set; }
+
+            [JsonProperty("serialId")]
+            public int? SerialId { get; set; }
 
         }
     }

--- a/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/ExposureTrackerTests.cs
@@ -105,5 +105,36 @@ namespace Datadog.Unity.Flags.Tests
 
             Assert.AreEqual(1, tracker.Count);
         }
+
+        [Test]
+        public void SerialIdDistinguishesExposureKeys()
+        {
+            var tracker = new ExposureTracker();
+
+            var absent = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "var-1");
+            var zero = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "var-1", 0);
+            var one = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "var-1", 1);
+
+            tracker.TrackExposure(absent);
+
+            Assert.IsTrue(tracker.Contains(absent));
+            Assert.IsFalse(tracker.Contains(zero));
+            Assert.IsFalse(tracker.Contains(one));
+
+            Assert.IsTrue(tracker.TrackExposure(zero));
+            Assert.IsTrue(tracker.TrackExposure(one));
+            Assert.AreEqual(3, tracker.Count);
+        }
+
+        [Test]
+        public void SameSerialIdDeduplicates()
+        {
+            var tracker = new ExposureTracker();
+            var key = new ExposureTracker.ExposureKey("user-1", "flag-1", "alloc-1", "var-1", 0);
+
+            Assert.IsTrue(tracker.TrackExposure(key));
+            Assert.IsFalse(tracker.TrackExposure(key));
+            Assert.AreEqual(1, tracker.Count);
+        }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/JsonSerializationTests.cs
@@ -98,5 +98,52 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsTrue(json.Contains("\"runtime_default_used\":true"));
             Assert.IsTrue(json.Contains("\"error\":{\"message\":\"FLAG_NOT_FOUND\"}"));
         }
+
+        [Test]
+        public void ExposureEventSerializesZeroSerialId()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("show-feature"),
+                allocation: new FlagRef("alloc-123"),
+                variant: new FlagRef("variant-a"),
+                subject: new ExposureSubject(id: "user-456"),
+                serialId: 0);
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsTrue(json.Contains("\"serial_id\":0"));
+        }
+
+        [Test]
+        public void ExposureEventSerializesPositiveSerialId()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("show-feature"),
+                allocation: new FlagRef("alloc-123"),
+                variant: new FlagRef("variant-a"),
+                subject: new ExposureSubject(id: "user-456"),
+                serialId: 42);
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsTrue(json.Contains("\"serial_id\":42"));
+        }
+
+        [Test]
+        public void ExposureEventOmitsAbsentSerialId()
+        {
+            var evt = new ExposureEvent(
+                timestamp: 1700000000000,
+                flag: new FlagRef("show-feature"),
+                allocation: new FlagRef("alloc-123"),
+                variant: new FlagRef("variant-a"),
+                subject: new ExposureSubject(id: "user-456"));
+
+            var json = JsonConvert.SerializeObject(evt);
+
+            Assert.IsFalse(json.Contains("serial_id"));
+        }
     }
 }

--- a/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
+++ b/packages/Datadog.Unity/Tests/Flags/PrecomputeParserTests.cs
@@ -124,5 +124,108 @@ namespace Datadog.Unity.Flags.Tests
             Assert.IsNotNull(flags);
             Assert.AreEqual(0, flags.Count);
         }
+
+        [Test]
+        public void ParsesZeroSerialId()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH"",
+                                ""serialId"": 0
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(0, flags["enable-feature"].SerialId);
+        }
+
+        [Test]
+        public void ParsesPositiveSerialId()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH"",
+                                ""serialId"": 42
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.AreEqual(42, flags["enable-feature"].SerialId);
+        }
+
+        [Test]
+        public void ParsesExplicitNullSerialIdAsAbsent()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH"",
+                                ""serialId"": null
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.IsNull(flags["enable-feature"].SerialId);
+        }
+
+        [Test]
+        public void ParsesMissingSerialIdAsAbsent()
+        {
+            var json = @"{
+                ""data"": {
+                    ""attributes"": {
+                        ""flags"": {
+                            ""enable-feature"": {
+                                ""variationType"": ""boolean"",
+                                ""variationValue"": true,
+                                ""doLog"": true,
+                                ""allocationKey"": ""alloc-abc"",
+                                ""variationKey"": ""treatment"",
+                                ""reason"": ""TARGETING_MATCH""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            var flags = PrecomputeAssignmentsFetcher.ParseResponse(json);
+
+            Assert.IsNull(flags["enable-feature"].SerialId);
+        }
     }
 }

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Decoders/ExposureEventDecoder.cs
@@ -21,6 +21,8 @@ namespace Datadog.Unity.Tests.Integration.Flags
         public string AllocationKey => _raw["allocation"]?["key"]?.Value<string>();
         public string VariantKey => _raw["variant"]?["key"]?.Value<string>();
         public string SubjectId => _raw["subject"]?["id"]?.Value<string>();
+        public bool HasSerialId => _raw["serial_id"] != null;
+        public int? SerialId => _raw["serial_id"]?.Value<int>();
         public Dictionary<string, object> SubjectAttributes
         {
             get

--- a/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/FlagsIntegrationTests.cs
@@ -223,6 +223,7 @@ namespace Datadog.Unity.Tests.Integration.Flags
             Assert.AreEqual("allocation-124", exp.AllocationKey);
             Assert.AreEqual("variation-124", exp.VariantKey);
             Assert.AreEqual("user-123", exp.SubjectId);
+            Assert.AreEqual(0, exp.SerialId);
 
             // Check headers on exposure request
             MockServerLog expEndpoint = null;
@@ -290,6 +291,46 @@ namespace Datadog.Unity.Tests.Integration.Flags
             var subjects = exposures.Select(e => e.SubjectId).ToList();
             CollectionAssert.Contains(subjects, "user-A");
             CollectionAssert.Contains(subjects, "user-B");
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SerialId_OmittedWhenServerSendsNull()
+        {
+            yield return InitFlags("user-123");
+
+            DdFlags.Instance.GetClient().GetStringValue("string-flag", "default");
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 1;
+            });
+
+            Assert.AreEqual(1, exposures.Count);
+            Assert.AreEqual("string-flag", exposures[0].FlagKey);
+            Assert.IsFalse(exposures[0].HasSerialId);
+        }
+
+        [UnityTest]
+        [Category("integration")]
+        public IEnumerator SerialId_SentWhenServerSendsValue()
+        {
+            yield return InitFlags("user-123");
+
+            DdFlags.Instance.GetClient().GetIntegerValue("integer-flag", 0);
+
+            var exposures = new List<ExposureEventDecoder>();
+            yield return _mockServer.PollRequests(PollTimeout, logs =>
+            {
+                exposures = ExposureEventDecoder.FromMockServer(logs);
+                return exposures.Count >= 1;
+            });
+
+            Assert.AreEqual(1, exposures.Count);
+            Assert.AreEqual("integer-flag", exposures[0].FlagKey);
+            Assert.AreEqual(7, exposures[0].SerialId);
         }
 
         // ─── Group 4: Evaluation telemetry ───────────────────────────────────────────

--- a/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json
+++ b/packages/Datadog.Unity/Tests/Integration/Flags/Resources/PrecomputePayload.json
@@ -6,9 +6,9 @@
       "createdAt": 1731939805123,
       "environment": { "name": "prod" },
       "flags": {
-        "string-flag":  { "allocationKey": "allocation-123", "variationKey": "variation-123", "variationType": "STRING",  "variationValue": "red",  "doLog": true, "reason": "TARGETING_MATCH" },
-        "boolean-flag": { "allocationKey": "allocation-124", "variationKey": "variation-124", "variationType": "BOOLEAN", "variationValue": true,   "doLog": true, "reason": "TARGETING_MATCH" },
-        "integer-flag": { "allocationKey": "allocation-125", "variationKey": "variation-125", "variationType": "NUMBER",  "variationValue": 42,     "doLog": true, "reason": "TARGETING_MATCH" },
+        "string-flag":  { "allocationKey": "allocation-123", "variationKey": "variation-123", "variationType": "STRING",  "variationValue": "red",  "doLog": true, "reason": "TARGETING_MATCH", "serialId": null },
+        "boolean-flag": { "allocationKey": "allocation-124", "variationKey": "variation-124", "variationType": "BOOLEAN", "variationValue": true,   "doLog": true, "reason": "TARGETING_MATCH", "serialId": 0 },
+        "integer-flag": { "allocationKey": "allocation-125", "variationKey": "variation-125", "variationType": "NUMBER",  "variationValue": 42,     "doLog": true, "reason": "TARGETING_MATCH", "serialId": 7 },
         "numeric-flag": { "allocationKey": "allocation-126", "variationKey": "variation-126", "variationType": "NUMBER",  "variationValue": 3.14,   "doLog": true, "reason": "TARGETING_MATCH" },
         "json-flag":    { "allocationKey": "allocation-127", "variationKey": "variation-127", "variationType": "OBJECT",  "variationValue": { "key": "value", "prop": 123 }, "doLog": true,  "reason": "TARGETING_MATCH" },
         "no-log-flag":  { "allocationKey": "allocation-128", "variationKey": "variation-128", "variationType": "BOOLEAN", "variationValue": true,                               "doLog": false, "reason": "TARGETING_MATCH" }


### PR DESCRIPTION
### What and why?

The precompute response contains a serial id for each flag. The SDK discarded it. The exposures intake uses the serial id to find the holdout that an allocation comes from. The compiler rewrites a holdout into a usual allocation before the SDK receives it, so the serial id is the only link back to the holdout.

This change reads the serial id and puts it on the exposure event as a top-level `serial_id` field. The SDK sends no field when the server sends no value. The server sends an explicit `null` for a flag with no serial id, so the model accepts a `null` and an absent key. The SDK does not validate the value.

The serial id is also part of the exposure deduplication key. The cache used only the targeting key, flag key, allocation key and variation key. A serial id that appeared while the allocation and the variation stayed the same made no new exposure. The server metric `ffe.ufc.vac_miss` shows that this transition occurs in production.

Serial ids start at zero for each organization, so zero is a usual value and not an edge case. A presence test written as a zero test or a truthiness test drops the serial id for the first allocation in every organization. The model uses `int?` for this reason, and the tests use zero, a positive value, an explicit `null` and an absent key.

| File | Change |
| --- | --- |
| `PrecomputeAssignmentsFetcher.cs` | Reads `serialId` from the response and gives it to the assignment |
| `FlagAssignment.cs` | Holds the optional serial id |
| `ExposureEvent.cs` | Writes `serial_id`, and omits the key when the value is absent |
| `ExposureTracker.cs` | Adds the serial id to the deduplication key |
| `FlagsClient.cs` | Gives the serial id to the deduplication key and to the event |

Reference implementation: `DataDog/openfeature-js-client#368`, which makes the same change for the web SDK.

### Testing

Unit tests cover the parser, the JSON output and the deduplication key. Integration tests read the payload that reaches the mock intake. The integration fixture now has a serial id of zero on `boolean-flag`, an explicit `null` on `string-flag`, and a value of 7 on `integer-flag`.

The intake schema sets `additionalProperties: false` and drops the whole event for an unknown key. The integration tests read the literal key `serial_id` from the wire for this reason.

### Risks

The deduplication key is wider. A subject whose serial id changes for an unchanged allocation and variation now makes a second exposure event. This is the intended behaviour, and the volume is bound by the rate of serial id resolution.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests

*Written with the help of Claude.*
